### PR TITLE
Fix border being applied to all buttons on hover due to bad merge.

### DIFF
--- a/styles/components/_buttons.scss
+++ b/styles/components/_buttons.scss
@@ -23,8 +23,6 @@
   &:focus:not(.btnRadio) {
     text-decoration: none;
     cursor: pointer;
-    border-width: 1px;
-    border-style: solid;
     outline: 0;
   }
 


### PR DESCRIPTION
Removes borders being applied to all buttons on hover when they shouldn't be.