### PR TITLE
Various tweaks

### DIFF
--- a/js/models/BaseModel.js
+++ b/js/models/BaseModel.js
@@ -52,8 +52,12 @@ import { Model } from 'backbone';
     }
   });
 
-  // can be set directly on the nested model / collection
+  // can be set directly on the nested model / collection (see note)
   parentModel.get('SMTPSettings').set('notifications', false);
+
+  Please Note: For a nested collection, unless the models have IDs, it's
+  recommended that you directly update the models on the nested collection,
+  at least if you want the relevant events to fire properly.
 
   === saving nested attributes ===
 
@@ -141,7 +145,7 @@ export default class extends Model {
         const nestedInstance = this.attributes[nestedKey];
 
         if (nestedInstance) {
-          nestedInstance.set(nestedData || {});
+          if (nestedData) nestedInstance.set(nestedData);
           delete attrs[nestedKey];
         } else {
           attrs[nestedKey] = new NestedClass(nestedData);

--- a/js/models/Profile.js
+++ b/js/models/Profile.js
@@ -120,6 +120,8 @@ export default class extends BaseModel {
         groupedByType[socialAttrs.type].indexOf(socialMd) > 0) {
         addError(`social[${index}].type`, 'You already have a social account of this type.');
       }
+
+      // todo: dont allow multiple others with the same username.
     });
 
     if (Object.keys(errObj).length) return errObj;

--- a/js/router.js
+++ b/js/router.js
@@ -57,7 +57,6 @@ export default class ObRouter extends Router {
   }
 
   execute(callback, args) {
-    app.simpleMessageModal.close();
     app.loadingModal.open();
 
     if (callback) callback.apply(this, args);

--- a/js/router.js
+++ b/js/router.js
@@ -59,7 +59,10 @@ export default class ObRouter extends Router {
   execute(callback, args) {
     app.loadingModal.open();
 
-    if (callback) callback.apply(this, args);
+    if (callback) {
+      this.trigger('will-route');
+      callback.apply(this, args);
+    }
   }
 
   loadPage(vw) {

--- a/js/start.js
+++ b/js/start.js
@@ -51,9 +51,6 @@ app.loadingModal = new LoadingModal({
 $.get(app.getServerUrl('ob/config')).done((data) => {
   app.profile = new Profile({ id: data.guid });
 
-  console.log('hello');
-  window.hello = app.profile;
-
   // todo: for now busting cache on fetch pending
   // issue where my server is not running the latest
   // code which solves this.

--- a/js/start.js
+++ b/js/start.js
@@ -34,17 +34,18 @@ const usersCl = new Collection([
 app.localSettings = new LocalSettings({ id: 1 });
 app.localSettings.fetch().fail(() => app.localSettings.save());
 
+app.pageNav = new PageNav();
+$('#pageNavContainer').append(app.pageNav.render().el);
+
+app.router = new ObRouter({ usersCl });
+
 // create and launch loading modal
 app.loadingModal = new LoadingModal({
   dismissOnOverlayClick: false,
   dismissOnEscPress: false,
   showCloseButton: false,
+  removeOnRoute: false,
 }).render().open();
-
-app.pageNav = new PageNav();
-$('#pageNavContainer').append(app.pageNav.render().el);
-
-app.router = new ObRouter({ usersCl });
 
 // get the server config
 $.get(app.getServerUrl('ob/config')).done((data) => {

--- a/js/start.js
+++ b/js/start.js
@@ -41,13 +41,6 @@ app.loadingModal = new LoadingModal({
   showCloseButton: false,
 }).render().open();
 
-// create our re-usable simple message modal instance
-app.simpleMessageModal = new SimpleMessageModal({ removeOnClose: false }).render();
-app.simpleMessageModal._origRemove = app.simpleMessageModal.remove;
-app.simpleMessageModal.remove = () => {
-  throw new Error('This is a shared instance that should not be removed.');
-};
-
 app.pageNav = new PageNav();
 $('#pageNavContainer').append(app.pageNav.render().el);
 
@@ -91,12 +84,21 @@ $.get(app.getServerUrl('ob/config')).done((data) => {
             app.loadingModal.close();
           }).fail((failData) => {
             app.loadingModal.close();
-            app.simpleMessageModal.open('Unable To Save Profile', failData.reason || '');
+            new SimpleMessageModal()
+              .render()
+              .open('Unable To Save Profile', failData.reason || '');
           });
         }
       } else {
         app.loadingModal.close();
-        app.simpleMessageModal.open('Unable To Get Profile');
+        new SimpleMessageModal()
+          .render()
+          .open('Unable To Get Profile');
       }
     });
+}).fail(() => {
+  app.loadingModal.close();
+  new SimpleMessageModal()
+    .render()
+    .open('Unable to obtain the server configuration.', 'Is your server running?');
 });

--- a/js/start.js
+++ b/js/start.js
@@ -51,6 +51,9 @@ app.loadingModal = new LoadingModal({
 $.get(app.getServerUrl('ob/config')).done((data) => {
   app.profile = new Profile({ id: data.guid });
 
+  console.log('hello');
+  window.hello = app.profile;
+
   // todo: for now busting cache on fetch pending
   // issue where my server is not running the latest
   // code which solves this.

--- a/js/templates/testProfile.html
+++ b/js/templates/testProfile.html
@@ -23,10 +23,10 @@
   <label>
     Social Accounts:
   </label>
-  <div class="js-socialContainer">
+  <div>
   <% if (ob.social && ob.social.length) { %>
      <% ob.social.forEach((socialAcct, index) => { %>
-      <div class="socialAccount js-socialAccount">
+      <div class="socialAccount">
         <% if (ob.errors[`social[${index}].type`]) print(ob.formErrorTmpl({ errors: ob.errors[`social[${index}].type`] })) %>  
        <label>
           Type:

--- a/js/templates/testProfile.html
+++ b/js/templates/testProfile.html
@@ -23,29 +23,29 @@
   <label>
     Social Accounts:
   </label>
+  <div class="js-socialContainer">
   <% if (ob.social && ob.social.length) { %>
-       <div> <% // wrapping div needeed for JS to properly calc index %>
-       <% ob.social.forEach((socialAcct, index) => { %>
-         <div class="socialAccount">
-           <% if (ob.errors[`social[${index}].type`]) print(ob.formErrorTmpl({ errors: ob.errors[`social[${index}].type`] })) %>  
-           <label>
-              Type:
-             <select name="<%= `social[${index}].type` %>">
-               <% ob.socialTypes.forEach((type) => { %>
-                  <option value="<%= type %>"<% if (socialAcct.type === type) print('selected')%>><% print(type.charAt(0).toUpperCase() + type.slice(1)) %></option>
-               <% }) %>
-             </select>
-           </label>
-           <% if (ob.errors[`social[${index}].username`]) print(ob.formErrorTmpl({ errors: ob.errors[`social[${index}].username`] })) %>  
-           <label>
-              Username:
-              <input name="<%= `social[${index}].username` %>" type="text" value="<%= socialAcct.username %>" />
-            </label>
-           <button type="button" class="js-RemoveSocial">Remove</button>
-         </div>
-    <% }); %>
+     <% ob.social.forEach((socialAcct, index) => { %>
+      <div class="socialAccount js-socialAccount">
+        <% if (ob.errors[`social[${index}].type`]) print(ob.formErrorTmpl({ errors: ob.errors[`social[${index}].type`] })) %>  
+       <label>
+          Type:
+         <select name="<%= `social[${index}].type` %>">
+           <% ob.socialTypes.forEach((type) => { %>
+              <option value="<%= type %>"<% if (socialAcct.type === type) print('selected')%>><% print(type.charAt(0).toUpperCase() + type.slice(1)) %></option>
+           <% }) %>
+         </select>
+       </label>
+       <% if (ob.errors[`social[${index}].username`]) print(ob.formErrorTmpl({ errors: ob.errors[`social[${index}].username`] })) %>  
+       <label>
+          Username:
+          <input name="<%= `social[${index}].username` %>" type="text" value="<%= socialAcct.username %>" />
+        </label>
+       <button type="button" class="js-RemoveSocial">Remove</button>
       </div>
+    <% }); %>
    <% } %>  
+  </div>
   <button type="button" class="js-AddSocial btnAddSocial">Add</button>
 
   <div class="buttonBar">

--- a/js/views/TestModalsPage.js
+++ b/js/views/TestModalsPage.js
@@ -1,6 +1,5 @@
 import BaseVw from './baseVw';
 import loadTemplate from '../utils/loadTemplate';
-import app from '../app';
 import TestModal from './modals/Test';
 import Dialog from './modals/Dialog';
 import SimpleMessageModal from './modals/SimpleMessage';

--- a/js/views/TestModalsPage.js
+++ b/js/views/TestModalsPage.js
@@ -3,6 +3,7 @@ import loadTemplate from '../utils/loadTemplate';
 import app from '../app';
 import TestModal from './modals/Test';
 import Dialog from './modals/Dialog';
+import SimpleMessageModal from './modals/SimpleMessage';
 
 export default class extends BaseVw {
   constructor(options = {}) {
@@ -23,8 +24,9 @@ export default class extends BaseVw {
   }
 
   onClickSimple() {
-    app.simpleMessageModal.open('Who do you think you are?',
-      'I seemed to have misplaced my shoes and glasses.');
+    new SimpleMessageModal()
+      .render()
+      .open('Who do you think you are?', 'I seemed to have misplaced my shoes and glasses.');
   }
 
   onClickDialog() {

--- a/js/views/TestProfilePage.js
+++ b/js/views/TestProfilePage.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import BaseVw from './baseVw';
 import loadTemplate from '../utils/loadTemplate';
 import app from '../app';
+import SimpleMessageModal from './modals/SimpleMessage';
 
 export default class extends BaseVw {
   constructor(options = {}) {
@@ -55,7 +56,9 @@ export default class extends BaseVw {
       formSave.done(() => {
         new Notification('Save complete', { silent: true }); // eslint-disable-line no-new
       }).fail((data) => {
-        app.simpleMessageModal.open('There was an error saving the data.', data.reason || '');
+        new SimpleMessageModal()
+          .render()
+          .open('There was an error saving the data.', data.reason || '');
       });
     }
 

--- a/js/views/TestProfilePage.js
+++ b/js/views/TestProfilePage.js
@@ -77,10 +77,6 @@ export default class extends BaseVw {
     this.render();
   }
 
-  getSocialContainer() {
-    return this.$socialContainer || this.$('.js-socialContainer');
-  }
-
   saveForm() {
     const formSave = app.profile.save();
 
@@ -113,8 +109,6 @@ export default class extends BaseVw {
         socialTypes: app.profile.socialTypes,
         errors: app.profile.validationError || {},
       }));
-
-      this.$socialContainer = null;
     });
 
     return this;

--- a/js/views/modals/BaseModal.js
+++ b/js/views/modals/BaseModal.js
@@ -12,6 +12,7 @@ export default class BaseModal extends BaseVw {
       showCloseButton: true,
       closeButtonClass: 'modalClose ion-close-round',
       modelContentClass: 'modalContent clrP',
+      removeOnClose: false,
       ...options,
     };
 
@@ -77,6 +78,10 @@ export default class BaseModal extends BaseVw {
       getAppFrame()[0].removeChild(this.el);
       this._open = false;
       this.trigger('close');
+    }
+
+    if (this.__options.removeOnClose) {
+      this.remove();
     }
 
     return this;

--- a/js/views/modals/BaseModal.js
+++ b/js/views/modals/BaseModal.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import loadTemplate from '../../utils/loadTemplate';
 import BaseVw from '../baseVw';
 import { getHtml, getAppFrame } from '../../utils/selectors';
+import app from '../../app';
 
 export default class BaseModal extends BaseVw {
   constructor(options = {}) {
@@ -13,6 +14,7 @@ export default class BaseModal extends BaseVw {
       closeButtonClass: 'modalClose ion-close-round',
       modelContentClass: 'modalContent clrP',
       removeOnClose: false,
+      removeOnRoute: true,
       ...options,
     };
 
@@ -29,6 +31,8 @@ export default class BaseModal extends BaseVw {
       $(document).on('keyup', BaseModal.__onDocKeypress);
       BaseModal.__docKeyPressHandlerBound = true;
     }
+
+    if (this.__options.removeOnRoute) this.listenTo(app.router, 'will-route', this.remove);
   }
 
   className() {
@@ -90,11 +94,20 @@ export default class BaseModal extends BaseVw {
   setModalOptions(options) {
     if (!options) return this;
 
-    this.__options = { ...this.__options, ...options };
-
     if (typeof options.showCloseButton !== 'undefined') {
       this.$modalClose[options.showCloseButton ? 'removeClass' : 'addClass']('hide');
     }
+
+    if (typeof options.removeOnRoute !== 'undefined' &&
+      options.removeOnRoute !== this.__options.removeOnRoute) {
+      if (options.removeOnRoute) {
+        this.listenTo(app.router, 'will-route', this.remove);
+      } else {
+        this.stopListening(app.router, 'will-route');
+      }
+    }
+
+    this.__options = { ...this.__options, ...options };
 
     return this;
   }
@@ -105,6 +118,7 @@ export default class BaseModal extends BaseVw {
 
   remove() {
     if (this.isOpen()) this.close();
+    app.router.off(null, this.onRoute);
     super.remove();
 
     return this;

--- a/js/views/modals/Dialog.js
+++ b/js/views/modals/Dialog.js
@@ -33,8 +33,7 @@ the bottom. If you find that your situation needs custom markup, css (beyond the
 can optionally pass in) and/or behavior (e.g. tabs, etc.), you should write a custom view
 and extend from the Base Modal.
 
-Also, if it's just a super simple message you need, please use the simpleMessageModal
-instance attached to our app instance.
+Also, if it's just a super simple message you need, please check out the SimpleMessageModal.
 */
 
 export default class extends BaseModal {

--- a/js/views/modals/Dialog.js
+++ b/js/views/modals/Dialog.js
@@ -39,12 +39,12 @@ Also, if it's just a super simple message you need, please check out the SimpleM
 export default class extends BaseModal {
   constructor(options = {}) {
     const opts = {
-      removeOnClose: true,
       title: '',
       message: '',
       titleClass: '',
       messageClass: '',
       buttons: [],
+      removeOnClose: true,
       ...options,
     };
 
@@ -68,8 +68,6 @@ export default class extends BaseModal {
       this.events = () => ({ ...super.events() || {}, ...events });
       this.delegateEvents(this.events);
     }
-
-    if (this.options.removeOnClose) this.on('close', () => this.remove());
   }
 
   className() {

--- a/js/views/modals/Settings/Settings.js
+++ b/js/views/modals/Settings/Settings.js
@@ -17,8 +17,6 @@ export default class extends BaseModal {
 
     this.tabViewCache = {};
     this.tabViews = { SettingsGeneral, SettingsPage };
-
-    if (this.options.removeOnClose) this.on('close', () => this.remove());
   }
 
   className() {

--- a/js/views/modals/SimpleMessage.js
+++ b/js/views/modals/SimpleMessage.js
@@ -20,7 +20,6 @@ export default class extends BaseModal {
     super(opts);
 
     this.options = opts;
-    if (this.options.removeOnClose) this.on('close', () => this.remove());
     this.title = options.title;
     this.message = options.message;
   }

--- a/js/views/modals/SimpleMessage.js
+++ b/js/views/modals/SimpleMessage.js
@@ -2,13 +2,6 @@ import loadTemplate from '../../utils/loadTemplate';
 import BaseModal from './BaseModal';
 
 /*
-  An instance of this modal is attached to our App instance, which allows you to display a
-  simple message as follows:
-
-  import app from './app'; // adjust path as needed
-
-  app.simpleMessageModal.open('The Beatles', 'We all need a little help from our friends.');
-
   Please Note: This Modal is designed for a very simple message (containing a title and a
   message body). If you need something beyond that, check out the Dialog which will allow
   you to optionally pass in classes as well as buttons. If you need something beyond that,

--- a/styles/modules/modals/_message.scss
+++ b/styles/modules/modals/_message.scss
@@ -1,4 +1,4 @@
-// The messageModal class is shared by both the simpleMessageModal and the Dialog and
+// The messageModal class is shared by both the SimpleMessageModal and the Dialog and
 // is therefore the place to declare styling common to both of them.
 // TODO: if we find they end up sharing very little in common, we can break them
 // out into seperate files.


### PR DESCRIPTION
Multiple, mostly unrelated things:

1.) Removed the singular simpleMessageModal instance that was to be shared by the app. After some thought, I realized there are likely scenarios where more than one simpleMessage will be on the screen at a time. For example, your page displays a message, then a profile save API call which had been fired off a minute ago fails and we want to display a message informing the user of that, but we still want the other message to remain stacked below until the user has a chance to dismiss it.

2.) Added "close on remove" functionality to the base modal. It's off by default, but any modals that want to provide that functionality can just pass in true for that option in the constructor.

3.) By default, I'm having modals remove themselves when the router will route. This is an option that can be turned off if it's not appropriate for your modal instance. While removing a modal you launched in the remove() method of your view (or registering it as a child) works for most cases, there are edge cases where this is not sufficient (e.g. non-views are launching modals). Putting in this functionality should shore up those edge-cases.

4.) Some tweaks to the nested attributes functionality and the profile example page.