### PR TITLE
Own page route

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -19,8 +19,7 @@ export default class ObRouter extends Router {
     const routes = [
       [/^@([^\/]+)[\/]?([^\/]*)[\/]?([^\/]*)[\/]?([^\/]*)$/, 'userViaHandle'],
       [/^(Qm[a-zA-Z0-9]+)[\/]?([^\/]*)[\/]?([^\/]*)[\/]?([^\/]*)$/, 'user'],
-      ['ownPage', 'ownPage'],
-      ['ownPage/:tab(/:action)', 'ownPage'],
+      [/^ownPage[\/]?(.*?)$/, 'ownPage'],
       ['transactions', 'transactions'],
       ['transactions/:tab', 'transactions'],
       ['test-modals', 'testModals'],
@@ -128,10 +127,17 @@ export default class ObRouter extends Router {
     });
   }
 
-  ownPage(tab, ...args) {
-    tab = [tab || 'about'];   // eslint-disable-line no-param-reassign
-    const path = _.compact(tab.concat(args)).join('/');
-    this.navigate(`${app.profile.id}${path ? `/${path}` : ''}`, { trigger: true });
+  ownPage(...args) {
+    let subPath = '';
+
+    if (args.length && args[0] !== null) {
+      subPath = args[0];
+    }
+
+    this.navigate(`${app.profile.id}/${subPath}`, {
+      trigger: true,
+      replace: true,
+    });
   }
 
   transactions(tab) {

--- a/js/router.js
+++ b/js/router.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import _ from 'underscore';
 import { Router } from 'backbone';
 import { getGuid } from './utils';
 import { getPageContainer } from './utils/selectors';

--- a/js/router.js
+++ b/js/router.js
@@ -126,14 +126,8 @@ export default class ObRouter extends Router {
     });
   }
 
-  ownPage(...args) {
-    let subPath = '';
-
-    if (args.length && args[0] !== null) {
-      subPath = args[0];
-    }
-
-    this.navigate(`${app.profile.id}/${subPath}`, {
+  ownPage(subPath) {
+    this.navigate(`${app.profile.id}/${subPath === null ? '' : subPath}`, {
       trigger: true,
       replace: true,
     });


### PR DESCRIPTION
This re-works the ownPage route so that it will just redirect to the user route, albeit with the user owns guid. Any and all other path components will carry over, so as we build out the user pages routes, we never need to also adjust the ownPage route.