### PR TITLE
Quick and dirty patch to show user cards in the connected peers.

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -85,7 +85,7 @@
   },
   "userShort": {
     "userLoading": "Loading...",
-    "userNotFound": "Information for %{guid} was not found on the network."
+    "userNotFound": "Information for %{guid} was <b>not found on the network.</b>"
   },
   "settings": {
     "settingsLabel": "Settings",

--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -1,12 +1,10 @@
 <div class="pad tx4">
-  <% console.log(ob) %>
   <h1><%= ob.polyT('connectedPeersPage.heading') %></h1>
   <p><em><%= ob.polyT('connectedPeersPage.infoMessage') %></em></p>
 
   <div class="pageContent">
-    <div class="userPageFollow flexRow js-peerWrapper">
+    <div class="userPageFollow flexRow js-peerWrapper"></div>
 
-    </div>
     <div class="js-morePeers hide">
       <hr class="clrBr">
       <a class="btn floR clrBr clrP js-morePeersBtn">Load More</a>
@@ -16,8 +14,4 @@
   <% if (!ob.peers.length) { %>
     <p><%= ob.polyT('connectedPeersPage.noResults') %></p>
   <% } %>
-
-
-
-
 </div>

--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -2,15 +2,22 @@
   <% console.log(ob) %>
   <h1><%= ob.polyT('connectedPeersPage.heading') %></h1>
   <p><em><%= ob.polyT('connectedPeersPage.infoMessage') %></em></p>
+
+  <div class="pageContent">
+    <div class="userPageFollow flexRow js-peerWrapper">
+
+    </div>
+    <div class="js-morePeers hide">
+      <hr>
+      <a class="btn js-morePeersBtn">Load More</a>
+    </div>
+  </div>
+
   <% if (!ob.peers.length) { %>
     <p><%= ob.polyT('connectedPeersPage.noResults') %></p>
   <% } %>
-  <div class="userPage">
-    <div class="pageContent">
-      <div class="userPageFollow flexRow js-peerWrapper">
 
-      </div>
-    </div>
-  </div>
+
+
 
 </div>

--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -1,11 +1,16 @@
 <div class="pad tx4">
+  <% console.log(ob) %>
   <h1><%= ob.polyT('connectedPeersPage.heading') %></h1>
   <p><em><%= ob.polyT('connectedPeersPage.infoMessage') %></em></p>
-  <% if (ob.peers.length) { %>
-    <ul>
-    <% ob.peers.forEach(peer => print(`<li><a href="#${peer}">${peer}</a></li>`)) %>
-    </ul>
-  <% } else { %>
+  <% if (!ob.peers.length) { %>
     <p><%= ob.polyT('connectedPeersPage.noResults') %></p>
   <% } %>
+  <div class="userPage">
+    <div class="pageContent">
+      <div class="userPageFollow flexRow js-peerWrapper">
+
+      </div>
+    </div>
+  </div>
+
 </div>

--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -8,8 +8,8 @@
 
     </div>
     <div class="js-morePeers hide">
-      <hr>
-      <a class="btn js-morePeersBtn">Load More</a>
+      <hr class="clrBr">
+      <a class="btn floR clrBr clrP js-morePeersBtn">Load More</a>
     </div>
   </div>
 

--- a/js/views/ConnectedPeersPage.js
+++ b/js/views/ConnectedPeersPage.js
@@ -12,6 +12,48 @@ export default class extends baseVw {
     }
 
     this.peers = options.peers;
+    this.peersLoaded = 0;
+    this.peersIterator = 3;
+  }
+
+  className() {
+    return 'userPage';
+  }
+
+  events() {
+    return {
+      'click .js-morePeersBtn': 'loadPeers',
+    };
+  }
+
+  get $peerWrapper() {
+    return this._$peerWrapper ||
+        (this._$peerWrapper = this.$('.js-peerWrapper'));
+  }
+
+  get $morePeers() {
+    return this._$morePeers ||
+        (this._$morePeers = this.$('.js-morePeers'))
+  }
+
+  loadPeers() {
+    if (this.peers.length > this.peersLoaded) {
+      this.peers.slice(this.peersLoaded, this.peersLoaded + this.peersIterator).forEach((peer) => {
+        console.log(peer)
+        const user = this.createChild(userShort, {
+          guid: peer,
+        });
+        this.$peerWrapper.append(user.render().$el);
+      });
+      this.peersLoaded += this.peersIterator;
+    }
+    
+    // check if next set exists
+    if (this.peers.length > this.peersLoaded) {
+      this.$morePeers.removeClass('hide');
+    } else {
+      this.$morePeers.addClass('hide');
+    }
   }
 
   render() {
@@ -20,17 +62,9 @@ export default class extends baseVw {
         peers: this.peers,
       }));
     });
-    
-    const peerWrapper = this.$('.js-peerWrapper');
-
-    if (this.peers.length) {
-      this.peers.forEach((peer) => {
-        const user = this.createChild(userShort, {
-          guid: peer,
-        });
-        peerWrapper.append(user.render().$el);
-      });
-    }
+    this._$peerWrapper = null;
+    this._$morePeers = null;
+    this.loadPeers();
 
     return this;
   }

--- a/js/views/ConnectedPeersPage.js
+++ b/js/views/ConnectedPeersPage.js
@@ -1,6 +1,7 @@
 import baseVw from './baseVw';
 import loadTemplate from '../utils/loadTemplate';
 import userShort from './userShort';
+import $ from 'jquery';
 
 export default class extends baseVw {
   constructor(options = {}) {
@@ -12,7 +13,7 @@ export default class extends baseVw {
     }
 
     this.peers = options.peers;
-    this.peersLoaded = 0;
+    this.loadPeersUpTo = 0;
     this.peersIterator = 12;
   }
 
@@ -33,23 +34,25 @@ export default class extends baseVw {
 
   get $morePeers() {
     return this._$morePeers ||
-        (this._$morePeers = this.$('.js-morePeers'))
+        (this._$morePeers = this.$('.js-morePeers'));
   }
 
   loadPeers() {
-    if (this.peers.length > this.peersLoaded) {
-      this.peers.slice(this.peersLoaded, this.peersLoaded + this.peersIterator).forEach((peer) => {
-        console.log(peer)
-        const user = this.createChild(userShort, {
-          guid: peer,
+    if (this.peers.length > this.loadPeersUpTo) {
+      const docFrag = $(document.createDocumentFragment());
+      this.peers.slice(this.loadPeersUpTo, this.loadPeersUpTo + this.peersIterator)
+        .forEach((peer) => {
+          const user = this.createChild(userShort, {
+            guid: peer,
+          });
+          docFrag.append(user.render().$el);
         });
-        this.$peerWrapper.append(user.render().$el);
-      });
-      this.peersLoaded += this.peersIterator;
+      this.$peerWrapper.append(docFrag);
+      this.loadPeersUpTo += this.peersIterator;
     }
 
     // check if next set exists
-    if (this.peers.length > this.peersLoaded) {
+    if (this.peers.length > this.loadPeersUpTo) {
       this.$morePeers.removeClass('hide');
     } else {
       this.$morePeers.addClass('hide');

--- a/js/views/ConnectedPeersPage.js
+++ b/js/views/ConnectedPeersPage.js
@@ -1,5 +1,6 @@
 import baseVw from './baseVw';
 import loadTemplate from '../utils/loadTemplate';
+import userShort from './userShort';
 
 export default class extends baseVw {
   constructor(options = {}) {
@@ -19,6 +20,17 @@ export default class extends baseVw {
         peers: this.peers,
       }));
     });
+    
+    const peerWrapper = this.$('.js-peerWrapper');
+
+    if (this.peers.length) {
+      this.peers.forEach((peer) => {
+        const user = this.createChild(userShort, {
+          guid: peer,
+        });
+        peerWrapper.append(user.render().$el);
+      });
+    }
 
     return this;
   }

--- a/js/views/ConnectedPeersPage.js
+++ b/js/views/ConnectedPeersPage.js
@@ -13,7 +13,7 @@ export default class extends baseVw {
 
     this.peers = options.peers;
     this.peersLoaded = 0;
-    this.peersIterator = 3;
+    this.peersIterator = 12;
   }
 
   className() {
@@ -47,7 +47,7 @@ export default class extends baseVw {
       });
       this.peersLoaded += this.peersIterator;
     }
-    
+
     // check if next set exists
     if (this.peers.length > this.peersLoaded) {
       this.$morePeers.removeClass('hide');


### PR DESCRIPTION
- shows user cards in the connected peers view so it's clear which ones are working profiles
- this is for testing in milestone 1, not production use.