### PR TITLE
Give the listing grid an index

### DIFF
--- a/styles/components/_listingsGrid.scss
+++ b/styles/components/_listingsGrid.scss
@@ -1,5 +1,7 @@
 .listingsGrid {
   flex-wrap: wrap;
+  position: relative;
+  z-index: 0; // contain any positioned elements
 
   .listingCard {
     margin: 0 $padMd $padMd 0;


### PR DESCRIPTION
- Closes #277
- gives a z-index of zero to the listing grid and a position of relative so it has a containing context for any child elements with absolute positioning.