### PR TITLE
Patch 132 to match address box design

### DIFF
--- a/js/templates/modals/settings/addresses.html
+++ b/js/templates/modals/settings/addresses.html
@@ -1,7 +1,7 @@
 <div class="bar padMd clrBr borderBottom">
   <h2 class="h3 txUnb"><%= ob.polyT('settings.addressesTab') %></h2>
 </div>
-<div class="tabFormWrapper js-addressesWrap clrS">
+<div class="tabFormWrapper js-addressesWrap clrP">
   <div class="settingsTabFormWrapperInner">
     <div class="js-listContainer"></div>
     <div class="js-formContainer"></div>

--- a/js/templates/modals/settings/addressesList.html
+++ b/js/templates/modals/settings/addressesList.html
@@ -8,6 +8,7 @@
        addressRow.forEach((address, index) => {
         addressIndex += 1;
     %>
+      <div class="col6">
         <div class="addressBox border clrP clrBr">
           <%= `${address.name}${address.company ? '<br />' : ''}` %>
           <%= `${address.company}${address.addressLineOne ? '<br />' : ''}` %>
@@ -17,6 +18,7 @@
           <% if (address.addressNotes) print(`<p class="notes">${address.addressNotes}</p>`) %>
           <a class="btn clrP clrBr js-delete" data-address-index="<%= addressIndex %>">Delete</a>
         </div>
+      </div>
      <% }); %>
     </div>
   <% }) %>

--- a/js/views/modals/Settings/AddressesList.js
+++ b/js/views/modals/Settings/AddressesList.js
@@ -6,7 +6,7 @@ import baseVw from '../../baseVw';
 export default class extends baseVw {
   constructor(options = {}) {
     super({
-      className: 'settingsAddressesList',
+      className: 'settingsAddressesList pad',
       ...options,
     });
 

--- a/styles/components/_layout.scss
+++ b/styles/components/_layout.scss
@@ -331,7 +331,7 @@
       padding-left: 0;
     }
 
-    &:last-child {
+    &:last-child:not(:only-child) {
       padding-right: 0;
     }
   }

--- a/styles/modules/modals/_settings.scss
+++ b/styles/modules/modals/_settings.scss
@@ -53,7 +53,7 @@
         padding: $padMd;
         padding-bottom: $padMd + 35 + $padMd; // give bottom aligned button space
         line-height: 1.3;
-        width: 50%;
+        height: 100%;
         box-sizing: border-box;
         position: relative;
         flex: 0 0 auto;


### PR DESCRIPTION
- removes secondary color behind address boxes
- add padding
- uses col6 to space the address boxes
- adjusts the gutterH code to account for only child columns

att @morebrownies, take a look at this, if it looks good merge it with 132 and I'll merge 132. 