### PR TITLE
Moves active tab style to mixin

### DIFF
--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -71,7 +71,7 @@
   }
 }
 
-@mixin textColor($col1, $col2: $col1) {
+@mixin textColor($col1, $col2: $col1, $col3: $col2) {
   /* generates the text color rules */
   /* if no second color is passed, set everything to the first color */
   color: $col1;
@@ -93,5 +93,9 @@
 
   input[type="radio"]:checked + label:before {
     background: $col1;
+  }
+
+  .tab.active {
+    color: $col3;
   }
 }

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -61,21 +61,17 @@ input[type=range][class~="clrS"] {
 }
 
 .clrT2 {
-  @include textColor($text2, $text3);
-
-  .tab.active {
-    color: $text;
-  }
+  @include textColor($text2, $text3, $text);
 }
 
 .clrT3 {
   // links in text color 3 are the same color, or they'd be too hard to see
-  @include textColor($text3);
+  @include textColor($text3, $text3, $text2);
 }
 
 .clrT4 {
   // links in text color 4 are the same color, or they'd be too hard to see
-  @include textColor($text4);
+  @include textColor($text4, $text4, $text3);
 }
 
 .clrTEm {
@@ -96,7 +92,7 @@ input[type=range][class~="clrS"] {
 }
 
 .clrTEmph1 {
-  @include textColor($emphasis1);  
+  @include textColor($emphasis1);
 }
 
 .clrBr {


### PR DESCRIPTION
- this moves the active tab style to the textColor mixin
- textColor() now has a 3rd parameter, for the tab color
- the other text colors now have a tab color set, so if a tab has clrT3, for example, when active it will have a color one step up.
- currently the tab color is the same as the link color, but this provides the option to set it to something different