### PR TITLE
Make scrollbar draggable.

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,277 @@
                 </span>
               </div>
             </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="flex gutterH">
+              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+              <div class="contentBox pad clrBr clrP noOverflow">
+                <span class="tx6">
+                  <b>@handle</b> example message that fades out
+                </span>
+              </div>
+            </div>
           </div><div>
             <div class="flex gutterH">
               <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
@@ -62,7 +333,13 @@
       let chatToggle = document.getElementById("chatContainer");
       chatToggle.addEventListener('click', function(){
         document.body.classList.toggle('chatOpen');
-      })
+      });
+      chatToggle.addEventListener('mouseenter', function(){
+        document.body.classList.add('chatHover');
+      });
+      chatToggle.addEventListener('mouseleave', function(){
+        document.body.classList.remove('chatHover');
+      });
     </script>
     <script>
       // install babel hooks in the renderer process

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -43,10 +43,24 @@ body {
   overflow: hidden;
   margin: 0;
 
-  &.chatOpen {
-    .modal::-webkit-scrollbar,
-    #contentFrame::-webkit-scrollbar {
-      width: 0;
+  &.chatHover {
+    .modal,
+    #contentFrame {
+      &::-webkit-scrollbar-track {
+        background: transparent;
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background: transparent;
+
+        &:hover {
+          background: transparent;
+        }
+
+        &:active {
+          background: transparent;
+        }
+      }
     }
   }
 }
@@ -200,14 +214,14 @@ ul, ol {
       width: 0;
     }
 
-    .chatOpen & {
-      width: $chatOpen;
-      right: 0;
-      padding-right: $scrollbar;
-
+    &:hover {
       &::-webkit-scrollbar {
         width: $scrollbar;
       }
+    }
+
+    .chatOpen & {
+      width: $chatOpen;
     }
 
     .chatWrapper {

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -42,6 +42,13 @@ html {
 body {
   overflow: hidden;
   margin: 0;
+
+  &.chatOpen {
+    .modal::-webkit-scrollbar,
+    #contentFrame::-webkit-scrollbar {
+      width: 0;
+    }
+  }
 }
 
 a {
@@ -193,17 +200,14 @@ ul, ol {
       width: 0;
     }
 
-    &:hover {
+    .chatOpen & {
+      width: $chatOpen;
       right: 0;
       padding-right: $scrollbar;
 
       &::-webkit-scrollbar {
         width: $scrollbar;
       }
-    }
-
-    .chatOpen & {
-      width: $chatOpen;
     }
 
     .chatWrapper {

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -48,7 +48,7 @@ $marg: 10px;
 $chatClosed: 48px;
 $chatOpen: 220px;
 $pageWidth: 950px;
-$scrollbar: 8px;
+$scrollbar: 10px;
 $modalContentInner: 957px;
 $buttonHeight: 35px;
 


### PR DESCRIPTION
- the chat scrollbar will no longer cover the page scrollbar, they are positioned next to each other.
- when chat is hovered over, the contentFrame and modal scrollbars are hidden
- the scroll bar puck is slightly wider (10px) to make it easier to click on
- Closes #334

Do not merge this until the chat bar branch that adds chat functionality has been merged, just in case there are conflicts.