### PR TITLE
userData command line option

### DIFF
--- a/js/start.js
+++ b/js/start.js
@@ -1,4 +1,4 @@
-import { remote, ipcRenderer, app as electronApp } from 'electron';
+import { remote, ipcRenderer } from 'electron';
 import $ from 'jquery';
 import Backbone from 'backbone';
 import Polyglot from 'node-polyglot';
@@ -24,11 +24,10 @@ import './utils/exchangeRateSyncer';
 import './utils/listingData';
 import { launchDebugLogModal } from './utils/modalManager';
 import listingDeleteHandler from './startup/listingDelete';
-import { fixLinuxZoomIssue, handleLinks, handleUserDataClOption } from './startup';
+import { fixLinuxZoomIssue, handleLinks } from './startup';
 import ConnectionManagement from './views/modals/connectionManagement/ConnectionManagement';
 
 fixLinuxZoomIssue();
-handleUserDataClOption(electronApp);
 
 app.localSettings = new LocalSettings({ id: 1 });
 app.localSettings.fetch().fail(() => app.localSettings.save());

--- a/js/start.js
+++ b/js/start.js
@@ -1,4 +1,4 @@
-import { remote, ipcRenderer } from 'electron';
+import { remote, ipcRenderer, app as electronApp } from 'electron';
 import $ from 'jquery';
 import Backbone from 'backbone';
 import Polyglot from 'node-polyglot';
@@ -24,10 +24,11 @@ import './utils/exchangeRateSyncer';
 import './utils/listingData';
 import { launchDebugLogModal } from './utils/modalManager';
 import listingDeleteHandler from './startup/listingDelete';
-import { fixLinuxZoomIssue, handleLinks } from './startup';
+import { fixLinuxZoomIssue, handleLinks, handleUserDataClOption } from './startup';
 import ConnectionManagement from './views/modals/connectionManagement/ConnectionManagement';
 
 fixLinuxZoomIssue();
+handleUserDataClOption(electronApp);
 
 app.localSettings = new LocalSettings({ id: 1 });
 app.localSettings.fetch().fail(() => app.localSettings.save());

--- a/js/startup/index.js
+++ b/js/startup/index.js
@@ -2,7 +2,6 @@
 // aren't appropriate to be in any existing module
 
 import { screen, shell } from 'electron';
-import { argv } from 'yargs';
 import $ from 'jquery';
 import Backbone from 'backbone';
 import { getBody } from '../utils/selectors';
@@ -48,18 +47,4 @@ export function handleLinks() {
 
     e.preventDefault();
   });
-}
-
-export function handleUserDataClOption(electronApp) {
-  if (!electronApp) {
-    throw new Error('Please provide the electron app object.');
-  }
-
-  if (argv.userData) {
-    try {
-      electronApp.setPath('userData', argv.userData);
-    } catch (e) {
-      throw new Error(`The passed in userData directory does not appear to be valid: ${e}`);
-    }
-  }
 }

--- a/js/startup/index.js
+++ b/js/startup/index.js
@@ -1,7 +1,8 @@
-// Putting one offs here that are too small for their own module and
+// Putting start-up related one offs here that are too small for their own module and
 // aren't appropriate to be in any existing module
 
 import { screen, shell } from 'electron';
+import { argv } from 'yargs';
 import $ from 'jquery';
 import Backbone from 'backbone';
 import { getBody } from '../utils/selectors';
@@ -47,4 +48,18 @@ export function handleLinks() {
 
     e.preventDefault();
   });
+}
+
+export function handleUserDataClOption(electronApp) {
+  if (!electronApp) {
+    throw new Error('Please provide the electron app object.');
+  }
+
+  if (argv.userData) {
+    try {
+      electronApp.setPath('userData', argv.userData);
+    } catch (e) {
+      throw new Error(`The passed in userData directory does not appear to be valid: ${e}`);
+    }
+  }
 }

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ import {
   Menu, Tray, session, crashReporter,
   autoUpdater, shell,
 } from 'electron';
+import { argv } from 'yargs';
 import path from 'path';
 import fs from 'fs';
 import childProcess from 'child_process';
@@ -10,6 +11,14 @@ import urlparse from 'url-parse';
 import _ from 'underscore';
 import LocalServer from './js/utils/localServer';
 import { bindLocalServerEvent } from './js/utils/mainProcLocalServerEvents';
+
+if (argv.userData) {
+  try {
+    app.setPath('userData', argv.userData);
+  } catch (e) {
+    throw new Error(`The passed in userData directory does not appear to be valid: ${e}`);
+  }
+}
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.


### PR DESCRIPTION
This change-set allows the setting of the userData path to be passed in as a command line option. This path controls to which folder localStorage data (and possibly other things) is stored as is critical if you want to run multiple clients on the same machine.

The option can be passed in as follows:

```
NODE_ENV=development ./node_modules/.bin/electron . --userData /Some/path/here
```

Keep in mind, on Windows, there is a different syntax there to set the environment variable.

Also, keep in mind with the above command you are bypassing all our dev "sugar" (watchers, sass compiler, etc...) that is otherwise present with `npm start`. Unfortunately, in order to pass a command line option to 'npm start' and then have it ultimately be passed into the 'electron' process would require some tweaks to our npm scripts. Since it's unlikely you would need to run a second client concurrently and develop on it, we're going to leave that alone for now.