### PR TITLE
Add gutter to form elements in Settings

### DIFF
--- a/js/templates/modals/settings/addressesForm.html
+++ b/js/templates/modals/settings/addressesForm.html
@@ -1,6 +1,6 @@
 <h2 class="h4 clrT"><%= ob.polyT('settings.addresses.sectionName') %></h2>
 <form class="padKids padStack contentBox pad rowMd clrP border clrBr js-addAddressForm">
-  <div class="flexRow">
+  <div class="flexRow gutterH">
     <div class="col3">
       <label for="settingsAddressName" class="required"><%= ob.polyT('settings.addresses.name') %></label>
     </div>
@@ -9,7 +9,7 @@
       <input type="text" class="clrBr clrSh2" name="name" id="settingsAddressName" value="<%= ob.name %>" placeholder="<%= ob.polyT('settings.addressesTab.placeholderName') %>" />
     </div>
   </div>
-  <div class="flexRow">
+  <div class="flexRow gutterH">
     <div class="col3">
       <label for="settingsAddressCompany"><%= ob.polyT('settings.addresses.company') %></label>
     </div>
@@ -18,7 +18,7 @@
       <input type="text" class="clrBr clrSh2" name="company" id="settingsAddressCompany" value="<%= ob.company %>" placeholder="<%= ob.polyT('settings.optional') %>" />
     </div>
   </div>
-  <div class="flexRow">
+  <div class="flexRow gutterH">
     <div class="col3">
       <label for="settingsAddressLineOne"><%= ob.polyT('settings.addresses.street') %></label>
     </div>
@@ -27,7 +27,7 @@
       <input type="text" class="clrBr clrSh2" name="addressLineOne" id="settingsAddressLineOne" value="<%= ob.addressLineOne %>"  placeholder="<%= ob.polyT('settings.addressesTab.placeholderAddress') %>" />
     </div>
   </div>
-  <div class="flexRow">
+  <div class="flexRow gutterH">
     <div class="col3">
       <label for="settingsAddressLineTwo"><%= ob.polyT('settings.addresses.apt') %></label>
     </div>
@@ -36,7 +36,7 @@
       <input type="text" class="clrBr clrSh2" name="addressLineTwo" id="settingsAddressLineTwo" value="<%= ob.addressLineTwo %>" placeholder="<%= ob.polyT('settings.optional') %>" />
     </div>
   </div>
-  <div class="flexRow">
+  <div class="flexRow gutterH">
     <div class="col3">
       <label for="settingsAddressCity"><%= ob.polyT('settings.addresses.city') %></label>
     </div>
@@ -45,7 +45,7 @@
       <input type="text" class="clrBr clrSh2" name="city" id="settingsAddressCity" value="<%= ob.city %>" placeholder="<%= ob.polyT('settings.addressesTab.placeholderCity') %>" />
     </div>
   </div>
-  <div class="flexRow">
+  <div class="flexRow gutterH">
     <div class="col3">
       <label for="settingsAddressState"><%= ob.polyT('settings.addresses.state') %></label>
     </div>
@@ -54,7 +54,7 @@
       <input type="text" class="clrBr clrSh2" name="state" id="settingsAddressState" value="<%= ob.state %>" placeholder="<%= ob.polyT('settings.addressesTab.placeholderState') %>" />
     </div>
   </div>
-  <div class="flexRow">
+  <div class="flexRow gutterH">
     <div class="col3">
       <label for="settingsAddressPostalCode"><%= ob.polyT('settings.addresses.postalCode') %></label>
     </div>
@@ -63,7 +63,7 @@
       <input type="text" class="clrBr clrSh2" name="postalCode" id="settingsAddressPostalCode" value="<%= ob.postalCode %>" placeholder="<%= ob.polyT('settings.addressesTab.placeholderPostalCode') %>" />
     </div>
   </div>
-  <div class="flexRow">
+  <div class="flexRow gutterH">
     <div class="col3">
       <label for="settingsAddressCountry" class="required"><%= ob.polyT('settings.addresses.country') %></label>
     </div>
@@ -73,10 +73,10 @@
         <% ob.countryList.forEach((country) => { %>
         <option value="<%= country.dataName %>" <% if (country.dataName == ob.country) print('selected') %>><%= country.name %></option>
         <% }); %>
-      </select>      
+      </select>
     </div>
   </div>
-  <div class="flexRow">
+  <div class="flexRow gutterH">
     <div class="col3">
       <label for="settingsAddressNotes"><%= ob.polyT('settings.addresses.notes') %></label>
     </div>

--- a/js/templates/modals/settings/advanced.html
+++ b/js/templates/modals/settings/advanced.html
@@ -11,7 +11,7 @@
     <div class="tabFormWrapper clrS">
         <div class="js-appearanceContainer">
           <form class="box padMdKids padStack clrP clrBr js-appearance">
-            <div class="flexRow">
+            <div class="flexRow gutterH">
               <div class="col3">
                 <label><%= ob.polyT('settings.advancedTab.appearance.visualEffects') %></label>
                 <div class="clrT2 txSm"><%= ob.polyT('settings.advancedTab.helperVisualEffects') %></div>
@@ -39,7 +39,7 @@
                 </div>
               </div>
             </div>
-            <div class="flexRow">
+            <div class="flexRow gutterH">
               <div class="col3">
                 <label><%= ob.polyT('settings.advancedTab.appearance.windowControlStyle') %></label>
                 <div class="clrT2 txSm"><%= ob.polyT('settings.advancedTab.helperWindowControls') %></div>
@@ -68,7 +68,7 @@
               </div>
             </div>
           </form>
-        </div>    
+        </div>
     </div>
   </div>
   <div class="contentBox padMd clrP clrBr clrSh3">
@@ -77,7 +77,7 @@
     <div class="tabFormWrapper clrS">
       <div class="js-transactionContainer">
         <form class="box padMdKids padStack clrP clrBr js-transaction">
-          <div class="flexRow">
+          <div class="flexRow gutterH">
             <div class="col3">
               <label><%= ob.polyT('settings.advancedTab.transaction.saveMetadata') %></label>
               <div class="clrT2 txSm"><%= ob.polyT('settings.advancedTab.helperSaveMetaData') %></div>
@@ -105,7 +105,7 @@
               </div>
             </div>
           </div>
-          <div class="flexRow">
+          <div class="flexRow gutterH">
             <div class="col3">
               <label><%= ob.polyT('settings.advancedTab.transaction.defaultFee') %></label>
               <div class="clrT2 txSm"><%= ob.polyT('settings.advancedTab.helperDefaultFee') %></div>
@@ -144,7 +144,7 @@
             </div>
           </div>
         </form>
-      </div>    
+      </div>
     </div>
   </div>
   <div class="contentBox padMd clrP clrBr clrSh3">
@@ -153,7 +153,7 @@
     <div class="tabFormWrapper clrS">
       <div class="js-serverContainer">
         <form class="box padMdKids padStack clrP clrBr js-server">
-          <div class="flexRow">
+          <div class="flexRow gutterH">
             <div class="col3">
               <label>
                 <%= ob.polyT('settings.advancedTab.server.management') %>
@@ -164,7 +164,7 @@
               <a class="btn clrP clrBr clrSh2 js-showConnectionManagement flexNoShrink"><%= ob.polyT('settings.advancedTab.server.btnShowManagementAction') %></a>
             </div>
           </div>
-          <div class="flexRow">
+          <div class="flexRow gutterH">
             <div class="col3">
               <label>
                 <%= ob.polyT('settings.advancedTab.server.peers') %>
@@ -215,7 +215,7 @@
               </div>
             </div>
           </div>
-          <div class="flexRow">
+          <div class="flexRow gutterH">
             <div class="col3">
               <label for="smtpServerAddress">
                 <%= ob.polyT('settings.advancedTab.smtp.serverAddress') %>
@@ -224,17 +224,17 @@
             </div>
             <div class="col6">
               <% if (ob.errors['smtpSettings.serverAddress']) print(ob.formErrorTmpl({ errors: ob.errors['smtpSettings.serverAddress'] })) %>
-              <input class="clrBr clrSh2" 
+              <input class="clrBr clrSh2"
                 required
                 type="text"
-                name="smtpSettings.serverAddress" 
-                id="smtpServerAddress" 
+                name="smtpSettings.serverAddress"
+                id="smtpServerAddress"
                 placeholder="<%= ob.polyT('settings.advancedTab.smtp.placeholderServerAddress') %>"
                 value="<%= ob.smtpSettings.serverAddress %>">
               <div class="clrT2 txBase padSm"><%= ob.polyT('settings.advancedTab.smtp.helperNewEmail', { helperGmailLink: `<a href="https://accounts.google.com/SignUp" class="clrTEm">${ob.polyT('settings.advancedTab.smtp.helperGmailLink')}</a>` }) %></div>
             </div>
           </div>
-          <div class="flexRow">
+          <div class="flexRow gutterH">
             <div class="col3">
               <label for="smtpUsername">
                 <%= ob.polyT('settings.advancedTab.smtp.username') %>
@@ -243,16 +243,16 @@
             </div>
             <div class="col6">
               <% if (ob.errors['smtpSettings.username']) print(ob.formErrorTmpl({ errors: ob.errors['smtpSettings.username'] })) %>
-              <input class="clrBr clrSh2" 
-                required        
+              <input class="clrBr clrSh2"
+                required
                 type="text"
-                name="smtpSettings.username" 
-                id="smtpUsername" 
+                name="smtpSettings.username"
+                id="smtpUsername"
                 placeholder="<%= ob.polyT('settings.advancedTab.smtp.placeholderUsername') %>"
                 value="<%= ob.smtpSettings.username %>">
             </div>
           </div>
-          <div class="flexRow">
+          <div class="flexRow gutterH">
             <div class="col3">
               <label for="smtpPassword">
                 <%= ob.polyT('settings.advancedTab.smtp.password') %>
@@ -261,16 +261,16 @@
             </div>
             <div class="col6">
               <% if (ob.errors['smtpSettings.password']) print(ob.formErrorTmpl({ errors: ob.errors['smtpSettings.password'] })) %>
-              <input class="clrBr clrSh2" 
-                required 
+              <input class="clrBr clrSh2"
+                required
                 type="password"
-                name="smtpSettings.password" 
-                id="smtpPassword" 
+                name="smtpSettings.password"
+                id="smtpPassword"
                 placeholder="<%= ob.polyT('settings.advancedTab.smtp.placeholderPassword') %>"
                 value="<%= ob.smtpSettings.password %>">
             </div>
           </div>
-          <div class="flexRow">
+          <div class="flexRow gutterH">
             <div class="col3">
               <label for="smtpSenderEmail">
                 <%= ob.polyT('settings.advancedTab.smtp.senderEmail') %>
@@ -279,16 +279,16 @@
             </div>
             <div class="col6">
               <% if (ob.errors['smtpSettings.senderEmail']) print(ob.formErrorTmpl({ errors: ob.errors['smtpSettings.senderEmail'] })) %>
-              <input class="clrBr clrSh2" 
+              <input class="clrBr clrSh2"
                 required
                 type="email"
-                name="smtpSettings.senderEmail" 
-                id="smtpSenderEmail" 
+                name="smtpSettings.senderEmail"
+                id="smtpSenderEmail"
                 placeholder="<%= ob.polyT('settings.advancedTab.smtp.placeholderSendFrom') %>"
                 value="<%= ob.smtpSettings.senderEmail %>">
             </div>
           </div>
-          <div class="flexRow">
+          <div class="flexRow gutterH">
             <div class="col3">
               <label for="smtpRecipientEmail">
                 <%= ob.polyT('settings.advancedTab.smtp.recipientEmail') %>
@@ -297,21 +297,21 @@
             </div>
             <div class="col6">
               <% if (ob.errors['smtpSettings.recipientEmail']) print(ob.formErrorTmpl({ errors: ob.errors['smtpSettings.recipientEmail'] })) %>
-              <input class="clrBr clrSh2" 
+              <input class="clrBr clrSh2"
                 required
                 type="email"
-                name="smtpSettings.recipientEmail" 
-                id="smtpRecipientEmail" 
+                name="smtpSettings.recipientEmail"
+                id="smtpRecipientEmail"
                 placeholder="<%= ob.polyT('settings.advancedTab.smtp.placeholderSendTo') %>"
                 value="<%= ob.smtpSettings.recipientEmail %>">
             </div>
           </div>
-          <div class="flexRow">
+          <div class="flexRow gutterH">
             <div class="col3">
             </div>
             <div class="col6">
-              <input  class="clrBr clrP clrTEm margR flexNoShrink" 
-                      type=reset 
+              <input  class="clrBr clrP clrTEm margR flexNoShrink"
+                      type=reset
                       value="<%= ob.polyT('settings.advancedTab.smtp.clearAction') %>"
               >
               <a class="btn clrP clrBr clrSh2 js-testSMTPSettings flexNoShrink"><%= ob.polyT('settings.advancedTab.smtp.testAction') %></a>
@@ -328,5 +328,5 @@
         btnText: ob.polyT('settings.btnSave')
       }) %>
     </div>
-  </div>  
+  </div>
 </div>

--- a/js/templates/modals/settings/general.html
+++ b/js/templates/modals/settings/general.html
@@ -10,7 +10,7 @@
 
   <div class="tabFormWrapper">
     <form class="box clrP padMdKids padStack settingsGeneralForm">
-      <div class="flexRow">
+      <div class="flexRow gutterH">
         <div class="col3">
           <label class="required"><%= ob.polyT('settings.language') %></label>
           <div class="clrT2 txSm"><%= ob.polyT('settings.generalTab.helperLanguage') %></div>
@@ -25,7 +25,7 @@
           <div class="clrT2 txSm padSm"><%= ob.polyT('settings.generalTab.helperTranslations', { helperTranslationsLink: `<a href="https://www.transifex.com/ob1/openbazaar/" class="clrTEm">${ob.polyT('settings.generalTab.helperTranslationsLink')}</a>` }) %></div>
         </div>
       </div>
-      <div class="flexRow">
+      <div class="flexRow gutterH">
         <div class="col3">
           <label class="required"><%= ob.polyT('settings.country') %></label>
           <div class="clrT2 txSm"><%= ob.polyT('settings.generalTab.helperCountry') %></div>
@@ -39,7 +39,7 @@
           </select>
         </div>
       </div>
-      <div class="flexRow">
+      <div class="flexRow gutterH">
         <div class="col3">
           <label class="required"><%= ob.polyT('settings.currency') %></label>
           <div class="clrT2 txSm"><%= ob.polyT('settings.generalTab.helperCurrency') %></div>
@@ -95,10 +95,10 @@
                    id="settingsBitcoinUnitSatoshi"
             <% if(ob.bitcoinUnit === 'SATOSHI') { %>checked<% } %>>
             <label for="settingsBitcoinUnitSatoshi"><%= ob.polyT('settings.generalTab.bitcoinUnitTypes.SATOSHI') %></label>
-          </div>                    
+          </div>
         </div>
-      </div>      
-      <div class="flexRow">
+      </div>
+      <div class="flexRow gutterH">
         <div class="col3">
           <label class="required"><%= ob.polyT('settings.viewNsfwContent') %></label>
         </div>

--- a/js/templates/modals/settings/moderation.html
+++ b/js/templates/modals/settings/moderation.html
@@ -13,7 +13,7 @@
 
     <div class="tabFormWrapper">
       <form class="box padMdKids padStack">
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label class="required"><%= ob.polyT('settings.moderationTab.moderationStatus') %></label>
           </div>
@@ -40,7 +40,7 @@
             </div>
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label class="required" for="moderationFeeType"><%= ob.polyT('settings.moderationTab.feeTypeAmount') %></label>
           </div>
@@ -96,7 +96,7 @@
           </div>
 
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsModeratorDescription" class="required"><%= ob.polyT('settings.moderationTab.description') %></label>
           </div>
@@ -106,7 +106,7 @@
                       class="clrBr clrSh2" placeholder="<%= ob.polyT('settings.moderationTab.descriptionHelper') %>"><%= ob.description %></textarea>
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsModeratorTerms" class="required"><%= ob.polyT('settings.moderationTab.terms') %></label>
           </div>
@@ -116,7 +116,7 @@
                       class="resizable clrBr clrSh2" placeholder="<%= ob.polyT('settings.moderationTab.termsHelper') %>"><%= ob.termsAndConditions %></textarea>
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsModeratorTerms" class="required"><%= ob.polyT('settings.moderationTab.languages') %></label>
           </div>
@@ -137,27 +137,29 @@
         </div>
       </form>
       <!-- the elements below are not part of the data being saved to the server -->
-      <div class="flexRow">
-        <div class="col3"></div>
-        <div class="col9">
-          <ul class="unstyled errorList hide js-moderationConfirmError">
-            <li><i class="ion-alert-circled"></i> <%= ob.polyT('settings.moderationTab.errors.confirm') %></li>
-          </ul>
-          <input type="checkbox" id="acceptGuidelines" class="<% if (ob.isModerator) { print('fauxChecked') } %>">
-          <label class="tx5b" for="acceptGuidelines">
-            <span>
-              <%= ob.polyT('settings.moderationTab.acceptGuidelines', { acceptGuidelinesLink: `<a href="https://openbazaar.org" class="clrTEm">${ob.polyT('settings.moderationTab.acceptGuidelinesLink')}</a>` }) %>
-            </span>
-          </label>
+      <div class="box padMd">
+        <div class="flexRow gutterH">
+          <div class="col3"></div>
+          <div class="col9">
+            <ul class="unstyled errorList hide js-moderationConfirmError">
+              <li><i class="ion-alert-circled"></i> <%= ob.polyT('settings.moderationTab.errors.confirm') %></li>
+            </ul>
+            <input type="checkbox" id="acceptGuidelines" class="<% if (ob.isModerator) { print('fauxChecked') } %>">
+            <label class="tx5b" for="acceptGuidelines">
+              <span>
+                <%= ob.polyT('settings.moderationTab.acceptGuidelines', { acceptGuidelinesLink: `<a href="https://openbazaar.org" class="clrTEm">${ob.polyT('settings.moderationTab.acceptGuidelinesLink')}</a>` }) %>
+              </span>
+            </label>
+          </div>
         </div>
-      </div>
-      <div class="flexRow">
-        <div class="col3"></div>
-        <div class="col9">
-          <input type="checkbox" id="understandRequirements" class="<% if (ob.isModerator) print('fauxChecked') %>">
-          <label class="tx5b" for="understandRequirements">
-            <span><%= ob.polyT('settings.moderationTab.understandRequirements') %></span>
-          </label>
+        <div class="flexRow gutterH">
+          <div class="col3"></div>
+          <div class="col9">
+            <input type="checkbox" id="understandRequirements" class="<% if (ob.isModerator) print('fauxChecked') %>">
+            <label class="tx5b" for="understandRequirements">
+              <span><%= ob.polyT('settings.moderationTab.understandRequirements') %></span>
+            </label>
+          </div>
         </div>
       </div>
     </div>

--- a/js/templates/modals/settings/page.html
+++ b/js/templates/modals/settings/page.html
@@ -5,13 +5,13 @@
         <%= ob.processingButton({
         className: 'btn clrP clrBr clrSh2 modalContentCornerBtn js-save',
         btnText: ob.polyT('settings.btnSave')
-      }) %>      
+      }) %>
     </div>
     <hr class="clrBr" />
 
     <div class="tabFormWrapper">
       <form class="box padMdKids padStack">
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsName" class="required"><%= ob.polyT('settings.name') %></label>
           </div>
@@ -20,7 +20,7 @@
             <input type="text" class="clrBr clrSh2" name="name" id="settingsName" value="<%= ob.name %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderName') %>">
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsHandle"><%= ob.polyT('settings.handle') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperHandle') %></div>
@@ -31,7 +31,7 @@
             <div class="clrT2 txSm padSm"><%= ob.polyT('settings.pageTab.helperHandleRegister', { helperHandleRegisterLink: `<a href="https://onename.com" class="clrTEm">${ob.polyT('settings.pageTab.helperHandleRegisterLink')}</a>` }) %></div>
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsShortDescription"><%= ob.polyT('settings.shortDescription') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperShortDescription') %></div>
@@ -42,7 +42,7 @@
                       class="clrBr clrSh2" placeholder="<%= ob.polyT('settings.pageTab.placeholderShortDescription') %>"><%= ob.shortDescription %></textarea>
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsLocation"><%= ob.polyT('settings.pageTab.locationLabel') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperLocation') %></div>
@@ -53,7 +53,7 @@
           </div>
         </div>
 
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label><%= ob.polyT('settings.avatar') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.loadAvatarHelp', {minWidth: ob.avatarMinWidth, minHeight: ob.avatarMinHeight}) %></div>
@@ -84,7 +84,7 @@
           </div>
         </div>
 
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label><%= ob.polyT('settings.nsfwContent') %></label>
           </div>
@@ -122,7 +122,7 @@
     <hr class="clrBr" />
     <div class="tabFormWrapper">
       <form class="box padMdKids padStack">
-        <div class="flexRow">
+        <div class="flexRow gutterH">
 <!--           <div class="col3">
             <label for="settingsAbout"><%= ob.polyT('settings.about') %></label>
           </div> -->
@@ -141,7 +141,7 @@
     <hr class="clrBr" />
     <div class="tabFormWrapper">
       <form class="box padMdKids padStack">
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsWebsite"><%= ob.polyT('settings.website') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperAbout') %></div>
@@ -152,7 +152,7 @@
                    value="<%= ob.website %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderWebsite') %>">
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsEmail"><%= ob.polyT('settings.email') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperAbout') %></div>
@@ -171,7 +171,7 @@
     <hr class="clrBr" />
     <div class="tabFormWrapper">
       <form class="box padMdKids padStack">
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label><%= ob.polyT('settings.header') %></label>
               <div class="clrT2 txSm"><%= ob.polyT('settings.loadHeaderHelp', {minWidth: ob.headerMinWidth, minHeight: ob.headerMinHeight}) %></div>
@@ -201,7 +201,7 @@
             </div>
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsPrimaryColor" class="required"><%= ob.polyT('settings.primaryColor') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperPrimaryColor') %></div>
@@ -212,7 +212,7 @@
                    value="<%= ob.primaryColor %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>">
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsSecondaryColor" class="required"><%= ob.polyT('settings.secondaryColor') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperSecondaryColor') %></div>
@@ -223,7 +223,7 @@
                    value="<%= ob.secondaryColor %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>">
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsTextColor" class="required"><%= ob.polyT('settings.textColor') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperTextColor') %></div>
@@ -234,7 +234,7 @@
                    value="<%= ob.textColor %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderTextColor') %>">
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsHighlightColor" class="required"><%= ob.polyT('settings.highlightColor') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperHighlightColor') %></div>
@@ -245,7 +245,7 @@
                    value="<%= ob.highlightColor %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightColor') %>">
           </div>
         </div>
-        <div class="flexRow">
+        <div class="flexRow gutterH">
           <div class="col3">
             <label for="settingsHighlightTextColor" class="required"><%= ob.polyT('settings.highlightTextColor') %></label>
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperHighlightTextColor') %></div>


### PR DESCRIPTION
- labels and notes under labels will no longer run into the form elements in the colum to the right of them.
- an alignment issue in the checkboxes at the bottom of the moderation tab is fixed.