### PR TITLE
Resizes select2 tag inputs to match other input heights.

### DIFF
--- a/styles/components/_select2.scss
+++ b/styles/components/_select2.scss
@@ -28,7 +28,7 @@
         border-bottom: 0;
       }
     }
-  }  
+  }
 }
 
 .select2-container--default {
@@ -89,12 +89,14 @@
       .select2-search--inline {
         padding: 1px; // match the border on the tags
         margin-top: 5px;
+        line-height:27px;
       }
     }
 
     &.select2-container--default .select2-selection--multiple .select2-selection__choice {
       padding-left: $pad;
       font-weight: 500;
+      line-height:27px;
 
       .select2-selection__choice__remove {
         float: right;
@@ -141,7 +143,7 @@
     &.emptyOfTags {
       display: block;
       top: 0;
-      line-height: 4rem;
+      line-height: 27px;
       margin-top: 6px;
     }
   }


### PR DESCRIPTION
@morebrownies this patch will change the select2 inputs with tags to be 40px tall, like the other inputs.

However, it does so by making the tags inside the input shorter (they were 40px tall, which caused the overall input to be 52px tall after padding was added). 

Check and see if this is the effect you were looking for.

![image](https://cloud.githubusercontent.com/assets/1584275/21782027/e2bd5b98-d67f-11e6-9257-bcae6c10c529.png)
