### PR TITLE
Page navigation fixes (fixes #142)

### DIFF
--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -146,6 +146,7 @@ ul, ol {
         }
 
         .tab {
+          border-radius: 0;
           box-sizing: content-box;
           font-size: $tx4;
 

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -71,7 +71,7 @@
   }
 }
 
-@mixin textColor($col1, $col2: $col1) {
+@mixin textColor($col1, $col2: $col1, $col3: $col2) {
   /* generates the text color rules */
   /* if no second color is passed, set everything to the first color */
   color: $col1;
@@ -93,5 +93,9 @@
 
   input[type="radio"]:checked + label:before {
     background: $col1;
+  }
+
+  .tab.active {
+    color: $col3;
   }
 }

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -61,21 +61,17 @@ input[type=range][class~="clrS"] {
 }
 
 .clrT2 {
-  @include textColor($text2, $text3);
-
-  .tab.active {
-    color: $text;
-  }
+  @include textColor($text2, $text3, $text);
 }
 
 .clrT3 {
   // links in text color 3 are the same color, or they'd be too hard to see
-  @include textColor($text3);
+  @include textColor($text3, $text3, $text2);
 }
 
 .clrT4 {
   // links in text color 4 are the same color, or they'd be too hard to see
-  @include textColor($text4);
+  @include textColor($text4, $text4, $text3);
 }
 
 .clrTEm {
@@ -96,7 +92,7 @@ input[type=range][class~="clrS"] {
 }
 
 .clrTEmph1 {
-  @include textColor($emphasis1);  
+  @include textColor($emphasis1);
 }
 
 .clrBr {

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -62,6 +62,10 @@ input[type=range][class~="clrS"] {
 
 .clrT2 {
   @include textColor($text2, $text3);
+
+  .tab.active {
+    color: $text;
+  }
 }
 
 .clrT3 {


### PR DESCRIPTION
@jjeffryes please double check how I coded this. It fixes the problem (the active tab is now darker text), but I'm not sure if it's the best way to handle it. 

```
.clrT2 {
  @include textColor($text2, $text3);

  .tab.active {
    color: $text;
  }
}
```