### PR TITLE
Add count to peers

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -22,7 +22,7 @@
   "connectedPeersPage": {
     "heading": "Connected Peers",
     "totalPeers": "%{totalPeers} Found",
-    "infoMessage": "If you do not see any peers below, you are not connected to the OpenBazaar network. If a peer does not have information available on the network, clicking on their guid below will result in a User Not Found page.",
+    "infoMessage": "You should see up to 12 peers below. If you are connected to more than 12 peers, click the more button to load the next 12.",
     "noResults": "No connected peers"
   },
   "serverConnect": {

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -22,7 +22,6 @@
   "connectedPeersPage": {
     "heading": "Connected Peers",
     "totalPeers": "%{totalPeers} Found",
-    "infoMessage": "You should see up to 12 peers below. If you are connected to more than 12 peers, click the more button to load the next 12.",
     "noResults": "No connected peers"
   },
   "serverConnect": {

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -22,7 +22,7 @@
   "connectedPeersPage": {
     "heading": "Connected Peers",
     "totalPeers": "%{totalPeers} Found",
-    "infoMessage": "Please note: If any peer does not have their profile set, clicking on their guid below will result in a User Not Found page.",
+    "infoMessage": "If you do not see any peers below, you are not connected to the OpenBazaar network. If a peer does not have information available on the network, clicking on their guid below will result in a User Not Found page.",
     "noResults": "No connected peers"
   },
   "serverConnect": {

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -21,6 +21,7 @@
   },
   "connectedPeersPage": {
     "heading": "Connected Peers",
+    "totalPeers": "%{totalPeers} Found",
     "infoMessage": "Please note: If any peer does not have their profile set, clicking on their guid below will result in a User Not Found page.",
     "noResults": "No connected peers"
   },

--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -1,17 +1,20 @@
-<div class="pad tx4">
-  <h1><%= ob.polyT('connectedPeersPage.heading') %></h1>
-  <p><em><%= ob.polyT('connectedPeersPage.infoMessage') %></em></p>
-
-  <div class="pageContent">
-    <div class="userPageFollow flexRow js-peerWrapper"></div>
-
-    <div class="js-morePeers hide">
-      <hr class="clrBr">
-      <a class="btn floR clrBr clrP js-morePeersBtn">Load More</a>
+<div class="pageContent">
+  <div class="row">
+    <div class="flex">
+      <h1 class="flexExpand"><%= ob.polyT('connectedPeersPage.heading') %></h1>
+      <div class="tx3 btn"><%= ob.polyT('connectedPeersPage.totalPeers', { totalPeers: ob.peers.length }) %></div>
     </div>
+    <p><em><%= ob.polyT('connectedPeersPage.infoMessage') %></em></p>
   </div>
+  <div class="userPageFollow flexRow js-peerWrapper"></div>
 
-  <% if (!ob.peers.length) { %>
-    <p><%= ob.polyT('connectedPeersPage.noResults') %></p>
-  <% } %>
+  <div class="js-morePeers hide">
+    <hr class="clrBr">
+    <a class="btn floR clrBr clrP js-morePeersBtn">Load More</a>
+  </div>
 </div>
+
+<% if (!ob.peers.length) { %>
+  <p><%= ob.polyT('connectedPeersPage.noResults') %></p>
+<% } %>
+

--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -1,10 +1,10 @@
 <div class="pageContent">
-  <div class="row">
+  <div class="rowLg">
     <div class="flex">
       <h1 class="flexExpand"><%= ob.polyT('connectedPeersPage.heading') %></h1>
       <div class="tx3 btn"><%= ob.polyT('connectedPeersPage.totalPeers', { totalPeers: ob.peers.length }) %></div>
     </div>
-    <p><em><%= ob.polyT('connectedPeersPage.infoMessage') %></em></p>
+    <p class="tx4"><em><%= ob.polyT('connectedPeersPage.infoMessage') %></em></p>
   </div>
   <div class="userPageFollow flexRow js-peerWrapper"></div>
 

--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -2,7 +2,7 @@
   <div class="rowLg">
     <div class="flex">
       <h1 class="flexExpand"><%= ob.polyT('connectedPeersPage.heading') %></h1>
-      <div class="tx3 btn"><%= ob.polyT('connectedPeersPage.totalPeers', { totalPeers: ob.peers.length }) %></div>
+      <div class="tx4 border clrBr clrP pad"><%= ob.polyT('connectedPeersPage.totalPeers', { totalPeers: ob.peers.length }) %></div>
     </div>
     <p class="tx4"><em><%= ob.polyT('connectedPeersPage.infoMessage') %></em></p>
   </div>

--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -4,7 +4,6 @@
       <h1 class="flexExpand"><%= ob.polyT('connectedPeersPage.heading') %></h1>
       <div class="tx4 border clrBr clrP pad"><%= ob.polyT('connectedPeersPage.totalPeers', { totalPeers: ob.peers.length }) %></div>
     </div>
-    <p class="tx4"><em><%= ob.polyT('connectedPeersPage.infoMessage') %></em></p>
   </div>
   <div class="userPageFollow flexRow js-peerWrapper"></div>
 

--- a/js/templates/userShort.html
+++ b/js/templates/userShort.html
@@ -1,4 +1,4 @@
-<div class="contentBox clrBr clrP clrSh2">
+<div class="contentBox clrBr clrP clrSh2 <% if (ob.notFound) { %>disabled<% } %>">
   <div class="shortHeader"
     <% var headerHash = ob.headerHashes ? ob.isHiRez() ? ob.headerHashes.small : ob.headerHashes.tiny : ''; %>
     <% if (headerHash) { %>


### PR DESCRIPTION
- adds a count to the connected peers page
- tweaks the styles and text
- userShort views that are not found on the network are disabled, so their buttons can't be clicked to fire actions that won't work.
- fully closes #61