### PR TITLE
Updated window controls (fixes #141)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,9 +103,8 @@ case "$TRAVIS_OS_NAME" in
     curl -L https://dl.bintray.com/develar/bin/wine.7z -o /tmp/wine.7z
     /tmp/7za x -o/usr/local/Cellar -y /tmp/wine.7z
 
-    brew cask install xquartz
-    brew link libusb libusb-compat fontconfig webp gd little-cms2 sane-backends libtasn1
-    brew install wine
+    brew link --overwrite fontconfig gd gnutls jasper libgphoto2 libicns libtasn1 libusb libusb-compat little-cms2 nettle openssl sane-backends webp wine git-lfs gnu-tar dpkg xz
+    brew install freetype graphicsmagick
     brew link xz
     brew install mono
 

--- a/js/templates/pageNav.html
+++ b/js/templates/pageNav.html
@@ -4,10 +4,14 @@
       <div class="windowControlsHolder">
         <div class="windowControls windowControlsMac">
           <a class="navClose js-navClose">
-            <i class="ion-ios-close-empty"></i>
+            <span class="ion-ios-close-empty"></span>
           </a>
-          <a class="navMin js-navMin"></a>
-          <a class="navMax js-navMax"></a>
+          <a class="navMin js-navMin">
+            <span class="ion-ios-minus-empty"></span>
+          </a>
+          <a class="navMax js-navMax">
+            <span class="ion-ios-plus-empty"></span>
+          </a>
         </div>
       </div>
       <div>

--- a/styles/modules/_pageNav.scss
+++ b/styles/modules/_pageNav.scss
@@ -72,18 +72,18 @@
         box-sizing: border-box;
 
         &.navClose {
-          background-color: #FF6059;
-          border: solid 1px #EF5851;
+          background-color: #FF6058;
+          border: solid 1px #E1473F;
         }
 
         &.navMin {
           background-color: #FFBD2E;
-          border: solid 1px #F0B128;
+          border: solid 1px #E0A117;
         }
 
         &.navMax {
-          background-color: #29C941;
-          border: solid 1px #27BB3D;
+          background-color: #29CB41;
+          border: solid 1px #13AD29;
           margin-right: 0;
         }
 

--- a/styles/modules/_pageNav.scss
+++ b/styles/modules/_pageNav.scss
@@ -66,27 +66,33 @@
 
       a {
         border-radius: 50%;
-        margin-right: 5px;
+        color: #000;
+        text-align: center;
+        margin-right: 8px;
         box-sizing: border-box;
 
         &.navClose {
-          background-color: #E45A5A;
+          background-color: #FF6059;
+          border: solid 1px #EF5851;
         }
 
         &.navMin {
-          background-color: #F8E71C;
+          background-color: #FFBD2E;
+          border: solid 1px #F0B128;
         }
 
         &.navMax {
-          background-color: #B8E986;
+          background-color: #29C941;
+          border: solid 1px #27BB3D;
+          margin-right: 0;
         }
 
-        i {
+        span {
           visibility: hidden;
-          font-size: 16px;
+          font-size: 10px;
         }
 
-        &:hover i {
+        &:hover span {
          visibility: visible;
         }
       }


### PR DESCRIPTION
This makes the Mac style window controls match the native experience more closely (fixes #141).

@jjeffryes there's one thing I wasn't able to figure out... On a native Mac window, when you hover any circle, all 3 icons display at the same time (as pictured below). 

![screenshot 2016-12-02 17 07 56](https://cloud.githubusercontent.com/assets/13066886/20855447/e7fb4af2-b8b1-11e6-8636-ecf0eabb7b11.png)

I wasn't able to figure out how to get this working in OB. If it's an easy change, it would be nice to layer it in. 




