### PR TITLE
Fixes external images that are too big.

### DIFF
--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -79,7 +79,7 @@
     </div>
   </div>
 
-  <div class="contentBox padLg clrP clrBr clrSh3">
+  <div class="contentBox descriptionSection padLg clrP clrBr clrSh3">
     <h2 class="txUnb"><%= ob.polyT('listingDetail.description') %></h2>
     <%= ob.item.description %>
     <% if(!ob.item.description) { print(ob.polyT('listingDetail.noDescription')) } %>

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -103,6 +103,12 @@ ul, ol {
   background-repeat: no-repeat;
 }
 
+.trumbowyg .trumbowyg-editor {
+  height: auto !important;
+  /* gross hack to stop trumbowyg from setting inline height to huge numbers when external
+  images are added */
+}
+
 #appFrame {
   position: absolute;
   height: 100%;

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -103,12 +103,6 @@ ul, ol {
   background-repeat: no-repeat;
 }
 
-.trumbowyg .trumbowyg-editor {
-  height: auto !important;
-  /* gross hack to stop trumbowyg from setting inline height to huge numbers when external
-  images are added */
-}
-
 #appFrame {
   position: absolute;
   height: 100%;

--- a/styles/components/_misc.scss
+++ b/styles/components/_misc.scss
@@ -12,11 +12,17 @@
     transform: translate(-25%, -25%);
     border-radius: 50%;
     border-style: solid;
-    border-width: 1px;              
+    border-width: 1px;
     width: 100%;
     height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
   }
+}
+
+.trumbowyg .trumbowyg-editor {
+  height: auto !important;
+  /* gross hack to stop trumbowyg from setting inline height to huge numbers when external
+  images are added */
 }

--- a/styles/components/_modal.scss
+++ b/styles/components/_modal.scss
@@ -66,7 +66,7 @@
       .topControls {
         margin-bottom: $padSm;
         height: 35px;
-      }      
+      }
     }
   }
 }

--- a/styles/components/_tabbedModal.scss
+++ b/styles/components/_tabbedModal.scss
@@ -30,6 +30,10 @@
     }
   }
 
+  .tabContent {
+    max-width: 757px;
+  }
+
   &.fixedNav {
     .tabColumn {
       position: fixed;

--- a/styles/modules/modals/_listingDetail.scss
+++ b/styles/modules/modals/_listingDetail.scss
@@ -34,6 +34,14 @@
         }
       }
 
+      .descriptionSection {
+
+        img {
+          max-width: 100%;
+          height: auto;
+        }
+      }
+
       #photoSection {
         height: 701px;
 


### PR DESCRIPTION
- sets the tabColumn in tabbed modals to a fixed max width to prevent content from making it too big.
- sets images in the description area to no larger than 100% width.
- Closes #227
- Closes #245

Also fixes weird bug where Trumbowyg sets its height to thousands of pixels tall when images are used (I think it's setting it's height based on the original height of the images, then shrinking the images to fit in the editor, leaving a huge gap at the bottom).

![image](https://cloud.githubusercontent.com/assets/1584275/21555611/9d02f63a-cde7-11e6-9e44-15ea6f59f2b2.png)
