### PR TITLE
Fix positioning issue with page navigation when a video tag is present.

### DIFF
--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -115,8 +115,7 @@ ul, ol {
   }
 
   #contentFrame {
-    position: relative;
-    top: $barLg;
+    padding-top: $barLg;
     overflow-y: scroll;
     height: calc(100% - #{$bar} - #{$barLg});
     box-sizing: border-box;

--- a/styles/modules/_userPage.scss
+++ b/styles/modules/_userPage.scss
@@ -1,5 +1,6 @@
 .userPage {
   height: 100%;
+  position: relative;
 
   .header {
     background-position: center;


### PR DESCRIPTION
Tweak to the positioning of some elements to prevent the presence of a video tag from changing the stacking order.