### PR TITLE
Patch hover effect.

### DIFF
--- a/styles/modules/_pageNav.scss
+++ b/styles/modules/_pageNav.scss
@@ -91,10 +91,10 @@
           visibility: hidden;
           font-size: 10px;
         }
+      }
 
-        &:hover span {
-         visibility: visible;
-        }
+      &:hover span {
+        visibility: visible;
       }
     }
   }


### PR DESCRIPTION
Tweaks the css for the desired effect.

The old rule was nested in the wrong place, it was being applied to the a selector, it should have been applied to the .windowControls selector.

I did notice when testing that the hover doesn't deactivate until the mouse moves about double the button height below it, and to the right, though moving up and to the left are as expected. I wasn't able to figure out why that was happening.