### PR TITLE
Remove Polish Language Option for now

### DIFF
--- a/js/data/languages.js
+++ b/js/data/languages.js
@@ -61,10 +61,10 @@ const languages = [
   //   name: '한국어 (Korean)',
   //   code: 'ko',
   // },
-  {
-    name: 'Polski (Polish)',
-    code: 'pl',
-  },
+  //{
+  //  name: 'Polski (Polish)',
+  //  code: 'pl',
+  //},
   // {
   //   name: 'Português (Portuguese, Brazil)',
   //   code: 'pt-BR',


### PR DESCRIPTION
The option to select the Polish language was just for testing, it does not have translations in place.