### PR TITLE
Restore position: relative to the #contentFrame element

### DIFF
--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -115,6 +115,7 @@ ul, ol {
   }
 
   #contentFrame {
+    position: relative;
     padding-top: $barLg;
     overflow-y: scroll;
     height: calc(100% - #{$bar});


### PR DESCRIPTION
This fixes various layout bugs caused by removing the positioning. Child elements with position: absolute were being put in a context above the content frame, which made them stack in unexpected ways.

- Closes #286