### PR TITLE
fixing image load so hack isnt necessary

### DIFF
--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -87,7 +87,7 @@
 
   <% if (ob.item.images.length) { %>
     <div class="contentBox clrP clrBr clrSh3 photoSection js-photoSection">
-      <div class="flexCent photoSelected js-photoSelected" data-index="0">
+      <div class="flexCent photoSelected js-photoSelected">
         <img class="photoSelectedInner js-photoSelectedInner">
       </div>
       <% if (ob.item.images.length > 1) { %>

--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -98,7 +98,7 @@
         <div class="photoStrip flex gutterH">
           <% ob.item.images.forEach(function(image, index){
           const chk = index === 0 ? "checked" : "";
-          print(`<input type="radio" name="photoStripThumbnails" class="js-photoSelect" data-index=${index} id="photoStrip${index}" ${chk}>`);
+          print(`<input type="radio" name="photoStripThumbnails" class="js-photoSelect" id="photoStrip${index}" ${chk}>`);
           print(`<label style="background-image: url(${ob.getServerUrl(`ipfs/${ob.isHiRez() ? image.small : image.tiny}`)}" for="photoStrip${index}"></label>`);
           }); %>
         </div>

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -145,7 +145,7 @@ export default class extends BaseModal {
   }
 
   onClickPhotoSelect(e) {
-    this.setSelectedPhoto($(e.target).data('index'));
+    this.setSelectedPhoto($(e.target).index('.js-photoSelect'));
   }
 
   setSelectedPhoto(photoIndex) {
@@ -159,8 +159,8 @@ export default class extends BaseModal {
     const photoHash = photoCol[photoIndex].original;
     const phSrc = app.getServerUrl(`ipfs/${photoHash}`);
 
+    this.activePhotoIndex = photoIndex;
     this.$photoSelected.trigger('zoom.destroy'); // old zoom must be removed
-
     this.$photoSelectedInner.attr('src', phSrc);
   }
 
@@ -379,7 +379,7 @@ export default class extends BaseModal {
 
       this.$('#shippingDestinations').select2();
       this.renderShippingDestinations(this.defaultCountry);
-      this.setSelectedPhoto(0);
+      this.setSelectedPhoto(this.activePhotoIndex);
     });
 
     return this;

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -26,6 +26,7 @@ export default class extends BaseModal {
     super(opts);
     this.options = opts;
     this._shipsFreeToMe = this.model.shipsFreeToMe;
+    this.activePhotoIndex = 0;
 
     this.countryData = getTranslatedCountries(app.settings.get('language'))
       .map(countryObj => ({ id: countryObj.dataName, text: countryObj.name }));
@@ -160,35 +161,27 @@ export default class extends BaseModal {
 
     this.$photoSelected.trigger('zoom.destroy'); // old zoom must be removed
 
-    this.$photoSelectedInner
-        .one('load', this.activateZoom(photoIndex, phSrc))
-        .attr('src', phSrc);
+    this.$photoSelectedInner.attr('src', phSrc);
   }
 
-  activateZoom(photoIndex, phSrc) {
-    setTimeout(() => {
-      // without a timeout the image hasn't rendered yet and has no height or width
-
-      if (this.$photoSelectedInner.width() >= this.$photoSelectedWidth ||
-          this.$photoSelectedInner.height() >= this.$photoSelectedHeight) {
-
-        this.$photoSelected
-            .attr('data-index', photoIndex)
-            .removeClass('unzoomable')
-            .zoom({
-              url: phSrc,
-              on: 'click',
-              onZoomIn: () => {
-                this.$photoSelected.addClass('open');
-              },
-              onZoomOut: () => {
-                this.$photoSelected.removeClass('open');
-              },
-            });
-      } else {
-        this.$photoSelected.addClass('unzoomable');
-      }
-    }, 500);
+  activateZoom() {
+    if (this.$photoSelectedInner.width() >= this.$photoSelectedWidth ||
+        this.$photoSelectedInner.height() >= this.$photoSelectedHeight) {
+      this.$photoSelected
+          .removeClass('unzoomable')
+          .zoom({
+            url: this.$photoSelectedInner.attr('src'),
+            on: 'click',
+            onZoomIn: () => {
+              this.$photoSelected.addClass('open');
+            },
+            onZoomOut: () => {
+              this.$photoSelected.removeClass('open');
+            },
+          });
+    } else {
+      this.$photoSelected.addClass('unzoomable');
+    }
   }
 
   setActivePhotoThumbnail(thumbIndex) {
@@ -202,7 +195,7 @@ export default class extends BaseModal {
   }
 
   onClickPhotoPrev() {
-    let targetIndex = parseInt(this.$photoSelected.attr('data-index'), 10) - 1;
+    let targetIndex = this.activePhotoIndex - 1;
     const imagesLength = parseInt(this.model.get('listing').toJSON().item.images.length, 10);
 
     targetIndex = targetIndex < 0 ? imagesLength - 1 : targetIndex;
@@ -211,7 +204,7 @@ export default class extends BaseModal {
   }
 
   onClickPhotoNext() {
-    let targetIndex = parseInt(this.$photoSelected.attr('data-index'), 10) + 1;
+    let targetIndex = this.activePhotoIndex + 1;
     const imagesLength = parseInt(this.model.get('listing').toJSON().item.images.length, 10);
 
     targetIndex = targetIndex >= imagesLength ? 0 : targetIndex;
@@ -325,11 +318,6 @@ export default class extends BaseModal {
       (this._$photoSelectedWidth = this.$photoSelected.width());
   }
 
-  get $photoSelectedInner() {
-    return this._$photoSelectedInner ||
-      (this._$photoSelectedInner = this.$('.js-photoSelectedInner'));
-  }
-
   get $shippingSection() {
     return this._$shippingSection ||
       (this._$shippingSection = this.$('#shippingSection'));
@@ -373,16 +361,18 @@ export default class extends BaseModal {
 
       super.render();
 
+      this.$photoSelectedInner = this.$('.js-photoSelectedInner');
       this._$deleteListing = null;
       this._$shipsFreeBanner = null;
       this._$popInMessages = null;
       this._$photoSection = null;
       this._$photoSelected = null;
-      this._$photoSelectedInner = null;
       this._$shippingOptions = null;
       this._$photoRadioBtns = null;
       this._$shippingSection = null;
       this._$closeClickTargets = null;
+
+      this.$photoSelectedInner.on('load', () => this.activateZoom());
 
       // commented out until variants are available
       // this.$('.js-variantSelect').select2();


### PR DESCRIPTION
Adjusting code so a timeout isn't necessary to determine if an image in the carousel is zoomable.

I don't 100% know why the other way didn't work, other than the fact that when the load event was bound with `one`, when the load fired it still referenced the previous image. So, the first time the page loads, there is no previous image and the height would be zero. Then, as you select another image, the load event would have the height of the previous image.

Anyhow... binding the event with `on` instead of `one` (and a few other tweaks to support that) seems to fix the issue.

@jjeffryes: FWIW, this is set to merge into #242 if it meets your approval.