### PR TITLE
Adds "Peers" tab to main tab nav. Also fixes i18n for words there. Pairs well with #270

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -27,6 +27,13 @@
   "serverConnect": {
     "defaultServerName": "Default Server"
   },
+  "mainNav": {
+    "followers": "Followers",
+    "following": "Following",
+    "home": "Home",
+    "store": "Store",
+    "peers": "Peers"
+  },
   "userPage": {
     "followsYou": "Follows You",
     "message": "Message",

--- a/js/templates/userPage/userPage.html
+++ b/js/templates/userPage/userPage.html
@@ -12,7 +12,7 @@
             <% } %>></div>
         </div>
         <div class="flexExpand">
-          <h1 class="h2 txUnb txUnl"><%= ob.name %></h1>
+          <h1 class="h2 txUnb txUnl tx1Ln"><%= ob.name %></h1>
           <div class="txt5b">
             <a class="js-tab" data-tab="Reputation">
               <span>Stars(x)</span>
@@ -24,10 +24,11 @@
         </div>
         <div class="flexExpand">
           <div class="flexHRight flexVCent gutterH clrT2">
-            <a class="btn tab clrBr js-tab" data-tab="home">Home</a>
-            <a class="btn tab clrBr js-tab" data-tab="store">Store<span class="clrTEmph1 margLSm js-listingsCount"><%= ob.listingCount %></span></a>
-            <a class="btn tab clrBr js-tab" data-tab="following">Following<span class="clrTEmph1 margLSm js-followingCount"><%= ob.followingCount %></span></a>
-            <a class="btn tab clrBr js-tab" data-tab="followers">Followers<span class="clrTEmph1 margLSm js-followerCount"><%= ob.followerCount %></span></a>
+            <a class="btn tab clrBr js-tab" data-tab="home"><%= ob.polyT('mainNav.home') %></a>
+            <a class="btn tab clrBr js-tab" data-tab="store"><%= ob.polyT('mainNav.store') %><span class="clrTEmph1 margLSm js-listingsCount"><%= ob.listingCount %></span></a>
+            <a class="btn tab clrBr js-tab" data-tab="following"><%= ob.polyT('mainNav.following') %><span class="clrTEmph1 margLSm js-followingCount"><%= ob.followingCount %></span></a>
+            <a class="btn tab clrBr js-tab" data-tab="followers"><%= ob.polyT('mainNav.followers') %><span class="clrTEmph1 margLSm js-followerCount"><%= ob.followerCount %></span></a>
+            <a class="btn tab clrBr js-tab" href="#connected-peers"><%= ob.polyT('mainNav.peers') %></a>
           </div>
         </div>
       </div>

--- a/styles/components/_type.scss
+++ b/styles/components/_type.scss
@@ -146,3 +146,7 @@ a .txNoUnd:hover {
   @extend .clamp;
   -webkit-line-clamp: 4;
 }
+
+.tx1Ln {
+  white-space: pre;
+}


### PR DESCRIPTION
**Commit detail:** 👾 

 - Added a "Peers" tab handle for the Connected Peers page to the main tab navigation.
 - Converts English words to i18n values for links in main nav: "Home", "Store", "Followers", "Following"
 

**What this does:** 🎉 🥇 💯 

When merged with #270 the new "Connected Peers" view from @jjeffryes is linked in the main tab bar. 

The idea is that this useful way ( the new Connected Peers tab ) to explore your local network is more accessible. 

**Lineage:** 👑 

This builds on the peers pages lineage: #270 by @jjeffryes and #103 by @rmisio 
And makes it more accessible by putting it in the main tab nav.

**Additional i18n bonus:** 🎏 

The words in main tab navigation were plain English. These are replaced with i18n key references in this change.

**Bling:** 💎 

The new connected peers tab by @jjeffryes 

<img width="637" alt="2017-01-09 2" src="https://cloud.githubusercontent.com/assets/23715260/21761100/b9986224-d68b-11e6-8e8c-10bbad7c09ba.png">


