### PR TITLE
updating default port in the server config model

### DIFF
--- a/js/models/ServerConfig.js
+++ b/js/models/ServerConfig.js
@@ -14,7 +14,7 @@ export default class extends BaseModel {
   defaults() {
     return {
       serverIp: 'localhost',
-      port: 8080,
+      port: 4002,
       SSL: false,
       default: false,
     };


### PR DESCRIPTION
Updating default port used for server configurations. Any existing clients will need to take the following steps for their connection to work:

A: wipe and start with a fresh client and server.

or

B:
1. pull latest server
2. in the server config file, change Addresses.Gateway from `/ip4/127.0.0.1/tcp/8080` to `/ip4/127.0.0.1/tcp/4002`.
3. pull the latest client and start it up.
4. in your JS console, execute this `localStorage.clear()`.
5. start the server
6. re-start the client