### PR TITLE
Fixes Content Frame height

### DIFF
--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -117,7 +117,7 @@ ul, ol {
   #contentFrame {
     padding-top: $barLg;
     overflow-y: scroll;
-    height: calc(100% - #{$bar} - #{$barLg});
+    height: calc(100% - #{$bar});
     box-sizing: border-box;
     z-index: 0;
 


### PR DESCRIPTION
The content frame was being cut off 55px from the bottom of the screen after the changes made to fix the tabs disappearing if a video tag was present. 

Closes #272