### PR TITLE
Removes the spacing from FlexRow

### DIFF
--- a/styles/components/_layout.scss
+++ b/styles/components/_layout.scss
@@ -36,7 +36,6 @@
   @extend .flex;
   //use this to contain columns
   align-items: stretch; //this stretches the items to 100% height
-  justify-content: space-between;
 }
 
 .snip,


### PR DESCRIPTION
- Closes #119
- I don't see any negative effects from this, but I added justify-content: space-between to flexRow to fix some issue, I don't remember what it was. It's possible it's been refactored out since.