### PR TITLE
Cleaned up a number of style issues (address bar, return to store, connection management, etc)

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -332,7 +332,12 @@
       "password": "Password",
       "username": "Username",
       "serverIp": "Server IP",
-      "name": "Name"
+      "name": "Name",
+      "placeholderName": "Enter a name...",
+      "placeholderServerIp": "The IP to your server (or localhost)",
+      "placeholderUsername": "The username to your server",
+      "placeholderPassword": "The password to your server",
+      "placeholderPort": "The port to your server"
     }
   },
   "formats": {

--- a/js/templates/modals/connectionManagement/configurationForm.html
+++ b/js/templates/modals/connectionManagement/configurationForm.html
@@ -17,7 +17,7 @@
       </div>
       <div class="col9">
       <% if (ob.errors.name) print(ob.formErrorTmpl({ errors: ob.errors.name })) %>
-        <input type="text" class="clrBr js-inputName" name="name" id="serverConfigName" value="<%= ob.name %>">
+        <input type="text" class="clrBr clrSh2 js-inputName" name="name" id="serverConfigName" value="<%= ob.name %>" placeholder="<%= ob.polyT('connectionManagement.configurationForm.placeholderName') %>" >
       </div>
     </div>
     <div class="flexRow">
@@ -26,7 +26,7 @@
       </div>
       <div class="col9">
       <% if (ob.errors.serverIp) print(ob.formErrorTmpl({ errors: ob.errors.serverIp })) %>
-        <input type="text" class="clrBr" name="serverIp" id="serverConfigServerIp" value="<%= ob.serverIp %>">
+        <input type="text" class="clrBr clrSh2" name="serverIp" id="serverConfigServerIp" value="<%= ob.serverIp %>"placeholder="<%= ob.polyT('connectionManagement.configurationForm.placeholderServerIp') %>">
       </div>
     </div>
     <div class="flexRow">
@@ -35,7 +35,7 @@
       </div>
       <div class="col9">
       <% if (ob.errors.username) print(ob.formErrorTmpl({ errors: ob.errors.username })) %>
-        <input type="text" class="clrBr" name="username" id="serverConfigUsername" value="<%= ob.username %>">
+        <input type="text" class="clrBr clrSh2" name="username" id="serverConfigUsername" value="<%= ob.username %>" placeholder="<%= ob.polyT('connectionManagement.configurationForm.placeholderUsername') %>">
       </div>
     </div>
     <div class="flexRow">
@@ -44,7 +44,7 @@
       </div>
       <div class="col9">
       <% if (ob.errors.password) print(ob.formErrorTmpl({ errors: ob.errors.password })) %>
-        <input type="password" class="clrBr" name="password" id="serverConfigPassword" value="<%= ob.password %>">
+        <input type="password" class="clrBr clrSh2" name="password" id="serverConfigPassword" value="<%= ob.password %>" placeholder="<%= ob.polyT('connectionManagement.configurationForm.placeholderPassword') %>">
       </div>
     </div>
     <div class="flexRow">
@@ -81,7 +81,7 @@
       </div>
       <div class="col9">
       <% if (ob.errors.port) print(ob.formErrorTmpl({ errors: ob.errors.port })) %>
-        <input type="text" class="clrBr" name="port" id="serverConfigPort" value="<%= ob.port %>" data-var-type="number">
+        <input type="text" class="clrBr clrSh2" name="port" id="serverConfigPort" value="<%= ob.port %>" data-var-type="number" placeholder="<%= ob.polyT('connectionManagement.configurationForm.placeholderPort') %>">
       </div>
     </div>    
   </form>
@@ -89,6 +89,6 @@
   <hr class="clrBr" />
   <div class="flexHRight flexVCent gutterHLg">
     <a class="js-cancel"><%= ob.polyT('connectionManagement.configurationForm.btnCancel') %></a>
-    <a class="btn clrP clrBr js-save"><%= ob.polyT('connectionManagement.configurationForm.btnSave') %></a>
+    <a class="btn clrP clrBr clrSh2 js-save"><%= ob.polyT('connectionManagement.configurationForm.btnSave') %></a>
   </div>
 </div>

--- a/js/templates/modals/connectionManagement/configurations.html
+++ b/js/templates/modals/connectionManagement/configurations.html
@@ -4,7 +4,7 @@
       <!-- OB branding comming soon... -->
     </div>  
     <div class="col4">
-      <h2 class="h3 clrT txUnl txCtr"><%= ob.polyT('connectionManagement.configurations.heading') %></h2>
+      <h2 class="h4 clrT txUnl txCtr"><%= ob.polyT('connectionManagement.configurations.heading') %></h2>
     </div>
     <div class="col4">
       <div class="flexHRight">

--- a/js/templates/modals/connectionManagement/configurations.html
+++ b/js/templates/modals/connectionManagement/configurations.html
@@ -1,4 +1,4 @@
-<div class="contentBox padMd clrP clrBr clrSh3">
+<div class="contentBox padMd clrP clrBr clrSh3" style="min-height: 500px">
   <div class="flexVCent">
     <div class="col4">
       <!-- OB branding comming soon... -->
@@ -8,7 +8,7 @@
     </div>
     <div class="col4">
       <div class="flexHRight">
-        <a class="btn clrP clrBr js-btnNew"><%= ob.polyT('connectionManagement.configurations.btnNew') %></a>
+        <a class="btn clrP clrSh2 clrBr js-btnNew"><%= ob.polyT('connectionManagement.configurations.btnNew') %></a>
       </div>
     </div>
   </div>

--- a/js/templates/modals/connectionManagement/connectionManagement.html
+++ b/js/templates/modals/connectionManagement/connectionManagement.html
@@ -1,7 +1,7 @@
 <div class="topControls flex js-closeClickTarget"></div>
 <div class="flex gutterH js-closeClickTarget">
   <div class="tabColumn contentBox padMd clrP clrBr clrSh3">
-    <h1 class="h3 txUp clrT2">MENU</h1>
+    <h1 class="h4 txUp clrT">MENU</h1>
     <div class="boxList tx4 clrTx1Br">
       <a class="js-tab tab row active" data-tab="Configurations"><%= ob.polyT('connectionManagement.configurations.tabName') %></a>
       <a class="js-tab tab row" data-tab="ConfigForm"><%= ob.polyT('connectionManagement.configurationForm.tabName') %></a>

--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -2,11 +2,11 @@
 
 <div class="topControls gutterHSm flex">
   <% if (ob.vendor) { %>
-  <div class="contentBox clrP clrBr clrT">
-    <div class="padSm gutterHSm overflowAuto flexVCent">
+  <div class="contentBox clrP clrSh3 clrBr clrT">
+    <div class="padSm gutterHSm overflowAuto margRSm flexVCent">
       <a class="clrBr2 clrSh1 disc storeOwnerAvatar flexNoShrink js-storeOwnerAvatar" style="<%= ob.getAvatarBgImage(ob.vendor.avatar) %>"></a>
-      <p class="txUnl clamp"><%= ob.vendor.name %></p>
-      <a class="link flexNoShrink js-goToStore"><% print(ob.openedFromStore ? ob.polyT('listingDetail.returnToStore'): ob.polyT('listingDetail.goToStore')) %></a>
+      <p class="txUnl tx3 clamp"><%= ob.vendor.name %></p>
+      <a class="link flexNoShrink tx6 margRSm js-goToStore"><% print(ob.openedFromStore ? ob.polyT('listingDetail.returnToStore'): ob.polyT('listingDetail.goToStore')) %></a>
     </div>
   </div>
   <% } %>

--- a/js/templates/modals/settings/settings.html
+++ b/js/templates/modals/settings/settings.html
@@ -3,7 +3,7 @@
 </div>
 <div class="flex gutterH">
   <div class="tabColumn contentBox padMd clrP clrBr clrSh3">
-    <h1 class="h3 txUp clrT2"><%= ob.polyT('settings.settingsLabel') %></h1>
+    <h1 class="h4 txUp clrT"><%= ob.polyT('settings.settingsLabel') %></h1>
     <div class="boxList tx4 clrTx1Br">
       <a class="js-tab tab clrT row active" data-tab="General"><%= ob.polyT('settings.generalTab.sectionName') %></a>
       <a class="js-tab tab row" data-tab="Page"><%= ob.polyT('settings.pageTab.sectionPage') %></a>

--- a/js/templates/pageNav.html
+++ b/js/templates/pageNav.html
@@ -16,16 +16,16 @@
       </div>
       <div>
         <div class="flexVCent">
-          <a class="iconBtn ion-chevron-left js-navBack"></a>
+          <a class="iconBtn margLSm ion-chevron-left js-navBack"></a>
           <a class="iconBtn ion-chevron-right js-navFwd"></a>
-          <a class="iconBtn ion-refresh js-navReload"></a>
+          <a class="iconBtn ion-refresh js-navReload margRSm"></a>
         </div>
       </div>
-      <div class="rowDivV clrBrBk"></div>
+      <div class="rowDivV margR clrBrBk"></div>
       <div class="pageNavCenter">
         <div class="flexVCent gutterHSm">
           <div class="searchWrapper">
-            <input type="text" class="js-addressBar flexExpand addressBar clrBr4"
+            <input type="text" class="js-addressBar flexExpand addressBar clrSh2 clrBr4"
                    placeholder="<%= ob.polyT('addressBarPlaceholder') %>" value="<%= ob.addressBarText %>" />
           </div>
           <% if (ob.testnet) { %>
@@ -33,13 +33,13 @@
               <%= ob.polyT('testnet') %>
             </div>
           <% } %>
-          <a class="btn barBtn clrP clrBr ion-navicon-round"></a>
+          <a class="bookmarkPage btn barBtn clrP clrBr clrSh2 tx4 ion-android-add"></a>
         </div>
       </div>
       <div class="rowDivV clrBrBk"></div>
       <div>
         <div class="flexVCent box">
-          <a class="iconBtn ion-eye"></a>
+          <a class="iconBtn margLSm ion-eye"></a>
           <a class="iconBtn ion-android-notifications js-navNotifBtn"></a>
           <a id="AvatarBtn" class="discSm clrBr2 clrSh1 js-navListBtn navListBtn" style="<%= ob.getAvatarBgImage(ob.avatarHashes) %>"></a>
           <nav class="navListWrapper foldDown js-navList">
@@ -90,7 +90,7 @@
               </div>
             </div>
           </nav>
-          <nav class="connManagementContainer foldDown js-connManagementContainer"></nav>
+          <nav class="connManagementContainer foldDown clrSh1 js-connManagementContainer"></nav>
         </div>
       </div>
     </div>

--- a/styles/components/_buttons.scss
+++ b/styles/components/_buttons.scss
@@ -198,12 +198,12 @@
   &:before {
     //insert a search icon before the text
     font-family: Ionicons;
-    content: "\f4a5";
+    content: "🔍";
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    font-size: 1.75em;
-    left: 0.6em;
+    font-size: 1.45em;
+    left: 8px;
     color: inherit;
   }
 }

--- a/styles/modules/_pageNav.scss
+++ b/styles/modules/_pageNav.scss
@@ -31,16 +31,18 @@
       transition: border-color .2s;
       font-size: $tx5;
       line-height: 1em; //allow dragging on area above and below the text input in the address bar
+      text-indent: 18px;
+    }
 
-      &:not(:hover, :focus){
-        border-color: transparent;
-      }
+    .bookmarkPage {
+      height: 31px;
+      width: 34px;
     }
 
     #AvatarBtn {
       border-width: 2px;
       border-style: solid;
-      margin: 5px 0;
+      margin: 5px 0 5px 5px;
     }
 
     #testnetFlag {
@@ -84,7 +86,6 @@
       order: -1;
     }
     .windowControls {
-      margin-right: 10px;
 
       a {
         border-radius: 50%;

--- a/styles/modules/modals/_listingDetail.scss
+++ b/styles/modules/modals/_listingDetail.scss
@@ -9,8 +9,8 @@
     .listingContent {
 
       .mainImage {
-        width: 500px;
-        height: 500px;
+        width: 530px;
+        height: 530px;
         background-position: center;
         background-repeat: no-repeat;
         background-size: cover;


### PR DESCRIPTION
**Changes**
- Cleaned up spacing in address bar
- Changed search icon 
- Change bookmark icon (we can use the + to simplify) 
- Made search input border always display (Sorry @joshj only showing it on hover was getting annoying. Always seeing the border is growing on me. Looking better now that the + button next to it balances it better)
- Cleaned up spacing/sizing of Return to store button on listing detail overlay
- Added missing shadows to a few places
- Adjusted typography 
- Increased the size of the photo on the listing detail screen in order to shrink down the right column slightly (the balance feels better and will reduce some white space)
- Added shadows to inputs in new connection screen
- Added placeholders to inputs in new connection screen
