### PR TITLE
Chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       
       <div id="chatCloseBtn" class="chatCloseBtn js-chatClose ion-ios-close-empty iconBtn clrP clrBr clrT2"></div>
       <div id="chatContainer"></div>
+      <div id="chatConvoContainer"></div>
       <section id="statusBar"></section>
     </div>
     <!-- delete this in production, it's just a warning for pre-alpha releases -->

--- a/index.html
+++ b/index.html
@@ -15,39 +15,7 @@
       <section id="contentFrame">
         <div id="pageContainer"></div>
       </section>
-      <div id="chatContainer" class="chat hide">
-        <div class="chatWrapper flexColRows gutterV"><!-- fake chat elements -->
-          <div>
-            <div class="flex gutterH">
-              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
-              <div class="contentBox pad clrBr clrP noOverflow">
-                <span class="tx6">
-                  <b>@handle</b> example message that fades out
-                </span>
-              </div>
-            </div>
-          </div>
-          <div>
-            <div class="flex gutterH">
-              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
-              <div class="contentBox pad clrBr clrP noOverflow">
-                <span class="tx6">
-                  <b>@handle</b> example message that fades out
-                </span>
-              </div>
-            </div>
-          </div><div>
-            <div class="flex gutterH">
-              <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
-              <div class="contentBox pad clrBr clrP noOverflow">
-                <span class="tx6">
-                  <b>@handle</b> example message that fades out
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <div id="chatContainer" class="hide"></div>
       <section id="statusBar"></section>
     </div>
     <!-- delete this in production, it's just a warning for pre-alpha releases -->

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../styles/lib/select2.css">
     <link rel="stylesheet" href="./styles/main.css">
   </head>
-  <body class="clrT clrS chatConvoOpen">
+  <body class="clrT clrS">
     <div id="appFrame">
       <section id="pageNavContainer"></section>
       <section id="contentFrame">

--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
       <section id="contentFrame">
         <div id="pageContainer"></div>
       </section>
+      
+      <div id="chatCloseBtn" class="chatCloseBtn js-chatClose ion-ios-close-empty iconBtn clrP clrBr clrT2"></div>
       <div id="chatContainer"></div>
       <section id="statusBar"></section>
     </div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../styles/lib/select2.css">
     <link rel="stylesheet" href="./styles/main.css">
   </head>
-  <body class="clrT clrS">
+  <body class="clrT clrS chatConvoOpen">
     <div id="appFrame">
       <section id="pageNavContainer"></section>
       <section id="contentFrame">

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       <section id="contentFrame">
         <div id="pageContainer"></div>
       </section>
-      <div id="chatContainer" class="hide"></div>
+      <div id="chatContainer"></div>
       <section id="statusBar"></section>
     </div>
     <!-- delete this in production, it's just a warning for pre-alpha releases -->
@@ -25,13 +25,6 @@
       </span>
 
     </div>
-    <script>
-      <!--just demo stuff-->
-      let chatToggle = document.getElementById("chatContainer");
-      chatToggle.addEventListener('click', function(){
-        document.body.classList.toggle('chatOpen');
-      })
-    </script>
     <script>
       // install babel hooks in the renderer process
       require('babel-register');

--- a/js/collections/ChatConversations.js
+++ b/js/collections/ChatConversations.js
@@ -24,15 +24,20 @@ module.exports = Collection.extend({
         resp = [...resp, ...resp];
       }
 
-      resp = resp.slice(1)
-        .map(convo => ({
-          ...convo,
-          peerId: Date.now() + Math.random(),
-          // unread: Math.floor(Math.random() * 20) + 0,
-          unread: 0,
-        }));
+      resp = resp.map(convo => ({
+        ...convo,
+        peerId: Date.now() + Math.random(),
+        unread: Math.floor(Math.random() * 20) + 0,
+      }));
 
-      resp[0].unread = 5;
+      resp[43].unread = 0;
+      resp[44].unread = 0;
+      resp[45].unread = 0;
+      resp[46].unread = 0;
+      resp[47].unread = 0;
+      resp[48].unread = 0;
+      resp[49].unread = 0;
+      resp[50].unread = 0;
     }
 
     return resp;

--- a/js/collections/ChatConversations.js
+++ b/js/collections/ChatConversations.js
@@ -12,6 +12,10 @@ module.exports = Collection.extend({
 
   model: ChatHead,
 
+  comparator(convo) {
+    return -convo.get('unread');
+  },
+
   parse(response) {
     let resp = response.filter(convo => (convo.peerId !== app.profile.guid));
 
@@ -24,8 +28,11 @@ module.exports = Collection.extend({
         .map(convo => ({
           ...convo,
           peerId: Date.now() + Math.random(),
-          unread: Math.floor(Math.random() * (20 - 1 + 1)) + 1,
+          // unread: Math.floor(Math.random() * 20) + 0,
+          unread: 0,
         }));
+
+      resp[0].unread = 5;
     }
 
     return resp;

--- a/js/collections/ChatConversations.js
+++ b/js/collections/ChatConversations.js
@@ -1,0 +1,42 @@
+import app from '../app';
+import { Collection } from 'backbone';
+import ListingShort from '../models/listing/ListingShort';
+
+export default class extends Collection {
+  // constructor(models = [], options = {}) {
+  //   super(models, options);
+  // }
+
+  model(attrs, options) {
+    return new ListingShort(attrs, options);
+  }
+
+  url() {
+    let url;
+
+    if (this.guid === app.profile.id) {
+      url = app.getServerUrl('ob/listings');
+    } else {
+      url = app.getServerUrl(`ipns/${this.guid}/listings/index.json`);
+    }
+
+    return url;
+  }
+
+  parse() {
+    const parsedResponse = [];
+
+    // response.forEach(listing => {
+    //   const updatedListing = listing;
+    //   const priceObj = updatedListing.price;
+
+
+    //   updatedListing.price.amount =
+    //     integerToDecimal(priceObj.amount, priceObj.currencyCode === 'BTC');
+
+    //   parsedResponse.push(updatedListing);
+    // });
+
+    return parsedResponse;
+  }
+}

--- a/js/collections/ChatConversations.js
+++ b/js/collections/ChatConversations.js
@@ -13,6 +13,39 @@ module.exports = Collection.extend({
   model: ChatHead,
 
   parse(response) {
-    return response.filter((conversation) => (conversation.peerId !== app.profile.guid));
+    // until lastMessage and unread are provided, we'll fudge them
+    const lastMessages = [
+      'I\'ll meet ya at tha crossroads dawg.',
+      'Are you talking to me? I don\'t think you are talking to me in that' +
+        'manner, eh? Is this all she wrote?',
+      'Straight fleecin it out playa',
+      'They be smashing my flo yo',
+      'What in the hell?',
+      'The winter winds came slow and heavy, the bean broth was slightly over done.',
+    ];
+
+    const unreads = [3, 6, 7, 1, 0, 4, 18, 5];
+
+    let resp = response.map((convo, index) => ({
+      ...convo,
+      lastMessage: lastMessages[index % lastMessages.length],
+      unread: unreads[index % unreads.length],
+    }));
+
+    // return resp.filter(convo => (convo.peerId !== app.profile.guid));
+
+    resp = resp.filter(convo => (convo.peerId !== app.profile.guid));
+
+    while (resp.length < 50) {
+      resp = [...resp, ...resp];
+    }
+
+    resp = resp.slice(1)
+      .map(convo => ({
+        ...convo,
+        peerId: Date.now() + Math.random(),
+      }));
+
+    return resp;
   },
 });

--- a/js/collections/ChatConversations.js
+++ b/js/collections/ChatConversations.js
@@ -36,15 +36,17 @@ module.exports = Collection.extend({
 
     resp = resp.filter(convo => (convo.peerId !== app.profile.guid));
 
-    while (resp.length < 50) {
-      resp = [...resp, ...resp];
-    }
+    if (resp.length) {
+      while (resp.length < 50) {
+        resp = [...resp, ...resp];
+      }
 
-    resp = resp.slice(1)
-      .map(convo => ({
-        ...convo,
-        peerId: Date.now() + Math.random(),
-      }));
+      resp = resp.slice(1)
+        .map(convo => ({
+          ...convo,
+          peerId: Date.now() + Math.random(),
+        }));
+    }
 
     return resp;
   },

--- a/js/collections/ChatConversations.js
+++ b/js/collections/ChatConversations.js
@@ -1,42 +1,18 @@
-import app from '../app';
 import { Collection } from 'backbone';
-import ListingShort from '../models/listing/ListingShort';
+import ChatHead from '../models/chat/ChatHead';
+import app from '../app';
 
-export default class extends Collection {
-  // constructor(models = [], options = {}) {
-  //   super(models, options);
-  // }
-
-  model(attrs, options) {
-    return new ListingShort(attrs, options);
-  }
+module.exports = Collection.extend({
+  /* we have to use the older style for this collection, the ES6 style creates a bug where models
+  cannot be removed using their ids */
 
   url() {
-    let url;
+    return app.getServerUrl('ob/chatconversations');
+  },
 
-    if (this.guid === app.profile.id) {
-      url = app.getServerUrl('ob/listings');
-    } else {
-      url = app.getServerUrl(`ipns/${this.guid}/listings/index.json`);
-    }
+  model: ChatHead,
 
-    return url;
-  }
-
-  parse() {
-    const parsedResponse = [];
-
-    // response.forEach(listing => {
-    //   const updatedListing = listing;
-    //   const priceObj = updatedListing.price;
-
-
-    //   updatedListing.price.amount =
-    //     integerToDecimal(priceObj.amount, priceObj.currencyCode === 'BTC');
-
-    //   parsedResponse.push(updatedListing);
-    // });
-
-    return parsedResponse;
-  }
-}
+  parse(response) {
+    return response.filter((conversation) => (conversation.peerId !== app.profile.guid));
+  },
+});

--- a/js/collections/ChatConversations.js
+++ b/js/collections/ChatConversations.js
@@ -13,28 +13,7 @@ module.exports = Collection.extend({
   model: ChatHead,
 
   parse(response) {
-    // until lastMessage and unread are provided, we'll fudge them
-    const lastMessages = [
-      'I\'ll meet ya at tha crossroads dawg.',
-      'Are you talking to me? I don\'t think you are talking to me in that' +
-        'manner, eh? Is this all she wrote?',
-      'Straight fleecin it out playa',
-      'They be smashing my flo yo',
-      'What in the hell?',
-      'The winter winds came slow and heavy, the bean broth was slightly over done.',
-    ];
-
-    const unreads = [3, 6, 7, 1, 0, 4, 18, 5];
-
-    let resp = response.map((convo, index) => ({
-      ...convo,
-      lastMessage: lastMessages[index % lastMessages.length],
-      unread: unreads[index % unreads.length],
-    }));
-
-    // return resp.filter(convo => (convo.peerId !== app.profile.guid));
-
-    resp = resp.filter(convo => (convo.peerId !== app.profile.guid));
+    let resp = response.filter(convo => (convo.peerId !== app.profile.guid));
 
     if (resp.length) {
       while (resp.length < 50) {
@@ -45,6 +24,7 @@ module.exports = Collection.extend({
         .map(convo => ({
           ...convo,
           peerId: Date.now() + Math.random(),
+          unread: Math.floor(Math.random() * (20 - 1 + 1)) + 1,
         }));
     }
 

--- a/js/collections/ChatHeads.js
+++ b/js/collections/ChatHeads.js
@@ -1,14 +1,46 @@
 import { Collection } from 'backbone';
 import ChatHead from '../models/chat/ChatHead';
 import app from '../app';
+// import moment from 'moment';
 
-module.exports = Collection.extend({
-  /* we have to use the older style for this collection, the ES6 style creates a bug where models
-  cannot be removed using their ids */
-
+export default class extends Collection {
   url() {
     return app.getServerUrl('ob/chatconversations');
-  },
+  }
 
-  model: ChatHead,
-});
+  model(attrs, options) {
+    return new ChatHead(attrs, options);
+  }
+
+  modelId(attrs) {
+    return attrs.peerId;
+  }
+
+  comparator(message) {
+    return (new Date(message.get('timestamp')).getTime()) * -1;
+  }
+
+  // parse(response) {
+  //   const convos = [];
+
+  //   if (!response || !response.length) return;
+
+  //   for (let i = 0; i < 100; i++) {
+  //     const daysAhead = Math.floor(Math.random() * 6);
+  //     const timestamp = moment(new Date((new Date()).getTime() + (86400000 * daysAhead)));
+
+  //     response.forEach((convo) => {
+  //       convos.push({
+  //         ...convo,
+  //         lastMessage: `${i + 1}: ${convo.lastMessage}`,
+  //         timestamp: timestamp.format(),
+  //         peerId: Math.random() + Date.now(),
+  //       });
+  //     });
+
+  //     // console.log(`${i + 1}: ${timestamp.format('MMM Do YY')}`);
+  //   }
+
+  //   return convos;
+  // }
+}

--- a/js/collections/ChatHeads.js
+++ b/js/collections/ChatHeads.js
@@ -1,7 +1,6 @@
 import { Collection } from 'backbone';
 import ChatHead from '../models/chat/ChatHead';
 import app from '../app';
-// import moment from 'moment';
 
 export default class extends Collection {
   url() {
@@ -19,28 +18,4 @@ export default class extends Collection {
   comparator(message) {
     return (new Date(message.get('timestamp')).getTime()) * -1;
   }
-
-  // parse(response) {
-  //   const convos = [];
-
-  //   if (!response || !response.length) return;
-
-  //   for (let i = 0; i < 100; i++) {
-  //     const daysAhead = Math.floor(Math.random() * 6);
-  //     const timestamp = moment(new Date((new Date()).getTime() + (86400000 * daysAhead)));
-
-  //     response.forEach((convo) => {
-  //       convos.push({
-  //         ...convo,
-  //         lastMessage: `${i + 1}: ${convo.lastMessage}`,
-  //         timestamp: timestamp.format(),
-  //         peerId: Math.random() + Date.now(),
-  //       });
-  //     });
-
-  //     // console.log(`${i + 1}: ${timestamp.format('MMM Do YY')}`);
-  //   }
-
-  //   return convos;
-  // }
 }

--- a/js/collections/ChatHeads.js
+++ b/js/collections/ChatHeads.js
@@ -11,35 +11,4 @@ module.exports = Collection.extend({
   },
 
   model: ChatHead,
-
-  comparator(convo) {
-    return -convo.get('unread');
-  },
-
-  // parse(response) {
-  //   let resp = response.filter(chatHead => (chatHead.peerId !== app.profile.guid));
-
-  //   if (resp.length) {
-  //     while (resp.length < 50) {
-  //       resp = [...resp, ...resp];
-  //     }
-
-  //     resp = resp.map(chatHead => ({
-  //       ...chatHead,
-  //       peerId: Date.now() + Math.random(),
-  //       unread: Math.floor(Math.random() * 20) + 0,
-  //     }));
-
-  //     resp[43].unread = 0;
-  //     resp[44].unread = 0;
-  //     resp[45].unread = 0;
-  //     resp[46].unread = 0;
-  //     resp[47].unread = 0;
-  //     resp[48].unread = 0;
-  //     resp[49].unread = 0;
-  //     resp[50].unread = 0;
-  //   }
-
-  //   return resp;
-  // },
 });

--- a/js/collections/ChatHeads.js
+++ b/js/collections/ChatHeads.js
@@ -18,4 +18,18 @@ export default class extends Collection {
   comparator(message) {
     return (new Date(message.get('timestamp')).getTime()) * -1;
   }
+
+  // parse(response) {
+  //   const moo = [{ ...response[0] }];
+
+  //   for (let i = 0; i < 100; i++) {
+  //     moo.push({
+  //       ...response[0],
+  //       peerId: String(i),
+  //       lastMessage: `${i}: ${response[0].lastMessage}`,
+  //     });
+  //   }
+
+  //   return moo;
+  // }
 }

--- a/js/collections/ChatHeads.js
+++ b/js/collections/ChatHeads.js
@@ -17,15 +17,15 @@ module.exports = Collection.extend({
   },
 
   parse(response) {
-    let resp = response.filter(convo => (convo.peerId !== app.profile.guid));
+    let resp = response.filter(chatHead => (chatHead.peerId !== app.profile.guid));
 
     if (resp.length) {
       while (resp.length < 50) {
         resp = [...resp, ...resp];
       }
 
-      resp = resp.map(convo => ({
-        ...convo,
+      resp = resp.map(chatHead => ({
+        ...chatHead,
         peerId: Date.now() + Math.random(),
         unread: Math.floor(Math.random() * 20) + 0,
       }));

--- a/js/collections/ChatHeads.js
+++ b/js/collections/ChatHeads.js
@@ -18,18 +18,4 @@ export default class extends Collection {
   comparator(message) {
     return (new Date(message.get('timestamp')).getTime()) * -1;
   }
-
-  // parse(response) {
-  //   const moo = [{ ...response[0] }];
-
-  //   for (let i = 0; i < 100; i++) {
-  //     moo.push({
-  //       ...response[0],
-  //       peerId: String(i),
-  //       lastMessage: `${i}: ${response[0].lastMessage}`,
-  //     });
-  //   }
-
-  //   return moo;
-  // }
 }

--- a/js/collections/ChatHeads.js
+++ b/js/collections/ChatHeads.js
@@ -16,30 +16,30 @@ module.exports = Collection.extend({
     return -convo.get('unread');
   },
 
-  parse(response) {
-    let resp = response.filter(chatHead => (chatHead.peerId !== app.profile.guid));
+  // parse(response) {
+  //   let resp = response.filter(chatHead => (chatHead.peerId !== app.profile.guid));
 
-    if (resp.length) {
-      while (resp.length < 50) {
-        resp = [...resp, ...resp];
-      }
+  //   if (resp.length) {
+  //     while (resp.length < 50) {
+  //       resp = [...resp, ...resp];
+  //     }
 
-      resp = resp.map(chatHead => ({
-        ...chatHead,
-        peerId: Date.now() + Math.random(),
-        unread: Math.floor(Math.random() * 20) + 0,
-      }));
+  //     resp = resp.map(chatHead => ({
+  //       ...chatHead,
+  //       peerId: Date.now() + Math.random(),
+  //       unread: Math.floor(Math.random() * 20) + 0,
+  //     }));
 
-      resp[43].unread = 0;
-      resp[44].unread = 0;
-      resp[45].unread = 0;
-      resp[46].unread = 0;
-      resp[47].unread = 0;
-      resp[48].unread = 0;
-      resp[49].unread = 0;
-      resp[50].unread = 0;
-    }
+  //     resp[43].unread = 0;
+  //     resp[44].unread = 0;
+  //     resp[45].unread = 0;
+  //     resp[46].unread = 0;
+  //     resp[47].unread = 0;
+  //     resp[48].unread = 0;
+  //     resp[49].unread = 0;
+  //     resp[50].unread = 0;
+  //   }
 
-    return resp;
-  },
+  //   return resp;
+  // },
 });

--- a/js/collections/ChatMessages.js
+++ b/js/collections/ChatMessages.js
@@ -1,0 +1,26 @@
+import app from '../app';
+import { Collection } from 'backbone';
+// import ListingShort from '../models/listing/ListingShort';
+
+export default class extends Collection {
+  constructor(models = [], options = {}) {
+    if (!options.guid) {
+      throw new Error('Please provide a guid of the other person in the conversation.');
+    }
+
+    super(models, options);
+    this.guid = options.guid;
+  }
+
+  // model(attrs, options) {
+  //   return new ListingShort(attrs, options);
+  // }
+
+  url() {
+    return app.getServerUrl(`ob/chatmessages/${this.guid}`);
+  }
+
+  // parse(response) {
+  //   return response;
+  // }
+}

--- a/js/collections/ChatMessages.js
+++ b/js/collections/ChatMessages.js
@@ -16,6 +16,10 @@ export default class extends Collection {
     return new ChatMessage(attrs, options);
   }
 
+  modelId(attrs) {
+    return attrs.messageId;
+  }
+
   comparator(message) {
     return message.get('timestamp');
   }

--- a/js/collections/ChatMessages.js
+++ b/js/collections/ChatMessages.js
@@ -1,6 +1,6 @@
 import app from '../app';
 import { Collection } from 'backbone';
-// import ListingShort from '../models/listing/ListingShort';
+import ChatMessage from '../models/chat/ChatMessage';
 
 export default class extends Collection {
   constructor(models = [], options = {}) {
@@ -12,15 +12,15 @@ export default class extends Collection {
     this.guid = options.guid;
   }
 
-  // model(attrs, options) {
-  //   return new ListingShort(attrs, options);
-  // }
+  model(attrs, options) {
+    return new ChatMessage(attrs, options);
+  }
+
+  comparator(message) {
+    return message.get('timestamp');
+  }
 
   url() {
     return app.getServerUrl(`ob/chatmessages/${this.guid}`);
   }
-
-  // parse(response) {
-  //   return response;
-  // }
 }

--- a/js/data/languages.js
+++ b/js/data/languages.js
@@ -61,10 +61,10 @@ const languages = [
   //   name: '한국어 (Korean)',
   //   code: 'ko',
   // },
-  //{
+  // {
   //  name: 'Polski (Polish)',
   //  code: 'pl',
-  //},
+  // },
   // {
   //   name: 'Português (Portuguese, Brazil)',
   //   code: 'pt-BR',

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -56,6 +56,8 @@
     "unreadMessages": "Unread messages %{arrow}",
     "conversation": {
       "messageInputPlaceholder": "Enter message…",
+      "loadMessagesError": "There was an error loading the messages. %{retryLink}",
+      "retryLink": "retry",
       "subMenu": {
         "viewPage": "View page",
         "blockUser": "Block user",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -62,7 +62,8 @@
         "viewPage": "View page",
         "blockUser": "Block user",
         "deleteConvo": "Delete conversation"
-      }
+      },
+      "typingIndicator": "%{user} is typing..."
     }
   },
   "userPage": {

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -53,7 +53,10 @@
     "notConnectedMenuItem": "Not Connected"
   },
   "chat": {
-    "unreadMessages": "Unread messages %{arrow}"
+    "unreadMessages": "Unread messages %{arrow}",
+    "conversation": {
+      "messageInputPlaceholder": "Enter message…"
+    }
   },
   "userPage": {
     "followsYou": "Follows You",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -53,6 +53,9 @@
     "notConnectedMenuItem": "Not Connected"
   },
   "chat": {
+    "fetchingConversations": "Retrieving your chat conversations…",
+    "errorFetching": "There was an error retrieving your chat conversations.",
+    "errorFetchingWithMessage": "There was an error retrieving your chat conversations: %{msg}",
     "unreadMessages": "Unread messages %{arrow}",
     "conversation": {
       "messageInputPlaceholder": "Enter message…",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -52,6 +52,9 @@
   "pageNav": {
     "notConnectedMenuItem": "Not Connected"
   },
+  "chat": {
+    "unreadMessages": "Unread messages %{arrow}"
+  },
   "userPage": {
     "followsYou": "Follows You",
     "message": "Message",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -63,7 +63,9 @@
         "blockUser": "Block user",
         "deleteConvo": "Delete conversation"
       },
-      "typingIndicator": "%{user} is typing..."
+      "typingIndicator": "%{user} is typing…",
+      "deleteConvoErrorTitle": "Unable to delete conversation",
+      "deletingOverlayText": "Deleting conversation…"
     }
   },
   "userPage": {
@@ -71,7 +73,7 @@
     "message": "Message",
     "customize": "Customize",
     "about": "About",
-    "aboutEmpty": "About is empty...",
+    "aboutEmpty": "About is empty…",
     "follow": "Follow",
     "unfollow": "Unfollow",
     "searchStore": "Search",
@@ -117,7 +119,7 @@
         },
         "categoryFilter": {
           "heading": "Category",
-          "showMore": "%{smart_count} more... |||| %{smart_count} more...",
+          "showMore": "%{smart_count} more… |||| %{smart_count} more…",
           "showLess": "less"
         }
     },
@@ -129,7 +131,7 @@
     }
   },
   "userShort": {
-    "userLoading": "Loading...",
+    "userLoading": "Loading…",
     "userNotFound": "Information for %{guid} was <b>not found on the network.</b>"
   },
   "about": {
@@ -205,7 +207,7 @@
         "UBTC": "µBTC",
         "SATOSHI": "Satoshi (sat)"
       },
-      "statusSaving": "Saving general settings...",
+      "statusSaving": "Saving general settings…",
       "statusSaveComplete": "General settings saved.",
       "statusSaveFailed": "Unable to save general settings.",
       "saveErrorAlertTitle": "Unable to save general settings"
@@ -222,11 +224,11 @@
       "helperTextColor": "Copy, About, Descriptions",
       "helperHighlightColor": "Notifications, Alerts, Badges",
       "helperHighlightTextColor": "Color within Notifications",
-      "placeholderAbout": "Write whatever you would like on your page...",
+      "placeholderAbout": "Write whatever you would like on your page…",
       "placeholderName": "Name of your page",
       "placeholderHandle": "Enter your Onename @handle",
       "placeholderLocation": "Enter your location",
-      "placeholderShortDescription": "Say something interesting...",
+      "placeholderShortDescription": "Say something interesting…",
       "placeholderWebsite": "http://",
       "placeholderEmail": "name@domain.com",
       "placeholderPrimaryColor": "#FFFFFF",
@@ -238,7 +240,7 @@
       "sectionLinks": "Links",
       "sectionAbout": "About",
       "sectionTheme": "Theme",
-      "statusSaving": "Saving page settings...",
+      "statusSaving": "Saving page settings…",
       "statusSaveComplete": "Page settings saved.",
       "statusSaveFailed": "Unable to save page settings.",
       "saveErrorAlertTitle": "Unable to save page settings",
@@ -252,11 +254,11 @@
       "placeholderPostalCode": "60654",
       "placeholderNotes": "e.g. leave packages behind bush",
       "sectionName": "Shipping Addresses",
-      "statusDeletingAddress": "Deleting address %{name}...",
+      "statusDeletingAddress": "Deleting address %{name}…",
       "statusDeleteAddressComplete": "Address %{name} deleted.",
       "statusDeleteAddressFailed": "Unable to delete address %{name}.",
       "deleteAddressErrorAlertTitle": "Unable to delete address %{name}",
-      "statusAddingAddress": "Adding address %{name}...",
+      "statusAddingAddress": "Adding address %{name}…",
       "statusAddAddressComplete": "Address %{name} added.",
       "statusAddAddressFailed": "Unable to add address %{name}.",
       "addAddressErrorAlertTitle": "Unable to add address %{name}"
@@ -315,7 +317,7 @@
         "macOS": "Mac (upper left)",
         "windowsOS": "Windows (upper right)"
       },
-      "statusSaving": "Saving advanced settings...",
+      "statusSaving": "Saving advanced settings…",
       "statusSaveComplete": "Advanced settings saved.",
       "statusSaveFailed": "Unable to save advanced settings.",
       "saveErrorAlertTitle": "Unable to save advanced settings"
@@ -347,7 +349,7 @@
       "acceptGuidelinesLink": "OpenBazaar Dispute Resolution Guidelines",
       "understandRequirements": "I understand I must offer my services to resolve disputes to anyone that requests them.",
       "status":{
-        "saving": "Saving moderation settings...",
+        "saving": "Saving moderation settings…",
         "done": "Moderation settings saved.",
         "fail": "Saving the moderation settings failed."
       },
@@ -400,7 +402,7 @@
       "postalCode": "Postal Code",
       "notes": "Address Notes"
     },
-    "statusSaving": "Saving settings...",
+    "statusSaving": "Saving settings…",
     "statusSaveFailed": "Settings failed to save.",
     "statusSaveComplete": "Settings saved.",
     "btnYes": "Yes",
@@ -453,7 +455,7 @@
       "username": "Username",
       "serverIp": "Server IP",
       "name": "Name",
-      "placeholderName": "Enter a name...",
+      "placeholderName": "Enter a name…",
       "placeholderServerIp": "The IP to your server (or localhost)",
       "placeholderUsername": "The username to your server",
       "placeholderPassword": "The password to your server",
@@ -506,11 +508,11 @@
   "listingCard": {
     "btnDetails": "Details",
     "freeShippingBanner": "Free Shipping",
-    "deleting": "Deleting...",
+    "deleting": "Deleting…",
     "deleted": "Deleted"
   },
   "listingDelete": {
-    "deletingListing": "Deleting listing %{listing}...",
+    "deletingListing": "Deleting listing %{listing}…",
     "deletedListing": "Listing %{listing} deleted.",
     "deletedFailedStatusMsg": "Unable to delete listing %{listing}.",
     "deletedFailedDialogTitle": "Unable to delete listing",
@@ -535,9 +537,9 @@
       "termsAndConditions": "Terms and Conditions",
       "coupons": "Coupons"
     },
-    "placeholderTitle": "Enter your title...",
+    "placeholderTitle": "Enter your title…",
     "placeholderSKU": "SKU, Part Number, ID, etc",
-    "placeholderDescription": "Describe your listing as best as you can... Include inline photos. Link to Youtube videos. etc",
+    "placeholderDescription": "Describe your listing as best as you can… Include inline photos. Link to Youtube videos. etc",
     "placeholderReturnPolicy": "What is your return policy? How many days are returns accepted for? Who pays for return shipping (if needed)? etc",
     "placeholderTerms": "What are the terms and conditions of the listing? What are you responsible for as the vendor? Is there a warranty? When is the transaction final? etc",
     "helperTitle": "Something descriptive that clearly explains what you're selling",
@@ -561,9 +563,9 @@
     "condition": "Condition",
     "sku": "SKU",
     "description": "Description",
-    "uploading": "Uploading...",
-    "categoryPlaceholder": "Enter a category...",
-    "tagsPlaceholder": "Enter #tags...",
+    "uploading": "Uploading…",
+    "categoryPlaceholder": "Enter a category…",
+    "tagsPlaceholder": "Enter #tags…",
     "btnCancelUpload": "cancel",
     "btnAddPhoto": "Add",
     "btnAddShippingOptionShort": "Add",
@@ -574,7 +576,7 @@
     "shippingOptions": {
         "optionHeading": "Shipping Option #%{listPosition}",
         "shippingDestinations": "Destinations",
-        "regionsPlaceholder": "Enter countries...",
+        "regionsPlaceholder": "Enter countries…",
         "nameLabel": "Option Title",
         "namePlaceholder": "e.g. USA Shipping, International, etc",
         "typeLabel": "Type",
@@ -615,7 +617,7 @@
     }
   },
   "exchangeRatesSyncer": {
-    "fetchingRatesStatusMsg": "Fetching exchange rates...",
+    "fetchingRatesStatusMsg": "Fetching exchange rates…",
     "fetchingRatesSuccessStatusMsg": "Successfully obtained exchange rates.",
     "fetchingRatesFailStatusMsg": "Unable to obtain exchange rates. %{retryLink}",
     "fetchingRatesFailStatusMsgRetryLink": "retry"

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -55,7 +55,12 @@
   "chat": {
     "unreadMessages": "Unread messages %{arrow}",
     "conversation": {
-      "messageInputPlaceholder": "Enter message…"
+      "messageInputPlaceholder": "Enter message…",
+      "subMenu": {
+        "viewPage": "View page",
+        "blockUser": "Block user",
+        "deleteConvo": "Delete conversation"
+      }
     }
   },
   "userPage": {

--- a/js/models/chat/ChatHead.js
+++ b/js/models/chat/ChatHead.js
@@ -1,8 +1,13 @@
+import app from '../../app';
 import BaseModel from '../BaseModel';
 
 export default class extends BaseModel {
   get idAttribute() {
     return 'peerId';
+  }
+
+  url() {
+    return app.getServerUrl('ob/chatconversation');
   }
 }
 

--- a/js/models/chat/ChatHead.js
+++ b/js/models/chat/ChatHead.js
@@ -1,0 +1,8 @@
+import BaseModel from '../BaseModel';
+
+export default class extends BaseModel {
+  get idAttribute() {
+    return 'peerId';
+  }
+}
+

--- a/js/models/chat/ChatMessage.js
+++ b/js/models/chat/ChatMessage.js
@@ -6,6 +6,7 @@ export default class extends BaseModel {
   defaults() {
     return {
       subject: '',
+      message: '',
       read: false,
       outgoing: true,
     };
@@ -13,6 +14,13 @@ export default class extends BaseModel {
 
   get idAttribute() {
     return 'messageId';
+  }
+
+  static get max() {
+    return {
+      subjectLength: 500,
+      messageLength: 20000,
+    };
   }
 
   url() {
@@ -26,10 +34,18 @@ export default class extends BaseModel {
       errObj[fieldName].push(error);
     };
 
-    // Not translating, since none of these errors are expected to make it into
-    // the UI.
+    const max = this.constructor.max;
+
     if (!attrs.peerId) {
       addError('peerId', 'The peerId is required');
+    }
+
+    if (attrs.subject.length > max.subjectLength) {
+      addError('subject', `The subject exceeds the max length of ${max.subjectLength}`);
+    }
+
+    if (attrs.message.length > max.messageLength) {
+      addError('message', `The message exceeds the max length of ${max.messageLength}`);
     }
 
     if (Object.keys(errObj).length) return errObj;

--- a/js/models/chat/ChatMessage.js
+++ b/js/models/chat/ChatMessage.js
@@ -1,8 +1,50 @@
+import moment from 'moment';
+import app from '../../app';
 import BaseModel from '../BaseModel';
 
 export default class extends BaseModel {
+  defaults() {
+    return {
+      subject: '',
+      read: false,
+      outgoing: true,
+    };
+  }
+
   get idAttribute() {
     return 'messageId';
+  }
+
+  url() {
+    return app.getServerUrl('ob/chat/');
+  }
+
+  validate(attrs) {
+    const errObj = {};
+    const addError = (fieldName, error) => {
+      errObj[fieldName] = errObj[fieldName] || [];
+      errObj[fieldName].push(error);
+    };
+
+    // Not translating, since none of these errors are expected to make it into
+    // the UI.
+    if (!attrs.peerId) {
+      addError('peerId', 'The peerId is required');
+    }
+
+    if (Object.keys(errObj).length) return errObj;
+
+    return undefined;
+  }
+
+  sync(method, model, options) {
+    options.attrs = options.attrs || model.toJSON(options);
+
+    if (method === 'create') {
+      options.attrs.timestamp = moment(Date.now()).format();
+    }
+
+    return super.sync(method, model, options);
   }
 }
 

--- a/js/models/chat/ChatMessage.js
+++ b/js/models/chat/ChatMessage.js
@@ -1,0 +1,8 @@
+import BaseModel from '../BaseModel';
+
+export default class extends BaseModel {
+  get idAttribute() {
+    return 'messageId';
+  }
+}
+

--- a/js/models/profile/Profile.js
+++ b/js/models/profile/Profile.js
@@ -168,6 +168,9 @@ export default class extends BaseModel {
 
       response.modInfo.fee.fixedFee.amount = integerToDecimal(amount, isBtc);
     }
+
+    if (response.handle.startsWith('@')) response.handle = response.handle.slice(1);
+
     return this.standardizeColorFields(response);
   }
 

--- a/js/start.js
+++ b/js/start.js
@@ -421,6 +421,7 @@ function start() {
 
         app.chat = new Chat({
           collection: chatConvos,
+          $scrollContainer: getChatContainer(),
         });
 
         chatConvos.fetch();

--- a/js/start.js
+++ b/js/start.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import Backbone from 'backbone';
 import Polyglot from 'node-polyglot';
 import './lib/whenAll.jquery';
+import moment from 'moment';
 import app from './app';
 import ServerConfigs from './collections/ServerConfigs';
 import ServerConfig from './models/ServerConfig';
@@ -45,12 +46,15 @@ function getValidLanguage(lang) {
 
 const initialLang = getValidLanguage(app.localSettings.get('language'));
 app.localSettings.set('language', initialLang);
+moment.locale(initialLang);
 app.polyglot = new Polyglot();
 app.polyglot.extend(require(`./languages/${initialLang}.json`));
 
 app.localSettings.on('change:language', (localSettings, lang) => {
   app.polyglot.extend(
     require(`./languages/${lang}.json`));  // eslint-disable-line global-require
+
+  moment.locale(lang);
 
   const restartLangChangeDialog = new Dialog({
     title: app.polyglot.t('langChangeRestartTitle'),

--- a/js/start.js
+++ b/js/start.js
@@ -10,6 +10,7 @@ import serverConnect, { events as serverConnectEvents } from './utils/serverConn
 import LocalSettings from './models/LocalSettings';
 import ObRouter from './router';
 import { getChatContainer } from './utils/selectors';
+import Chat from './views/chat/Chat.js';
 import PageNav from './views/PageNav.js';
 import LoadingModal from './views/modals/Loading';
 import StartupLoadingModal from './views/modals/StartupLoading';
@@ -405,6 +406,12 @@ function start() {
         app.loadingModal.close();
         location.hash = location.hash || app.profile.id;
         Backbone.history.start();
+
+        // load chat
+        // app.chat = new Chat({
+        //   collection: new 
+        // });
+        getChatContainer().append(app.chat.render().el);
       });
     });
   });

--- a/js/start.js
+++ b/js/start.js
@@ -11,6 +11,7 @@ import LocalSettings from './models/LocalSettings';
 import ObRouter from './router';
 import { getChatContainer } from './utils/selectors';
 import Chat from './views/chat/Chat.js';
+import ChatConversations from './collections/ChatConversations';
 import PageNav from './views/PageNav.js';
 import LoadingModal from './views/modals/Loading';
 import StartupLoadingModal from './views/modals/StartupLoading';
@@ -408,10 +409,15 @@ function start() {
         Backbone.history.start();
 
         // load chat
-        // app.chat = new Chat({
-        //   collection: new 
-        // });
-        getChatContainer().append(app.chat.render().el);
+        const chatConvos = new ChatConversations();
+
+        chatConvos.once('request', (cl, xhr) => {
+          xhr.always(getChatContainer().append(app.chat.el));
+        });
+
+        app.chat = new Chat({
+          collection: chatConvos,
+        });
       });
     });
   });

--- a/js/start.js
+++ b/js/start.js
@@ -420,6 +420,8 @@ function start() {
         });
 
         chatConvos.fetch();
+
+        $('#chatCloseBtn').on('click', () => (app.chat.close()));
       });
     });
   });

--- a/js/start.js
+++ b/js/start.js
@@ -416,7 +416,7 @@ function start() {
         const chatConvos = new ChatHeads();
 
         chatConvos.once('request', (cl, xhr) => {
-          xhr.always(app.chat.attach(getChatContainer()));
+          xhr.always(() => app.chat.attach(getChatContainer()));
         });
 
         app.chat = new Chat({

--- a/js/start.js
+++ b/js/start.js
@@ -471,9 +471,6 @@ function connectToServer() {
 let connectedAtLeastOnce = false;
 
 serverConnectEvents.on('connected', () => {
-  // getChatContainer().removeClass('hide');
-  if (app.chat) app.chat.show();
-
   app.connectionManagmentModal.setModalOptions({
     dismissOnEscPress: true,
     showCloseButton: true,
@@ -484,6 +481,7 @@ serverConnectEvents.on('connected', () => {
   } else {
     connectedAtLeastOnce = true;
     app.connectionManagmentModal.close();
+    if (app.chat) app.chat.show();
   }
 });
 
@@ -495,8 +493,11 @@ serverConnectEvents.on('disconnect', () => {
     showCloseButton: false,
   });
 
-  // getChatContainer().addClass('hide');
-  if (app.chat) app.chat.hide();
+  if (app.chat) {
+    app.chat.close();
+    app.chat.hide();
+  }
+
   app.pageNav.navigable = false;
   app.connectionManagmentModal.open();
 });

--- a/js/start.js
+++ b/js/start.js
@@ -420,7 +420,6 @@ function start() {
         });
 
         chatConvos.fetch();
-
         $('#chatCloseBtn').on('click', () => (app.chat.close()));
       });
     });

--- a/js/start.js
+++ b/js/start.js
@@ -11,7 +11,7 @@ import LocalSettings from './models/LocalSettings';
 import ObRouter from './router';
 import { getChatContainer } from './utils/selectors';
 import Chat from './views/chat/Chat.js';
-import ChatConversations from './collections/ChatConversations';
+import ChatHeads from './collections/ChatHeads';
 import PageNav from './views/PageNav.js';
 import LoadingModal from './views/modals/Loading';
 import StartupLoadingModal from './views/modals/StartupLoading';
@@ -409,7 +409,7 @@ function start() {
         Backbone.history.start();
 
         // load chat
-        const chatConvos = new ChatConversations();
+        const chatConvos = new ChatHeads();
 
         chatConvos.once('request', (cl, xhr) => {
           xhr.always(app.chat.attach(getChatContainer()));

--- a/js/start.js
+++ b/js/start.js
@@ -412,12 +412,14 @@ function start() {
         const chatConvos = new ChatConversations();
 
         chatConvos.once('request', (cl, xhr) => {
-          xhr.always(getChatContainer().append(app.chat.el));
+          xhr.always(app.chat.attach(getChatContainer()));
         });
 
         app.chat = new Chat({
           collection: chatConvos,
         });
+
+        chatConvos.fetch();
       });
     });
   });
@@ -464,7 +466,8 @@ function connectToServer() {
 let connectedAtLeastOnce = false;
 
 serverConnectEvents.on('connected', () => {
-  getChatContainer().removeClass('hide');
+  // getChatContainer().removeClass('hide');
+  if (app.chat) app.chat.show();
 
   app.connectionManagmentModal.setModalOptions({
     dismissOnEscPress: true,
@@ -487,7 +490,8 @@ serverConnectEvents.on('disconnect', () => {
     showCloseButton: false,
   });
 
-  getChatContainer().addClass('hide');
+  // getChatContainer().addClass('hide');
+  if (app.chat) app.chat.hide();
   app.pageNav.navigable = false;
   app.connectionManagmentModal.open();
 });

--- a/js/templates/chat/chat.html
+++ b/js/templates/chat/chat.html
@@ -1,11 +1,11 @@
 <div class="chatWrapper">
   <div class="js-chatHeadsContainer"></div>
 </div>
-<div class="topUnreadBanner clrE1 clrTOnEmph">
+<a class="topUnreadBanner js-topUnreadBanner clrE1 clrTOnEmph">
   <span class="fullText"><%= ob.polyT('chat.unreadMessages', { arrow: '▲' }) %></span>
   <span class="arrowOnly">▲</span>
-</div>
-<div class="bottomUnreadBanner clrE1 clrTOnEmph">
+</a>
+<a class="bottomUnreadBanner js-bottomUnreadBanner clrE1 clrTOnEmph">
   <span class="fullText"><%= ob.polyT('chat.unreadMessages', { arrow: '▼' }) %></span>
   <span class="arrowOnly">▼</span>
-</div>
+</a>

--- a/js/templates/chat/chat.html
+++ b/js/templates/chat/chat.html
@@ -1,6 +1,4 @@
-<div class="chatWrapper">
-  <div class="js-chatHeadsContainer"></div>
-</div>
+<div class="js-chatHeadsContainer"></div>
 <a class="topUnreadBanner js-topUnreadBanner clrE1 clrTOnEmph">
   <span class="fullText"><%= ob.polyT('chat.unreadMessages', { arrow: '▲' }) %></span>
   <span class="arrowOnly">▲</span>

--- a/js/templates/chat/chat.html
+++ b/js/templates/chat/chat.html
@@ -1,6 +1,3 @@
-<div class="js-close chatCloseBtn ion-ios-close-empty iconBtn clrP clrBr clrT2 clrSh3"></div>
-<div class="chatScrollWrapper">
-  <div class="chatWrapper flexColRows gutterV">
-    <div class="js-chatHeadsContainer"></div>
-  </div>
+<div class="chatWrapper flexColRows gutterV">
+  <div class="js-chatHeadsContainer"></div>
 </div>

--- a/js/templates/chat/chat.html
+++ b/js/templates/chat/chat.html
@@ -1,3 +1,24 @@
+<% if (ob.fetching) { %>
+<div class="flex gutterHSm js-fetchStateHead" style="width: 225px; margin-top: 10px;">
+  <a class="padTn"><%= ob.spinner() %></a>
+  <div class="contentBox padSm clrBr clrP clrSh1 tx6" style="width: 177px">
+    <span class="tx6"><%= ob.polyT('chat.fetchingConversations') %></span>
+  </div>
+</div>
+<% } else if (ob.fetchError) { %>
+<div class="flex gutterHSm js-fetchStateHead" style="width: 225px; margin-top: 10px;">
+  <a class='pad clrTErr tx1 ion-android-warning'></a>
+  <div class="contentBox padSm clrBr clrP clrSh1 tx6" style="width: 177px">
+    <% if (!ob.fetchErrorMessage) { %>
+    <span class="tx6"><%= ob.polyT('chat.errorFetching') %></span>
+    <% } else { %>
+    <span class="tx6"><%= ob.polyT('chat.errorFetchingWithMessage', { msg: ob.fetchErrorMessage }) %></span>
+    <% } %>
+    <div><a class="tx6 js-retryFetchConvos">Retry</a></div>
+  </div>
+</div>
+<% } %>
+
 <div class="js-chatHeadsContainer"></div>
 <a class="topUnreadBanner js-topUnreadBanner clrE1 clrTOnEmph">
   <span class="fullText"><%= ob.polyT('chat.unreadMessages', { arrow: '▲' }) %></span>

--- a/js/templates/chat/chat.html
+++ b/js/templates/chat/chat.html
@@ -1,0 +1,31 @@
+<div class="chatWrapper flexColRows gutterV">
+  <div>
+    <div class="flex gutterH">
+      <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+      <div class="contentBox pad clrBr clrP noOverflow">
+        <span class="tx6">
+          <b>@handle</b> example message that fades out
+        </span>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="flex gutterH">
+      <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+      <div class="contentBox pad clrBr clrP noOverflow">
+        <span class="tx6">
+          <b>@handle</b> example message that fades out
+        </span>
+      </div>
+    </div>
+  </div><div>
+    <div class="flex gutterH">
+      <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+      <div class="contentBox pad clrBr clrP noOverflow">
+        <span class="tx6">
+          <b>@handle</b> example message that fades out
+        </span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/js/templates/chat/chat.html
+++ b/js/templates/chat/chat.html
@@ -1,3 +1,3 @@
-<div class="chatWrapper flexColRows gutterV">
+<div class="chatWrapper">
   <div class="js-chatHeadsContainer"></div>
 </div>

--- a/js/templates/chat/chat.html
+++ b/js/templates/chat/chat.html
@@ -1,31 +1,6 @@
-<div class="chatWrapper flexColRows gutterV">
-  <div>
-    <div class="flex gutterH">
-      <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
-      <div class="contentBox pad clrBr clrP noOverflow">
-        <span class="tx6">
-          <b>@handle</b> example message that fades out
-        </span>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div class="flex gutterH">
-      <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
-      <div class="contentBox pad clrBr clrP noOverflow">
-        <span class="tx6">
-          <b>@handle</b> example message that fades out
-        </span>
-      </div>
-    </div>
-  </div><div>
-    <div class="flex gutterH">
-      <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink js-navListBtn" style="background-image: url('../imgs/defaultAvatar.png')"></a>
-      <div class="contentBox pad clrBr clrP noOverflow">
-        <span class="tx6">
-          <b>@handle</b> example message that fades out
-        </span>
-      </div>
-    </div>
+<div class="js-close chatCloseBtn ion-ios-close-empty iconBtn clrP clrBr clrT2 clrSh3"></div>
+<div class="chatScrollWrapper">
+  <div class="chatWrapper flexColRows gutterV">
+    <div class="js-chatHeadsContainer"></div>
   </div>
 </div>

--- a/js/templates/chat/chat.html
+++ b/js/templates/chat/chat.html
@@ -1,3 +1,11 @@
 <div class="chatWrapper">
   <div class="js-chatHeadsContainer"></div>
 </div>
+<div class="topUnreadBanner clrE1 clrTOnEmph">
+  <span class="fullText"><%= ob.polyT('chat.unreadMessages', { arrow: '▲' }) %></span>
+  <span class="arrowOnly">▲</span>
+</div>
+<div class="bottomUnreadBanner clrE1 clrTOnEmph">
+  <span class="fullText"><%= ob.polyT('chat.unreadMessages', { arrow: '▼' }) %></span>
+  <span class="arrowOnly">▼</span>
+</div>

--- a/js/templates/chat/chatHead.html
+++ b/js/templates/chat/chatHead.html
@@ -1,0 +1,8 @@
+<div class="flexVCent gutterHSm">
+  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+  <div class="contentBox padSm clrBr clrP noOverflow">
+    <span class="tx6">
+      <b>@handle</b> <%= ob.lastMessage %>
+    </span>
+  </div>
+</div>

--- a/js/templates/chat/chatHead.html
+++ b/js/templates/chat/chatHead.html
@@ -7,5 +7,5 @@
   </div>
 </div>
 <% if (ob.unread) { %>
-<div class="disc unreadBadge clrE1 clrTOnEmph clrBr2 clrSh1"><%= ob.unread %></div>
+<div class="disc unreadBadge clrE1 clrTOnEmph clrBr2 clrSh1 <% if (ob.unread > 9) print('ellipsisShown') %>"><%= ob.unread > 9 ? '…' : ob.unread  %></div>
 <% } %>

--- a/js/templates/chat/chatHead.html
+++ b/js/templates/chat/chatHead.html
@@ -1,6 +1,6 @@
 <div class="flexVCent gutterHSm">
   <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" style="<%= ob.getAvatarBgImage(ob.avatarHashes || {}) %>"></a>
-  <div class="contentBox padSm clrBr clrP clrSh1 noOverflow">
+  <div class="contentBox headContent clrBr clrP clrSh1 noOverflow">
     <span class="tx6">
       <span class="handleGuid noOverflow <% if (ob.unread) print('txB') %>"><%= ob.handle ? `@${ob.handle}` : ob.peerId %>:</span> <%= ob.lastMessage %>
     </span>

--- a/js/templates/chat/chatHead.html
+++ b/js/templates/chat/chatHead.html
@@ -1,8 +1,11 @@
 <div class="flexVCent gutterHSm">
   <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" style="background-image: url('../imgs/defaultAvatar.png')"></a>
-  <div class="contentBox padSm clrBr clrP noOverflow">
+  <div class="contentBox padSm clrBr clrP clrSh1 noOverflow">
     <span class="tx6">
-      <b>@handle</b> <%= ob.lastMessage %>
+      <span class="handleGuid noOverflow <% if (ob.unread) print('txB') %>"><%= ob.peerId %>:</span> <%= ob.lastMessage %>
     </span>
   </div>
 </div>
+<% if (ob.unread) { %>
+<div class="disc unreadBadge clrE1 clrTOnEmph clrBr2 clrSh1"><%= ob.unread %></div>
+<% } %>

--- a/js/templates/chat/chatHead.html
+++ b/js/templates/chat/chatHead.html
@@ -1,8 +1,8 @@
 <div class="flexVCent gutterHSm">
-  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" style="background-image: url('../imgs/defaultAvatar.png')"></a>
+  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" style="<%= ob.getAvatarBgImage(ob.avatarHashes || {}) %>"></a>
   <div class="contentBox padSm clrBr clrP clrSh1 noOverflow">
     <span class="tx6">
-      <span class="handleGuid noOverflow <% if (ob.unread) print('txB') %>"><%= ob.peerId %>:</span> <%= ob.lastMessage %>
+      <span class="handleGuid noOverflow <% if (ob.unread) print('txB') %>"><%= ob.handle ? `@${ob.handle}` : ob.peerId %>:</span> <%= ob.lastMessage %>
     </span>
   </div>
 </div>

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -1,16 +1,8 @@
 <div class="clrBr clrP clrBr flexVCent gutterH padSm convoHeader" style="height: 50px">
-  <div class="js-convoProfileHeaderContainer flexExpand">
-    <div class="flexVCent gutterH">
-      <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" style="background-image: url('../imgs/defaultAvatar.png')""></a>
-      <div class="tx6">
-        <div class="rowTn">@hipHopper</div>
-        <div>📍Chinatown, West</div>
-      </div>
-    </div>
-  </div>
+  <div class="js-convoProfileHeaderContainer flexExpand"></div>
   <div class="btnStrip">
     <a class="btn clrBr clrP clrSh2 ion-android-more-vertical iconBtn"></a>
-    <a class="btn clrBr clrP clrSh2 ion-ios-close-empty iconBtn"></a>
+    <a class="btn clrBr clrP clrSh2 ion-ios-close-empty iconBtn js-closeConvo"></a>
   </div>
 </div>
 <div class="js-convoMessagesContainer flexExpand"></div>

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -12,7 +12,9 @@
     <a class="clrT js-blockUser"><%= ob.polyT('chat.conversation.subMenu.blockUser') %></a>
     <a class="clrT"><%= ob.polyT('chat.conversation.subMenu.deleteConvo') %></a>
   </div>
-  <div class="convoMessagesWrap tx6 js-convoMessagesWrap">
+  <div class="convoMessagesWindow tx6 js-convoMessagesWindow">
+    <% const username = `<span class="typingUsername noOverflow">${ob.profile.handle || ob.guid}</span>`; %>
+    <div class="typingIndicator noOverflow clrBr clrP clrT2 clrSh1"><%= ob.polyT('chat.conversation.typingIndicator', { user: username }) %></div>
     <%= ob.spinner() %>
     <%
       const retryLink = `<a class="js-retryLoadMessage">${ob.polyT('chat.conversation.retryLink')}</a>`;

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -13,8 +13,7 @@
     <a class="clrT"><%= ob.polyT('chat.conversation.subMenu.deleteConvo') %></a>
   </div>
   <div class="convoMessagesWindow tx6 js-convoMessagesWindow">
-    <% const username = `<span class="typingUsername noOverflow">${ob.profile.handle || ob.guid}</span>`; %>
-    <div class="typingIndicator noOverflow clrBr clrP clrT2 clrSh1"><%= ob.polyT('chat.conversation.typingIndicator', { user: username }) %></div>
+    <div class="typingIndicator noOverflow clrBr clrP clrT2 clrSh1 js-typingIndicator"><%= ob.typingIndicator %></div>
     <%= ob.spinner() %>
     <%
       const retryLink = `<a class="js-retryLoadMessage">${ob.polyT('chat.conversation.retryLink')}</a>`;

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -7,10 +7,13 @@
 </div>
 <div class="posR flexExpand">
   <div class="overlay hide js-messagesOverlay"></div>
+  <div class="overlay deletingOverlay js-deletingOverlay">
+    <div><%= ob.polyT('chat.conversation.deletingOverlayText') %></div>
+  </div>
   <div class="subMenu boxList clrBr clrP clrSh1 hide js-subMenu">
     <a class="clrT" href="<%= ob.guid %>"><%= ob.polyT('chat.conversation.subMenu.viewPage') %></a>
     <a class="clrT js-blockUser"><%= ob.polyT('chat.conversation.subMenu.blockUser') %></a>
-    <a class="clrT"><%= ob.polyT('chat.conversation.subMenu.deleteConvo') %></a>
+    <a class="clrT js-deleteConversation deleteConvoMenuItem"><%= ob.polyT('chat.conversation.subMenu.deleteConvo') %></a>
   </div>
   <div class="convoMessagesWindow tx6 js-convoMessagesWindow">
     <div class="typingIndicator noOverflow clrBr clrP clrT2 clrSh1 js-typingIndicator"><%= ob.typingIndicator %></div>

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -12,19 +12,14 @@
     <a class="clrT js-blockUser"><%= ob.polyT('chat.conversation.subMenu.blockUser') %></a>
     <a class="clrT"><%= ob.polyT('chat.conversation.subMenu.deleteConvo') %></a>
   </div>
-  <div class="convoMessagesWrap tx6">
+  <div class="convoMessagesWrap tx6 js-convoMessagesWrap">
     <%= ob.spinner() %>
     <%
       const retryLink = `<a class="js-retryLoadMessage">${ob.polyT('chat.conversation.retryLink')}</a>`;
       const loadMessagesError = ob.polyT('chat.conversation.loadMessagesError', { retryLink: retryLink });
     %>
     <div class="clrTErr messagesFetchError js-loadMessagesError <% if (!ob.showLoadMessagesError) print('hide') %>"><%= loadMessagesError %></div>
-    <div class="js-convoMessagesContainer hide">
-      <p>welcome to the jungle</p>
-      <p>we've got fun and games</p>
-      <p>we've got everything you wanted</p>
-      <p>and we don't even know the names</p>
-    </div>
+    <div class="js-convoMessagesContainer"></div>
   </div>
 </div>
 <div class="clrBr clrP convoFooter">

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -1,13 +1,30 @@
 <div class="clrBr clrP clrBr flexVCent gutterH padSm convoHeader" style="height: 50px">
   <div class="js-convoProfileHeaderContainer flexExpand"></div>
   <div class="btnStrip">
-    <a class="btn clrBr clrP clrSh2 ion-android-more-vertical iconBtn"></a>
+    <a class="btn clrBr clrP clrSh2 ion-android-more-vertical iconBtn js-subMenuTrigger"></a>
     <a class="btn clrBr clrP clrSh2 ion-ios-close-empty iconBtn js-closeConvo"></a>
   </div>
 </div>
-<div class="js-convoMessagesContainer flexExpand"></div>
+<div class="posR flexExpand">
+  <div class="overlay hide js-messagesOverlay"></div>
+  <div class="subMenu boxList clrBr clrP clrSh1 hide js-subMenu">
+    <a class="clrT" href="<%= ob.guid %>"><%= ob.polyT('chat.conversation.subMenu.viewPage') %></a>
+    <a class="clrT js-blockUser"><%= ob.polyT('chat.conversation.subMenu.blockUser') %></a>
+    <a class="clrT"><%= ob.polyT('chat.conversation.subMenu.deleteConvo') %></a>
+  </div>
+  <div class="js-convoMessagesContainer convoMessagesWrap">
+    <br />
+    <br />
+    Hello world 😀<br />
+    Hello world 😀<br />
+    Hello world 😀<br />
+    Hello world 😀<br />
+    Hello world 😀<br />
+    Hello world 😀<br />
+  </div>
+</div>
 <div class="clrBr clrP convoFooter">
-  <div class="flexCent">
+  <div class="flexCent padTn">
     <input type="text" class="clrP js-inputMessage" placeholder="<%= ob.polyT('chat.conversation.messageInputPlaceholder') %>" />
     <div class="pad tx5 js-emojiMenuTrigger">😀</div>
   </div>

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -8,7 +8,7 @@
 <div class="js-convoMessagesContainer flexExpand"></div>
 <div class="clrBr clrP convoFooter">
   <div class="flexCent">
-    <input type="text" class="clrP js-inputMessage" placeholder="Enter message… (translate me)" />
+    <input type="text" class="clrP js-inputMessage" placeholder="<%= ob.polyT('chat.conversation.messageInputPlaceholder') %>" />
     <div class="pad tx5 js-emojiMenuTrigger">😀</div>
   </div>
 </div>

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -12,15 +12,19 @@
     <a class="clrT js-blockUser"><%= ob.polyT('chat.conversation.subMenu.blockUser') %></a>
     <a class="clrT"><%= ob.polyT('chat.conversation.subMenu.deleteConvo') %></a>
   </div>
-  <div class="js-convoMessagesContainer convoMessagesWrap">
-    <br />
-    <br />
-    Hello world 😀<br />
-    Hello world 😀<br />
-    Hello world 😀<br />
-    Hello world 😀<br />
-    Hello world 😀<br />
-    Hello world 😀<br />
+  <div class="convoMessagesWrap tx6">
+    <%= ob.spinner() %>
+    <%
+      const retryLink = `<a class="js-retryLoadMessage">${ob.polyT('chat.conversation.retryLink')}</a>`;
+      const loadMessagesError = ob.polyT('chat.conversation.loadMessagesError', { retryLink: retryLink });
+    %>
+    <div class="clrTErr messagesFetchError js-loadMessagesError <% if (!ob.showLoadMessagesError) print('hide') %>"><%= loadMessagesError %></div>
+    <div class="js-convoMessagesContainer hide">
+      <p>welcome to the jungle</p>
+      <p>we've got fun and games</p>
+      <p>we've got everything you wanted</p>
+      <p>and we don't even know the names</p>
+    </div>
   </div>
 </div>
 <div class="clrBr clrP convoFooter">

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -1,8 +1,22 @@
-<div>
-  <div class="js-convoHeaderContainer"></div>
+<div class="clrBr clrP clrBr flexVCent gutterH padSm convoHeader" style="height: 50px">
+  <div class="js-convoProfileHeaderContainer flexExpand">
+    <div class="flexVCent gutterH">
+      <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" style="background-image: url('../imgs/defaultAvatar.png')""></a>
+      <div class="tx6">
+        <div class="rowTn">@hipHopper</div>
+        <div>📍Chinatown, West</div>
+      </div>
+    </div>
+  </div>
+  <div class="btnStrip">
+    <a class="btn clrBr clrP clrSh2 ion-android-more-vertical iconBtn"></a>
+    <a class="btn clrBr clrP clrSh2 ion-ios-close-empty iconBtn"></a>
+  </div>
 </div>
-<div class="js-convoMessagesContainer"></div>
-<div class="flexCent">
-  <input type="text" class="js-inputMessage" placeholder="Enter message… (translate me)" />
-  <div>😀</div>
+<div class="js-convoMessagesContainer flexExpand"></div>
+<div class="clrBr clrP convoFooter">
+  <div class="flexCent">
+    <input type="text" class="clrP js-inputMessage" placeholder="Enter message… (translate me)" />
+    <div class="pad tx5 js-emojiMenuTrigger">😀</div>
+  </div>
 </div>

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -28,7 +28,7 @@
 </div>
 <div class="clrBr clrP convoFooter">
   <div class="flexCent padTn">
-    <input type="text" class="clrP js-inputMessage" placeholder="<%= ob.polyT('chat.conversation.messageInputPlaceholder') %>" />
+    <input type="text" class="clrP js-inputMessage" placeholder="<%= ob.polyT('chat.conversation.messageInputPlaceholder') %>" maxlength="<%= ob.maxMessageLength %>" />
     <div class="pad tx5 js-emojiMenuTrigger">😀</div>
   </div>
 </div>

--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -1,0 +1,8 @@
+<div>
+  <div class="js-convoHeaderContainer"></div>
+</div>
+<div class="js-convoMessagesContainer"></div>
+<div class="flexCent">
+  <input type="text" class="js-inputMessage" placeholder="Enter message… (translate me)" />
+  <div>😀</div>
+</div>

--- a/js/templates/chat/convoMessage.html
+++ b/js/templates/chat/convoMessage.html
@@ -1,6 +1,6 @@
 <% if (!ob.outgoing) { %>
 <div class="gutterHSm flex rowLg">
-  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="<%= ob.getAvatarBgImage(ob.avatarHashes) %>" <% } %>></a>
+  <a  href="#<%= ob.peerId %>" class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="<%= ob.getAvatarBgImage(ob.avatarHashes) %>" <% } %>></a>
   <div class="posR flexExpand">
     <div class="contentBox msgContentBox clrBr clrP clrSh1">
       <span class="tx6"><%= ob.message %></span>
@@ -25,6 +25,6 @@
     </div>
     <% } %>      
   </div>
-  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="<%= ob.getAvatarBgImage(ob.avatarHashes) %>" <% } %>></a>  
+  <a href="#<%= ob.ownGuid %>" class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="<%= ob.getAvatarBgImage(ob.avatarHashes) %>" <% } %>></a>  
 </div>
 <% } %>

--- a/js/templates/chat/convoMessage.html
+++ b/js/templates/chat/convoMessage.html
@@ -1,33 +1,31 @@
 <% if (!ob.outgoing) { %>
-<div class="row">
-  <div class="flexVCent gutterHSm">
-    <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>  
-    <div class="contentBox padSm clrBr clrP clrSh1">
+<div class="gutterHSm flex rowLg">
+  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>
+  <div class="posR flexExpand">
+    <div class="contentBox msgContentBox clrBr clrP clrSh1">
       <span class="tx6"><%= ob.message %></span>
     </div>
-  </div>
-  <% if (ob.showTimestampLine) { %>
-  <div>
-    <div style="margin-left: 45px">
+    <% if (ob.showTimestampLine) { %>
+    <div class="timestampLine posA">
       <span class="clrTEm ion-checkmark <% if (!ob.read) print('h2ide') %>"></span>
-      <span><%= ob.moment(ob.timestamp).fromNow() %></span>
+      <span class="clrT2"><%= ob.moment(ob.timestamp).fromNow() %></span>
     </div>
+    <% } %>      
   </div>
-  <% } %>
+</div>
 <% } else { %>
-<div class="row">
-  <div class="flexVCent flexHRight gutterHSm">
-    <div class="contentBox padSm clrBr clrP clrSh1">
+<div class="flexHRight gutterHSm rowLg">
+  <div class="posR flexExpand">
+    <div class="contentBox msgContentBox clrBr clrP clrSh1">
       <span class="tx6"><%= ob.message %></span>
     </div>
-    <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>  
-  </div>
-  <% if (ob.showTimestampLine) { %>
-  <div class="flexHRight">
-    <div style="margin-right: 45px">
+    <% if (ob.showTimestampLine) { %>
+    <div class="timestampLine posA" style="right: 2px;">
       <span class="clrTEm ion-checkmark <% if (!ob.read) print('h2ide') %>"></span>
-      <span><%= ob.moment(ob.timestamp).fromNow() %></span>
+      <span class="clrT2"><%= ob.moment(ob.timestamp).fromNow() %></span>
     </div>
+    <% } %>      
   </div>
-  <% } %>
+  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>  
+</div>
 <% } %>

--- a/js/templates/chat/convoMessage.html
+++ b/js/templates/chat/convoMessage.html
@@ -1,35 +1,33 @@
 <% if (!ob.outgoing) { %>
-<div class="flexVCent gutterHSm rowLg">
-  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>
-  <div class="posR">
-    <div class="contentBox padSm clrBr clrP clrSh1 rowSm">
+<div class="row">
+  <div class="flexVCent gutterHSm">
+    <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>  
+    <div class="contentBox padSm clrBr clrP clrSh1">
       <span class="tx6"><%= ob.message %></span>
     </div>
-    <% if (ob.showTimestampLine) { %>
-    <div class="posA">
+  </div>
+  <% if (ob.showTimestampLine) { %>
+  <div>
+    <div style="margin-left: 45px">
       <span class="clrTEm ion-checkmark <% if (!ob.read) print('h2ide') %>"></span>
       <span><%= ob.moment(ob.timestamp).fromNow() %></span>
     </div>
-    <% } %>    
   </div>
-</div>
+  <% } %>
 <% } else { %>
-<div class="flexHRight">
-  <div>
-    <div class="flexVCent gutterHSm rowLg">
-      <div class="posR">
-        <div class="contentBox padSm clrBr clrP clrSh1 rowSm">
-          <span class="tx6"><%= ob.message %></span>
-        </div>
-        <% if (ob.showTimestampLine) { %>
-        <div class="posA">
-          <span class="clrTEm ion-checkmark <% if (!ob.read) print('h2ide') %>"></span>
-          <span><%= ob.moment(ob.timestamp).fromNow() %></span>
-        </div>
-        <% } %>    
-      </div>
-      <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>  
+<div class="row">
+  <div class="flexVCent flexHRight gutterHSm">
+    <div class="contentBox padSm clrBr clrP clrSh1">
+      <span class="tx6"><%= ob.message %></span>
+    </div>
+    <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>  
+  </div>
+  <% if (ob.showTimestampLine) { %>
+  <div class="flexHRight">
+    <div style="margin-right: 45px">
+      <span class="clrTEm ion-checkmark <% if (!ob.read) print('h2ide') %>"></span>
+      <span><%= ob.moment(ob.timestamp).fromNow() %></span>
     </div>
   </div>
-</div>
+  <% } %>
 <% } %>

--- a/js/templates/chat/convoMessage.html
+++ b/js/templates/chat/convoMessage.html
@@ -7,7 +7,7 @@
     </div>
     <% if (ob.showTimestampLine) { %>
     <div class="timestampLine posA">
-      <span class="clrT2"><%= ob.moment(ob.timestamp).fromNow() %></span>
+      <span class="clrT2"><%= ob.moment(ob.timestamp).format('l LT') %></span>
     </div>
     <% } %>      
   </div>
@@ -21,7 +21,7 @@
     <% if (ob.showTimestampLine) { %>
     <div class="timestampLine posA" style="right: 2px;">
       <span class="clrTEm ion-checkmark <% if (!ob.showAsRead) print('hide') %>"></span>
-      <span class="clrT2"><%= ob.moment(ob.timestamp).fromNow() %></span>
+      <span class="clrT2"><%= ob.moment(ob.timestamp).format('l LT') %></span>
     </div>
     <% } %>      
   </div>

--- a/js/templates/chat/convoMessage.html
+++ b/js/templates/chat/convoMessage.html
@@ -7,7 +7,6 @@
     </div>
     <% if (ob.showTimestampLine) { %>
     <div class="timestampLine posA">
-      <span class="clrTEm ion-checkmark <% if (!ob.read) print('hide') %>"></span>
       <span class="clrT2"><%= ob.moment(ob.timestamp).fromNow() %></span>
     </div>
     <% } %>      

--- a/js/templates/chat/convoMessage.html
+++ b/js/templates/chat/convoMessage.html
@@ -20,7 +20,7 @@
     </div>
     <% if (ob.showTimestampLine) { %>
     <div class="timestampLine posA" style="right: 2px;">
-      <span class="clrTEm ion-checkmark <% if (!ob.read) print('hide') %>"></span>
+      <span class="clrTEm ion-checkmark <% if (!ob.showAsRead) print('hide') %>"></span>
       <span class="clrT2"><%= ob.moment(ob.timestamp).fromNow() %></span>
     </div>
     <% } %>      

--- a/js/templates/chat/convoMessage.html
+++ b/js/templates/chat/convoMessage.html
@@ -1,13 +1,13 @@
 <% if (!ob.outgoing) { %>
 <div class="gutterHSm flex rowLg">
-  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>
+  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="<%= ob.getAvatarBgImage(ob.avatarHashes) %>" <% } %>></a>
   <div class="posR flexExpand">
     <div class="contentBox msgContentBox clrBr clrP clrSh1">
       <span class="tx6"><%= ob.message %></span>
     </div>
     <% if (ob.showTimestampLine) { %>
     <div class="timestampLine posA">
-      <span class="clrTEm ion-checkmark <% if (!ob.read) print('h2ide') %>"></span>
+      <span class="clrTEm ion-checkmark <% if (!ob.read) print('hide') %>"></span>
       <span class="clrT2"><%= ob.moment(ob.timestamp).fromNow() %></span>
     </div>
     <% } %>      
@@ -21,11 +21,11 @@
     </div>
     <% if (ob.showTimestampLine) { %>
     <div class="timestampLine posA" style="right: 2px;">
-      <span class="clrTEm ion-checkmark <% if (!ob.read) print('h2ide') %>"></span>
+      <span class="clrTEm ion-checkmark <% if (!ob.read) print('hide') %>"></span>
       <span class="clrT2"><%= ob.moment(ob.timestamp).fromNow() %></span>
     </div>
     <% } %>      
   </div>
-  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>  
+  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="<%= ob.getAvatarBgImage(ob.avatarHashes) %>" <% } %>></a>  
 </div>
 <% } %>

--- a/js/templates/chat/convoMessage.html
+++ b/js/templates/chat/convoMessage.html
@@ -1,0 +1,35 @@
+<% if (!ob.outgoing) { %>
+<div class="flexVCent gutterHSm rowLg">
+  <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>
+  <div class="posR">
+    <div class="contentBox padSm clrBr clrP clrSh1 rowSm">
+      <span class="tx6"><%= ob.message %></span>
+    </div>
+    <% if (ob.showTimestampLine) { %>
+    <div class="posA">
+      <span class="clrTEm ion-checkmark <% if (!ob.read) print('h2ide') %>"></span>
+      <span><%= ob.moment(ob.timestamp).fromNow() %></span>
+    </div>
+    <% } %>    
+  </div>
+</div>
+<% } else { %>
+<div class="flexHRight">
+  <div>
+    <div class="flexVCent gutterHSm rowLg">
+      <div class="posR">
+        <div class="contentBox padSm clrBr clrP clrSh1 rowSm">
+          <span class="tx6"><%= ob.message %></span>
+        </div>
+        <% if (ob.showTimestampLine) { %>
+        <div class="posA">
+          <span class="clrTEm ion-checkmark <% if (!ob.read) print('h2ide') %>"></span>
+          <span><%= ob.moment(ob.timestamp).fromNow() %></span>
+        </div>
+        <% } %>    
+      </div>
+      <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink <% if (!ob.showAvatar) print('invisible') %>" <% if (ob.showAvatar) { %>style="background-image: url('../imgs/defaultAvatar.png')" <% } %>></a>  
+    </div>
+  </div>
+</div>
+<% } %>

--- a/js/templates/chat/convoProfileHeader.html
+++ b/js/templates/chat/convoProfileHeader.html
@@ -1,5 +1,5 @@
-<a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" style="<%= ob.getAvatarBgImage(ob.avatarHashes || {}) %>"></a>
+<a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" href="<%= ob.guid %>" style="<%= ob.getAvatarBgImage(ob.avatarHashes || {}) %>"></a>
 <div class="tx6">
-  <div class="rowTn handle noOverflow"><%= ob.handle ? `@${ob.handle}` : ob.guid %></div>
+  <a class="rowTn handle noOverflow clrT" href="<%= ob.guid %>"><%= ob.handle ? `@${ob.handle}` : ob.guid %></a>
   <div><%= ob.location ? `📍${ob.location}` : '' %></div>
 </div>

--- a/js/templates/chat/convoProfileHeader.html
+++ b/js/templates/chat/convoProfileHeader.html
@@ -1,0 +1,5 @@
+<a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" style="<%= ob.getAvatarBgImage(ob.avatarHashes || {}) %>"></a>
+<div class="tx6">
+  <div class="rowTn handle noOverflow"><%= ob.handle ? `@${ob.handle}` : ob.guid %></div>
+  <div><%= ob.location ? `📍${ob.location}` : '' %></div>
+</div>

--- a/js/templates/userPage/userPage.html
+++ b/js/templates/userPage/userPage.html
@@ -50,8 +50,8 @@
     <div>
       <div class="btnStrip floR clrSh2">
         <% if(ob.ownPage) { %>
-        <a class="btn clrP clrBr js-messageBtn"><%= ob.polyT('userPage.customize') %></a>
-        <a class="btn clrP clrBr js-messageBtn">Example Button</a>
+        <a class="btn clrP clrBr"><%= ob.polyT('userPage.customize') %></a>
+        <a class="btn clrP clrBr">Example Button</a>
         <% } else { %>
         <a class="btn clrP clrBr js-messageBtn"><%= ob.polyT('userPage.message') %></a>
         <a class="btn clrP clrBr js-followBtn">

--- a/js/utils/Socket.js
+++ b/js/utils/Socket.js
@@ -47,6 +47,8 @@ export default class {
     this._socket.onmessage = (...args) => {
       if (args[0] && args[0].data) {
         args[0].jsonData = JSON.parse(args[0].data);
+      } else {
+        args[0].jsonData = {};
       }
 
       this.trigger(...['message'].concat(args));

--- a/js/utils/serverConnect.js
+++ b/js/utils/serverConnect.js
@@ -54,19 +54,27 @@ export function getDebugLog() {
  * Returns an object with data about the current connection, incuding
  * the status (e.g. 'connecting', 'connected'...) and any relevant data
  * (e.g. the Socket instance, the Server Configuration model...).
- *
- * If you're looking to bind to Socket events, you would call this method
- * and then bind to the Socket instance that's returned. Keep in mind that
- * until the first connection is made, this method will return null, in which
- * case you'd wanted to wait until the 'connected' event to do your binding.
- *
- * But, since the app won't proceed out of Start.js, until a connection is
- * made, it's really only in Start.js that you need to wait for the event
- * and beyond Start.js you should just be able to get the socket via this
- * method.
  */
 export function getCurrentConnection() {
   return currentConnection;
+}
+
+/**
+ * Call this method to obtain the socket instance in order to bind socket events.
+ * If we are not currently connected to a server, this method will return false.
+ * For the most part, you could no-op in that case since as it is now the
+ * Connection Modal will overlay the app when there is no connection and any
+ * subsequent reconnection will result in the app re-starting.
+ */
+export function getSocket() {
+  const serverConnection = getCurrentConnection();
+  let returnVal = false;
+
+  if (serverConnection && serverConnection.status !== 'disconnected') {
+    returnVal = serverConnection.socket;
+  }
+
+  return returnVal;
 }
 
 function socketConnect(socket) {

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -201,6 +201,19 @@ export default class extends baseVw {
   _openConversation(guid, profilePromise) {
     this.open();
 
+    if (this.chatHeads) {
+      this.clearActiveChatHead();
+
+      // If there's a chat head, mark it as active
+      const chatHeadModel = this.collection.get(guid);
+
+      if (chatHeadModel) {
+        this.chatHeads.views[this.collection.indexOf(chatHeadModel)]
+          .$el
+          .addClass('active');
+      }
+    }
+
     if (this.conversation && this.conversation.guid === guid) {
       // In order for the chat head unread count to update properly, be sure to
       // open before marking convo as read.
@@ -278,7 +291,15 @@ export default class extends baseVw {
   }
 
   closeConversation() {
+    this.clearActiveChatHead();
     if (this.conversation) this.conversation.close();
+  }
+
+  clearActiveChatHead() {
+    if (this.chatHeads) {
+      this.chatHeads.views
+        .forEach(chatHead => chatHead.$el.removeClass('active'));
+    }
   }
 
   open() {

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -9,7 +9,6 @@ import Profile from '../../models/profile/Profile';
 import baseVw from '../baseVw';
 import ChatHeads from './ChatHeads';
 import Conversation from './Conversation';
-import moment from 'moment';
 
 export default class extends baseVw {
   constructor(options = {}) {
@@ -118,6 +117,17 @@ export default class extends baseVw {
 
     this.listenTo(this.conversation, 'convoMarkedAsRead',
       () => this.onConvoMarkedAsRead(guid));
+
+    this.listenTo(this.conversation, 'deleting',
+      (e) => {
+        e.request.done(() => {
+          this.collection.remove(e.guid);
+
+          if (this.conversation && this.conversation.guid === e.guid) {
+            this.conversation.close();
+          }
+        });
+      });
 
     this.$chatConvoContainer
       .append(this.conversation.render().el);
@@ -328,6 +338,7 @@ export default class extends baseVw {
 
       this.listenTo(this.chatHeads, 'chatHeadClick', this.onChatHeadClick);
       this.listenTo(this.chatHeads, 'rendered', this.onChatHeadsRendered);
+      this.listenTo(this.chatHeads, 'click')
 
       // It is important that both of the following occur before the chatHeads
       // view is rendered:

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -1,0 +1,67 @@
+// import $ from 'jquery';
+// import _ from 'underscore';
+import loadTemplate from '../../utils/loadTemplate';
+import baseVw from '../baseVw';
+
+export default class extends baseVw {
+  constructor(options = {}) {
+    if (!options.collection) {
+      throw new Error('Please provide a chat conversations collection.');
+    }
+
+    super(options);
+
+    // this._state = {
+    //   status: 'not-connected',
+    //   ...options.initialState || {},
+    // };
+  }
+
+  className() {
+    return 'chat';
+  }
+
+  events() {
+    return {
+      // 'click .js-btnConnect': 'onConnectClick',
+    };
+  }
+
+  // getState() {
+  //   return this._state;
+  // }
+
+  // setState(state, replace = false) {
+  //   let newState;
+
+  //   if (replace) {
+  //     this._state = {};
+  //   } else {
+  //     newState = _.extend({}, this._state, state);
+  //   }
+
+  //   if (!_.isEqual(this._state, newState)) {
+  //     this._state = newState;
+  //     this.render();
+  //   }
+
+  //   return this;
+  // }
+
+  // remove() {
+  //   super.remove();
+  // }
+
+  render() {
+    loadTemplate('chat/chat.html', (t) => {
+      this.$el.html(t({
+        // ...this.model.toJSON(),
+        // ...this._state,
+      }));
+
+      // this._$deleteConfirm = null;
+    });
+
+    return this;
+  }
+}

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -1,7 +1,9 @@
-// import $ from 'jquery';
+import $ from 'jquery';
 // import _ from 'underscore';
+import { getBody } from '../../utils/selectors';
 import loadTemplate from '../../utils/loadTemplate';
 import baseVw from '../baseVw';
+import ChatHeads from './ChatHeads';
 
 export default class extends baseVw {
   constructor(options = {}) {
@@ -15,6 +17,14 @@ export default class extends baseVw {
     //   status: 'not-connected',
     //   ...options.initialState || {},
     // };
+
+    this._isOpen = false;
+
+    this.listenTo(this.collection, 'sync', () => {
+      console.log('boom selecta');
+      window.boom = this.collection;
+      this.render();
+    });
   }
 
   className() {
@@ -52,14 +62,68 @@ export default class extends baseVw {
   //   super.remove();
   // }
 
+  onChatHeadClick() {
+    if (!this.isOpen) {
+      this.open();
+    }
+  }
+
+  open() {
+    this._isOpen = true;
+    getBody().addClass('chatOpen');
+  }
+
+  close() {
+    this._isOpen = false;
+    getBody().removeClass('chatOpen');
+  }
+
+  get isOpen() {
+    return this._isOpen;
+  }
+
+  // This chat view, in some cases, needs to know when it becomes visible,
+  // so please show it via this method.
+  show() {
+    this.$el.removeClass('hide');
+    return this;
+  }
+
+  hide() {
+    this.$el.addClass('hide');
+    return this;
+  }
+
+  // This chat view, in some cases, needs to know when it is attached to the dom,
+  // so please use this method to do so.
+  attach(container) {
+    if (!container || !(container instanceof $ && container[0] instanceof HTMLElement)) {
+      throw new Error('Please provide a container as a jQuery object or DOM element.');
+    }
+
+    $(container).append(this.el);
+    return this;
+  }
+
   render() {
     loadTemplate('chat/chat.html', (t) => {
       this.$el.html(t({
+        // chatHeads: this.collection.toJSON(),
         // ...this.model.toJSON(),
         // ...this._state,
       }));
 
       // this._$deleteConfirm = null;
+
+      if (this.chatHeads) this.chatHeads.remove();
+      this.chatHeads = this.createChild(ChatHeads, {
+        collection: this.collection,
+      });
+
+      this.listenTo(this.chatHeads, 'chatHeadClick', this.onChatHeadClick);
+
+      this.$('.js-chatHeadsContainer')
+        .append(this.chatHeads.render().el);
     });
 
     return this;

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -91,6 +91,9 @@ export default class extends baseVw {
     this.listenTo(this.conversation, 'clickCloseConvo',
       () => this.closeConversation());
 
+    this.listenTo(this.conversation, 'newOutgoingMessage',
+      (e) => this.onNewChatMessage(e.model.toJSON()));
+
     this.$chatConvoContainer
       .append(this.conversation.render().el);
 
@@ -148,13 +151,14 @@ export default class extends baseVw {
   }
 
   onSocketMessage(e) {
-    const msg = e.jsonData.message;
+    this.onNewChatMessage(e.jsonData.message);
+  }
 
+  onNewChatMessage(msg) {
     if (msg && !msg.subject) {
       const chatHead = this.collection.get(msg.peerId);
       const chatHeadData = {
         peerId: msg.peerId,
-        unread: 0,
         lastMessage: msg.message,
         outgoing: false,
       };

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -192,7 +192,6 @@ export default class extends baseVw {
   }
 
   onConvoMarkedAsRead(guid) {
-    console.log('on that mark that read yo what what');
     if (!guid) {
       throw new Error('Please provide a guid.');
     }

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -86,12 +86,21 @@ export default class extends baseVw {
     }
 
     if (this.conversation && this.conversation.guid === guid) {
+      getBody().addClass('chatConvoOpen');
       return;
 
       // For now we'll do nothing. An enhancement could be determining if the existing
       // convo is a.) still waiting on the profile b.) has an older profile than the one
-      // provided, and if so update the convo with the given profile
+      // provided, and if so update the convo with the given profile.
     }
+
+    if (chatHead) console.log(); // temporary. be happy linter.
+
+    getBody().addClass('chatConvoOpen');
+  }
+
+  closeConversation() {
+    getBody().removeClass('chatConvoOpen');
   }
 
   onScroll() {

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -263,7 +263,7 @@ export default class extends baseVw {
     let profilePromise;
 
     if (profile) {
-      // If the profile model is provided, well turn it into a deferred.
+      // If the profile model is provided, we'll turn it into a deferred.
       const deferred = $.Deferred();
       this.profileDeferreds[guid] = deferred;
       deferred.resolve(profile);

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -199,6 +199,8 @@ export default class extends baseVw {
    * Outside of this view, please use the "public" openConversation().
    */
   _openConversation(guid, profilePromise) {
+    this.open();
+
     if (this.conversation && this.conversation.guid === guid) {
       // In order for the chat head unread count to update properly, be sure to
       // open before marking convo as read.
@@ -244,7 +246,6 @@ export default class extends baseVw {
       .append(this.conversation.render().el);
 
     this.conversation.open();
-    this.open();
 
     if (oldConvo) oldConvo.remove();
   }

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -338,7 +338,6 @@ export default class extends baseVw {
 
       this.listenTo(this.chatHeads, 'chatHeadClick', this.onChatHeadClick);
       this.listenTo(this.chatHeads, 'rendered', this.onChatHeadsRendered);
-      this.listenTo(this.chatHeads, 'click')
 
       // It is important that both of the following occur before the chatHeads
       // view is rendered:

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -9,6 +9,7 @@ import Profile from '../../models/profile/Profile';
 import baseVw from '../baseVw';
 import ChatHeads from './ChatHeads';
 import Conversation from './Conversation';
+import moment from 'moment';
 
 export default class extends baseVw {
   constructor(options = {}) {
@@ -184,6 +185,7 @@ export default class extends baseVw {
       const chatHeadData = {
         peerId: msg.peerId,
         lastMessage: msg.message,
+        timestamp: msg.timestamp,
         outgoing: false,
         unread: 1,
       };
@@ -196,10 +198,13 @@ export default class extends baseVw {
           chatHeadData.unread = chatHead.get('unread') + 1;
         }
 
-        chatHead.set(chatHeadData);
-      } else {
-        this.collection.add(chatHeadData, { at: 0 });
+        this.collection.remove(chatHead);
       }
+
+      this.collection.add(chatHeadData, {
+        at: 0,
+        merge: true,
+      });
     }
   }
 

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -4,8 +4,10 @@ import '../../utils/velocity';
 import { getBody } from '../../utils/selectors';
 import { isScrolledIntoView } from '../../utils/dom';
 import loadTemplate from '../../utils/loadTemplate';
+import Profile from '../../models/profile/Profile';
 import baseVw from '../baseVw';
 import ChatHeads from './ChatHeads';
+import Conversation from './Conversation';
 
 export default class extends baseVw {
   constructor(options = {}) {
@@ -66,6 +68,29 @@ export default class extends baseVw {
   onChatHeadClick() {
     if (!this.isOpen) {
       this.open();
+    } else {
+      // if (this.currentConversation)
+    }
+  }
+
+  openConversation(guid, profile, chatHead) {
+    if (!profile ||
+      !(profile instanceof Profile) ||
+      !profile.then) {
+      throw new Error('Please provide a profile model or a promise that provides' +
+        ' one when it resolves.');
+
+      // If providing a promise, please pass the Profile instance into the
+      // resolve handler, so the following will work:
+      // promise.done(profile => { // i gotz me a profile model! });
+    }
+
+    if (this.conversation && this.conversation.guid === guid) {
+      return;
+
+      // For now we'll do nothing. An enhancement could be determining if the existing
+      // convo is a.) still waiting on the profile b.) has an older profile than the one
+      // provided, and if so update the convo with the given profile
     }
   }
 
@@ -215,6 +240,13 @@ export default class extends baseVw {
 
       this.$('.js-chatHeadsContainer')
         .append(this.chatHeads.render().el);
+
+      this.conversation = this.createChild(Conversation, {
+        guid: 'abc123',
+        profile: $.Deferred().promise(),
+      });
+      $('#chatConvoContainer')
+        .append(this.conversation.render().el);
 
       // todo: pass in scroll container as a view option
       this.$scrollContainer = $('#chatContainer');

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -79,7 +79,6 @@ export default class extends baseVw {
 
       // todo: after chat head logic, update below line.
       if (this.collection.get(guid).get('unread') && this.conversation.messages.length) {
-        console.log('check it');
         this.conversation.markConvoAsRead();
       }
 

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -17,11 +17,6 @@ export default class extends baseVw {
 
     super(options);
 
-    // this._state = {
-    //   status: 'not-connected',
-    //   ...options.initialState || {},
-    // };
-
     this._isOpen = false;
     this.throttledOnScroll = _.throttle(this.onScroll, 100).bind(this);
 
@@ -39,31 +34,6 @@ export default class extends baseVw {
       'click .js-bottomUnreadBanner': 'onClickBottomUnreadBanner',
     };
   }
-
-  // getState() {
-  //   return this._state;
-  // }
-
-  // setState(state, replace = false) {
-  //   let newState;
-
-  //   if (replace) {
-  //     this._state = {};
-  //   } else {
-  //     newState = _.extend({}, this._state, state);
-  //   }
-
-  //   if (!_.isEqual(this._state, newState)) {
-  //     this._state = newState;
-  //     this.render();
-  //   }
-
-  //   return this;
-  // }
-
-  // remove() {
-  //   super.remove();
-  // }
 
   onChatHeadClick(e) {
     if (!this.isOpen) {
@@ -175,6 +145,7 @@ export default class extends baseVw {
   close() {
     this._isOpen = false;
     getBody().removeClass('chatOpen');
+    this.closeConversation();
   }
 
   get isOpen() {

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -1,9 +1,10 @@
 import $ from 'jquery';
 import _ from 'underscore';
 import '../../utils/velocity';
+import app from '../../app';
 import { getBody } from '../../utils/selectors';
 import { isScrolledIntoView } from '../../utils/dom';
-import { getCurrentConnection } from '../../utils/serverConnect';
+import { getSocket } from '../../utils/serverConnect';
 import loadTemplate from '../../utils/loadTemplate';
 import Profile from '../../models/profile/Profile';
 import baseVw from '../baseVw';
@@ -26,17 +27,17 @@ export default class extends baseVw {
     this._isOpen = false;
     this.$scrollContainer = options.$scrollContainer;
     this.throttledOnScroll = _.throttle(this.onScroll, 100).bind(this);
+    this.debouncedOnProfileFetchScroll = _.debounce(this.onProfileFetchScroll, 200).bind(this);
+    this.profileDeferreds = {};
+    this.lastProfileFetchedIndex = -1;
 
     // TODO: handle fetch error.
     this.listenTo(this.collection, 'sync', () => this.render());
 
-    const serverConnection = getCurrentConnection();
+    this.socket = getSocket();
 
-    if (serverConnection && serverConnection.status !== 'disconnected') {
-      this.listenTo(serverConnection.socket, 'message', this.onSocketMessage);
-    } else {
-      // There's no connection to the server. The connection modal will appear and
-      // a subsequent reconnect will re-start the app.
+    if (this.socket) {
+      this.listenTo(this.socket, 'message', this.onSocketMessage);
     }
   }
 
@@ -55,8 +56,7 @@ export default class extends baseVw {
     if (!this.isOpen) {
       this.open();
     } else {
-      const profilePromise = $.Deferred().promise();
-
+      const profilePromise = this.fetchProfile(e.view.model.id);
       this.openConversation(e.view.model.id, profilePromise, e.view.model);
     }
   }
@@ -143,6 +143,10 @@ export default class extends baseVw {
 
   onScroll() {
     this.handleUnreadBadge();
+  }
+
+  onProfileFetchScroll() {
+    this.fetchProfileOfVisibleChatHeads();
   }
 
   onClickTopUnreadBanner() {
@@ -247,8 +251,10 @@ export default class extends baseVw {
     return this._isOpen;
   }
 
-  // This chat view, in some cases, needs to know when it becomes visible,
-  // so please show it via this method.
+  /**
+   * This chat view, may need to know when it becomes visible,
+   * so please show it via this method.
+   */
   show() {
     this.$el.removeClass('hide');
     return this;
@@ -259,8 +265,10 @@ export default class extends baseVw {
     return this;
   }
 
-  // This chat view, in some cases, needs to know when it is attached to the dom,
-  // so please use this method to do so.
+  /**
+   * This chat view mey need to know when it is attached to the dom,
+   * so please use this method to do so.
+   */
   attach(container) {
     if (!container || !(container instanceof $ && container[0] instanceof HTMLElement)) {
       throw new Error('Please provide a container as a jQuery object or DOM element.');
@@ -315,6 +323,83 @@ export default class extends baseVw {
     }
   }
 
+  /**
+   * Will return a promise that resolves to a Profile. If we have already
+   * fetched or are in the promise of fetching a Profile, then the
+   * existing promise will be returned.
+   */
+  fetchProfile(guid) {
+    if (!guid) {
+      throw new Error('Please provide a guid.');
+    }
+
+    const profileDeferred = this.profileDeferreds[guid];
+    let returnVal = profileDeferred;
+
+    if (!profileDeferred) {
+      this.fetchProfiles([guid]);
+      returnVal = this.profileDeferreds[guid];
+    }
+
+    return returnVal.promise();
+  }
+
+  /**
+   * Will asynchronously (profiles returned via sockets) fetch the provided
+   * list of profiles and update the this.profileDeferreds. Will not refetch
+   * profiles that have already been fetched or are in the process of being
+   * fetched.
+   */
+  fetchProfiles(profiles) {
+    if (!_.isArray(profiles)) {
+      throw new Error('Please provide a list of profiles.');
+    }
+
+    const profilesToFetch = [];
+
+    if (profiles.length) {
+      profiles.forEach(profileId => {
+        if (!this.profileDeferreds[profileId]) {
+          const deferred = $.Deferred();
+          this.profileDeferreds[profileId] = deferred;
+          profilesToFetch.push(profileId);
+        }
+      });
+
+      $.post({
+        url: app.getServerUrl('ob/fetchprofiles?async=true'),
+        data: JSON.stringify(profilesToFetch),
+        dataType: 'json',
+        contentType: 'application/json',
+      }).done((data) => {
+        if (this.socket) {
+          this.listenTo(this.socket, 'message', (e) => {
+            if (e.jsonData.id === data.id) {
+              const profile = new Profile(e.jsonData.profile);
+              this.profileDeferreds[e.jsonData.peerId].resolve(profile);
+
+              if (this.chatHeads) {
+                this.chatHeads.setProfile(e.jsonData.peerId, profile);
+              }
+            }
+          });
+        }
+      });
+    }
+  }
+
+  fetchProfileOfVisibleChatHeads() {
+    if (!this.chatHeads || !this.chatHeads.views.length) return;
+
+    // Find which heads are in the viewport and filter out any that have already
+    // had or are having their profiles fetched.
+    const profilesToFetch = this.chatHeads.views.filter(chatHead => (
+      !this.profileDeferreds[chatHead.model.get('peerId')] && isScrolledIntoView(chatHead.el)
+    )).map(chatHead => (chatHead.model.get('peerId')));
+
+    this.fetchProfiles(profilesToFetch);
+  }
+
   get $chatConvoContainer() {
     return this._$chatConvoContainer ||
       (this._$chatConvoContainer = $('#chatConvoContainer'));
@@ -322,13 +407,7 @@ export default class extends baseVw {
 
   render() {
     loadTemplate('chat/chat.html', (t) => {
-      this.$el.html(t({
-        // chatHeads: this.collection.toJSON(),
-        // ...this.model.toJSON(),
-        // ...this._state,
-      }));
-
-      // this._$deleteConfirm = null;
+      this.$el.html(t());
 
       if (this.chatHeads) this.chatHeads.remove();
       this.chatHeads = this.createChild(ChatHeads, {
@@ -353,6 +432,11 @@ export default class extends baseVw {
 
       this.$scrollContainer.off('scroll', this.throttledOnScroll)
         .on('scroll', this.throttledOnScroll);
+
+      this.$scrollContainer.off('scroll', this.debouncedOnProfileFetchScroll)
+        .on('scroll', this.debouncedOnProfileFetchScroll);
+
+      this.fetchProfileOfVisibleChatHeads();
     });
 
     return this;

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -77,10 +77,10 @@ export default class extends baseVw {
   onChatHeadClick(e) {
     if (!this.isOpen) {
       this.open();
-    } else {
-      const profilePromise = this.fetchProfile(e.view.model.id);
-      this._openConversation(e.view.model.id, profilePromise, e.view.model);
     }
+
+    const profilePromise = this.fetchProfile(e.view.model.id);
+    this._openConversation(e.view.model.id, profilePromise, e.view.model);
   }
 
   onChatHeadsRendered() {

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -79,6 +79,7 @@ export default class extends baseVw {
 
       // todo: after chat head logic, update below line.
       if (this.collection.get(guid).get('unread') && this.conversation.messages.length) {
+        console.log('check it');
         this.conversation.markConvoAsRead();
       }
 

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -10,7 +10,7 @@ import ChatHeads from './ChatHeads';
 export default class extends baseVw {
   constructor(options = {}) {
     if (!options.collection) {
-      throw new Error('Please provide a chat conversations collection.');
+      throw new Error('Please provide a chat heads collection.');
     }
 
     super(options);
@@ -23,9 +23,8 @@ export default class extends baseVw {
     this._isOpen = false;
     this.throttledOnScroll = _.throttle(this.onScroll, 100).bind(this);
 
-    this.listenTo(this.collection, 'sync', () => {
-      this.render();
-    });
+    // TODO: handle fetch error.
+    this.listenTo(this.collection, 'sync', () => this.render());
   }
 
   className() {

--- a/js/views/chat/Chat.js
+++ b/js/views/chat/Chat.js
@@ -67,7 +67,7 @@ export default class extends baseVw {
     }
   }
 
-  openConversation(guid, profile, chatHead) {
+  openConversation(guid, profile) {
     if (!guid) {
       throw new Error('Please provide a guid.');
     }
@@ -106,7 +106,6 @@ export default class extends baseVw {
     this.conversation = this.createChild(Conversation, {
       guid,
       profile,
-      chatHead,
     });
 
     this.listenTo(this.conversation, 'clickCloseConvo',

--- a/js/views/chat/ChatHead.js
+++ b/js/views/chat/ChatHead.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import loadTemplate from '../../utils/loadTemplate';
 import baseVw from '../baseVw';
 
@@ -28,8 +29,17 @@ export default class extends baseVw {
   }
 
   render() {
+    const message = this.model.get('lastMessage');
+
+    // Give any links the emphasis color.
+    const $msgHtml = $(`<div>${message}</div>`);
+
+    $msgHtml.find('a')
+      .addClass('clrTEm');
+
     let templateData = {
       ...this.model.toJSON(),
+      lastMessage: $msgHtml.html(),
     };
 
     if (this.profile) {

--- a/js/views/chat/ChatHead.js
+++ b/js/views/chat/ChatHead.js
@@ -1,5 +1,3 @@
-// import $ from 'jquery';
-// import _ from 'underscore';
 import loadTemplate from '../../utils/loadTemplate';
 import baseVw from '../baseVw';
 

--- a/js/views/chat/ChatHead.js
+++ b/js/views/chat/ChatHead.js
@@ -1,0 +1,50 @@
+// import $ from 'jquery';
+// import _ from 'underscore';
+import loadTemplate from '../../utils/loadTemplate';
+import baseVw from '../baseVw';
+
+export default class extends baseVw {
+  constructor(options = {}) {
+    if (!options.model) {
+      throw new Error('Please provide a model.');
+    }
+
+    super(options);
+
+    // this._state = {
+    //   status: 'not-connected',
+    //   ...options.initialState || {},
+    // };
+  }
+
+  className() {
+    return 'chatHead';
+  }
+
+  events() {
+    return {
+      click: 'onClick',
+    };
+  }
+
+  onClick() {
+    this.trigger('click', { view: this });
+  }
+
+  // remove() {
+  //   super.remove();
+  // }
+
+  render() {
+    loadTemplate('chat/chatHead.html', (t) => {
+      this.$el.html(t({
+        ...this.model.toJSON(),
+        // ...this._state,
+      }));
+
+      // this._$deleteConfirm = null;
+    });
+
+    return this;
+  }
+}

--- a/js/views/chat/ChatHead.js
+++ b/js/views/chat/ChatHead.js
@@ -11,10 +11,7 @@ export default class extends baseVw {
 
     super(options);
 
-    // this._state = {
-    //   status: 'not-connected',
-    //   ...options.initialState || {},
-    // };
+    this.listenTo(this.model, 'change', this.render);
   }
 
   className() {
@@ -31,18 +28,11 @@ export default class extends baseVw {
     this.trigger('click', { view: this });
   }
 
-  // remove() {
-  //   super.remove();
-  // }
-
   render() {
     loadTemplate('chat/chatHead.html', (t) => {
       this.$el.html(t({
         ...this.model.toJSON(),
-        // ...this._state,
       }));
-
-      // this._$deleteConfirm = null;
     });
 
     return this;

--- a/js/views/chat/ChatHead.js
+++ b/js/views/chat/ChatHead.js
@@ -8,6 +8,7 @@ export default class extends baseVw {
     }
 
     super(options);
+    this.profile = options.profile;
 
     this.listenTo(this.model, 'change', this.render);
   }
@@ -27,10 +28,19 @@ export default class extends baseVw {
   }
 
   render() {
+    let templateData = {
+      ...this.model.toJSON(),
+    };
+
+    if (this.profile) {
+      templateData = {
+        ...templateData,
+        ...this.profile.toJSON(),
+      };
+    }
+
     loadTemplate('chat/chatHead.html', (t) => {
-      this.$el.html(t({
-        ...this.model.toJSON(),
-      }));
+      this.$el.html(t(templateData));
     });
 
     return this;

--- a/js/views/chat/ChatHeads.js
+++ b/js/views/chat/ChatHeads.js
@@ -16,6 +16,9 @@ export default class extends baseVw {
     super(options);
     this._chatHeadViews = [];
     this.$scrollContainer = options.$scrollContainer;
+    // If providing profiles, the expectation is that they will be an object
+    // with the guid as the key and a Profile model instance as the value.
+    this.profiles = options.profiles || {};
 
     this.listenTo(this.collection, 'update', this.onCollectionUpdate);
   }
@@ -47,15 +50,39 @@ export default class extends baseVw {
     return this._chatHeadViews;
   }
 
+  setProfile(guid, profile) {
+    // Todo: when the profile is updated on the server to include the GUID, the signature
+    // of this function can be simplified.
+
+    if (!guid) {
+      throw new Error('Please provide a guid.');
+    }
+
+    if (!profile) {
+      throw new Error('Please provide a Profile model.');
+    }
+
+    this.profiles[guid] = profile;
+    this.render();
+  }
+
   createChatHead(model, options = {}) {
     if (!model) {
       throw new Error('Please provide a model.');
     }
 
-    const chatHead = this.createChild(ChatHead, {
+    const viewData = {
       ...options,
       model,
-    });
+    };
+
+    const profile = this.profiles[model.get('peerId')];
+
+    if (profile) {
+      viewData.profile = profile;
+    }
+
+    const chatHead = this.createChild(ChatHead, viewData);
 
     this._chatHeadViews.push(chatHead);
     this.listenTo(chatHead, 'click', (...args) => this.trigger('chatHeadClick', ...args));

--- a/js/views/chat/ChatHeads.js
+++ b/js/views/chat/ChatHeads.js
@@ -21,7 +21,7 @@ export default class extends baseVw {
   }
 
   className() {
-    return 'chatHeads';
+    return 'chatHeads flexColRows gutterVSm';
   }
 
   events() {

--- a/js/views/chat/ChatHeads.js
+++ b/js/views/chat/ChatHeads.js
@@ -1,0 +1,60 @@
+// import $ from 'jquery';
+// import _ from 'underscore';
+import loadTemplate from '../../utils/loadTemplate';
+import baseVw from '../baseVw';
+import ChatHead from './ChatHead';
+
+export default class extends baseVw {
+  constructor(options = {}) {
+    if (!options.collection) {
+      throw new Error('Please provide a chat conversations collection.');
+    }
+
+    super(options);
+
+    this.chatHeadViews = [];
+
+    // this._state = {
+    //   status: 'not-connected',
+    //   ...options.initialState || {},
+    // };
+  }
+
+  className() {
+    return 'chatHeads';
+  }
+
+  events() {
+    return {
+      // 'click .js-btnConnect': 'onConnectClick',
+    };
+  }
+
+  // remove() {
+  //   super.remove();
+  // }
+
+  render() {
+    // loadTemplate('chat/chatHeads.html', (t) => {
+    //   this.$el.html(t({
+    //     chatHeads: this.collection.toJSON(),
+    //     ...this.model.toJSON(),
+    //     ...this._state,
+    //   }));
+
+    //   this._$deleteConfirm = null;
+    // });
+
+    this.chatHeadViews.forEach(vw => vw.remove());
+    this.chatHeadViews = [];
+
+    this.collection.forEach(chatHead => {
+      const view = this.createChild(ChatHead, { model: chatHead });
+      this.listenTo(view, 'click', () => this.trigger('chatHeadClick'));
+      this.chatHeadViews.push(view);
+      this.$el.append(view.render().el);
+    });
+
+    return this;
+  }
+}

--- a/js/views/chat/ChatHeads.js
+++ b/js/views/chat/ChatHeads.js
@@ -54,7 +54,7 @@ export default class extends baseVw {
 
     this.collection.forEach(chatHead => {
       const view = this.createChild(ChatHead, { model: chatHead });
-      this.listenTo(view, 'click', () => this.trigger('chatHeadClick'));
+      this.listenTo(view, 'click', (...args) => this.trigger('chatHeadClick', ...args));
       this._chatHeadViews.push(view);
       this.$el.append(view.render().el);
     });

--- a/js/views/chat/ChatHeads.js
+++ b/js/views/chat/ChatHeads.js
@@ -16,8 +16,8 @@ export default class extends baseVw {
     super(options);
     this._chatHeadViews = [];
     this.$scrollContainer = options.$scrollContainer;
+
     this.listenTo(this.collection, 'update', this.onCollectionUpdate);
-    // this.listenTo(this.collection, 'sort', this.render);
   }
 
   className() {
@@ -34,8 +34,6 @@ export default class extends baseVw {
       prevScroll.height = this.$scrollContainer[0].scrollHeight;
       prevScroll.top = this.$scrollContainer[0].scrollTop;
 
-      // const view = this.createChatHead(options.changes.added[0]);
-      // this.$el.prepend(view.render().el);
       this.render();
 
       this.$scrollContainer[0].scrollTop = prevScroll.top +

--- a/js/views/chat/ChatHeads.js
+++ b/js/views/chat/ChatHeads.js
@@ -12,7 +12,7 @@ export default class extends baseVw {
 
     super(options);
 
-    this.chatHeadViews = [];
+    this._chatHeadViews = [];
 
     // this._state = {
     //   status: 'not-connected',
@@ -34,6 +34,10 @@ export default class extends baseVw {
   //   super.remove();
   // }
 
+  get views() {
+    return this._chatHeadViews;
+  }
+
   render() {
     // loadTemplate('chat/chatHeads.html', (t) => {
     //   this.$el.html(t({
@@ -45,13 +49,13 @@ export default class extends baseVw {
     //   this._$deleteConfirm = null;
     // });
 
-    this.chatHeadViews.forEach(vw => vw.remove());
-    this.chatHeadViews = [];
+    this._chatHeadViews.forEach(vw => vw.remove());
+    this._chatHeadViews = [];
 
     this.collection.forEach(chatHead => {
       const view = this.createChild(ChatHead, { model: chatHead });
       this.listenTo(view, 'click', () => this.trigger('chatHeadClick'));
-      this.chatHeadViews.push(view);
+      this._chatHeadViews.push(view);
       this.$el.append(view.render().el);
     });
 

--- a/js/views/chat/ChatHeads.js
+++ b/js/views/chat/ChatHeads.js
@@ -1,6 +1,6 @@
 // import $ from 'jquery';
 // import _ from 'underscore';
-import loadTemplate from '../../utils/loadTemplate';
+// import loadTemplate from '../../utils/loadTemplate';
 import baseVw from '../baseVw';
 import ChatHead from './ChatHead';
 

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -60,6 +60,11 @@ export default class extends baseVw {
 
         if (this.convoMessages) {
           this.convoMessages.setProfile(model);
+          const handle = model.get('handle');
+
+          if (handle) {
+            this.setTypingIndicator(handle);
+          }
         }
       });
     }
@@ -448,13 +453,19 @@ export default class extends baseVw {
   }
 
   getTypingIndicatorContent() {
-    const name = this.profile && this.profile.handle ? `@${this.profile.handle}` : this.guid;
+    let name = this.guid;
+
+    if (this.profile) {
+      const handle = this.profile.get('handle');
+      if (handle) name = `@${handle}`;
+    }
+
     const usernameHtml = `<span class="typingUsername noOverflow">${name}</span>`;
     return app.polyglot.t('chat.conversation.typingIndicator', { user: usernameHtml });
   }
 
-  setTypingIndicator(username) {
-    this.$typingIndicator.html(this.getTypingIndicatorContent(username));
+  setTypingIndicator() {
+    this.$typingIndicator.html(this.getTypingIndicatorContent());
   }
 
   get $typingIndicator() {

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -38,7 +38,7 @@ export default class extends baseVw {
   }
 
   className() {
-    return 'chatConversation clrP';
+    return 'chatConversation flexColRows clrP';
   }
 
   events() {

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -152,7 +152,6 @@ export default class extends baseVw {
       this.firstSyncComplete = true;
       this.setScrollTop(this.$convoMessagesWindow[0].scrollHeight);
       if (this.isOpen) {
-        console.log('howdy yo');
         this.markConvoAsRead();
       }
     }
@@ -299,7 +298,6 @@ export default class extends baseVw {
 
       this.messages.push(message);
       if (this.isOpen) {
-        console.log('hello');
         this.markConvoAsRead();
       }
 
@@ -314,10 +312,14 @@ export default class extends baseVw {
     } else if (e.jsonData.messageRead &&
       e.jsonData.messageRead.subject === this.subject &&
       e.jsonData.messageRead.peerId === this.guid) {
-      console.log('i be happity hippity');
       // Conversant read your message
       if (this.convoMessages) {
-        console.log('i am iron man');
+        const model = this.messages.get(e.jsonData.messageRead.messageId);
+
+        if (model) {
+          model.set('read', true);
+        }
+
         this.convoMessages.markMessageAsRead(e.jsonData.messageRead.messageId);
       }
     }

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -53,8 +53,12 @@ export default class extends baseVw {
         if (this.convoProfileHeader) {
           this.convoProfileHeader.setState({
             handle: model.get('handle'),
-            avatarHashes: model.get('avatarHashes'),
+            avatarHashes: model.get('avatarHashes').toJSON(),
           });
+        }
+
+        if (this.convoMessages) {
+          this.convoMessages.setOtherProfile(model);
         }
       });
     }
@@ -525,8 +529,6 @@ export default class extends baseVw {
       });
 
       this.$('.js-convoMessagesContainer').html(this.convoMessages.render().el);
-
-      // this.$convoMessagesWindow.on('scroll', this.throttledScroll);
       this.throttleScrollHandler();
     });
 

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -3,6 +3,7 @@ import _ from 'underscore';
 import app from '../../app';
 import { getBody } from '../../utils/selectors';
 import { getCurrentConnection } from '../../utils/serverConnect';
+import { openSimpleMessage } from '../modals/SimpleMessage';
 import loadTemplate from '../../utils/loadTemplate';
 import ChatMessages from '../../collections/ChatMessages';
 import ChatMessage from '../../models/chat/ChatMessage';
@@ -76,8 +77,7 @@ export default class extends baseVw {
   }
 
   get messagesPerPage() {
-    // TODO: set to 25 or so after dev complete!!!
-    return 5;
+    return 25;
   }
 
   className() {
@@ -92,6 +92,7 @@ export default class extends baseVw {
       'click .js-blockUser': 'onClickBlockUser',
       'click .js-subMenu a': 'onClickSubMenuLink',
       'click .js-retryLoadMessage': 'onClickRetryLoadMessage',
+      'click .js-deleteConversation': 'onClickDeleteConvo',
       'keyup .js-inputMessage': 'onKeyUpMessageInput',
     };
   }
@@ -323,6 +324,26 @@ export default class extends baseVw {
         this.convoMessages.markMessageAsRead(e.jsonData.messageRead.messageId);
       }
     }
+  }
+
+  onClickDeleteConvo() {
+    this.$el.addClass('isDeleting');
+
+    const request = $.ajax({
+      url: app.getServerUrl(`ob/chatconversation/${this.guid}`),
+      type: 'DELETE',
+    }).fail((xhr) => {
+      const failReason = xhr.responseJSON && xhr.responseJSON.reason || '';
+      openSimpleMessage(
+        app.polyglot.t('chat.conversation.deleteConvoErrorTitle'),
+        failReason
+      );
+    }).always(() => this.$el.removeClass('isDeleting'));
+
+    this.trigger('deleting', {
+      request,
+      guid: this.guid,
+    });
   }
 
   showTypingIndicator() {

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import loadTemplate from '../../utils/loadTemplate';
 import ChatMessages from '../../collections/ChatMessages';
+import ChatMessage from '../../models/chat/ChatMessage';
 import Profile from '../../models/profile/Profile';
 import baseVw from '../baseVw';
 import ConvoProfileHeader from './ConvoProfileHeader';
@@ -67,6 +68,7 @@ export default class extends baseVw {
       'click .js-blockUser': 'onClickBlockUser',
       'click .js-subMenu a': 'onClickSubMenuLink',
       'click .js-retryLoadMessage': 'onClickRetryLoadMessage',
+      'keyup .js-inputMessage': 'onKeyUpMessageInput',
     };
   }
 
@@ -125,6 +127,33 @@ export default class extends baseVw {
 
   onClickRetryLoadMessage() {
     this.fetchMessages(...this.lastFetchMessagesArgs);
+  }
+
+  onKeyUpMessageInput(e) {
+    if (e.which !== 13) return;
+
+    const message = e.target.value.trim();
+
+    if (!message) return;
+
+    const chatMessage = new ChatMessage({
+      peerId: this.guid,
+      message,
+    });
+
+    const save = chatMessage.save();
+
+    if (save) {
+      // At least for now, ignoring any server failures. Odds are really low of
+      // it happening and repurcussions minimal.
+      this.messages.push(chatMessage);
+    } else {
+      // Developer error - this shouldn't happen.
+      console.error('There was an error saving the chat message.');
+      console.dir(save);
+    }
+
+    $(e.target).val('');
   }
 
   fetchMessages(offsetId, limit = this.messagesPerPage) {

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -58,7 +58,7 @@ export default class extends baseVw {
         }
 
         if (this.convoMessages) {
-          this.convoMessages.setOtherProfile(model);
+          this.convoMessages.setProfile(model);
         }
       });
     }
@@ -511,7 +511,7 @@ export default class extends baseVw {
 
       if (this.profile) {
         convoProfileHeaderInitialState.handle = this.profile.get('handle');
-        convoProfileHeaderInitialState.avatarHashes = this.profile.get('avatarHashes');
+        convoProfileHeaderInitialState.avatarHashes = this.profile.get('avatarHashes').toJSON();
       }
 
       this.convoProfileHeader = this.createChild(ConvoProfileHeader, {
@@ -526,6 +526,7 @@ export default class extends baseVw {
       this.convoMessages = new ConvoMessages({
         collection: this.messages,
         $scrollContainer: this.$convoMessagesWindow,
+        profile: this.profile,
       });
 
       this.$('.js-convoMessagesContainer').html(this.convoMessages.render().el);

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -106,7 +106,10 @@ export default class extends baseVw {
     this.$el.addClass('loadingMessages');
   }
 
-  onMessagesSync() {
+  onMessagesSync(mdCl) {
+    // at this point, only interested in the collection sync (not any of its models)
+    if (!mdCl instanceof ChatMessages) return;
+
     this.showLoadMessagesError = false;
     this.$loadMessagesError.addClass('hide');
     this.$el.removeClass('loadingMessages');

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -3,6 +3,7 @@
 import Profile from '../../models/profile/Profile';
 import loadTemplate from '../../utils/loadTemplate';
 import baseVw from '../baseVw';
+import ConvoProfileHeader from './ConvoProfileHeader';
 
 export default class extends baseVw {
   constructor(options = {}) {
@@ -28,7 +29,16 @@ export default class extends baseVw {
     if (options.profile instanceof Profile) {
       this.profile = this.options.profile;
     } else {
-      // this.profile.done(() => {});
+      options.profile.done(model => {
+        this.profile = model;
+
+        if (this.convoProfileHeader) {
+          this.convoProfileHeader.setState({
+            handle: model.get('handle'),
+            avatarHashes: model.get('avatarHashes'),
+          });
+        }
+      });
     }
 
     // this._state = {
@@ -43,8 +53,12 @@ export default class extends baseVw {
 
   events() {
     return {
-      // click: 'onClick',
+      'click .js-closeConvo': 'onClickCloseConvo',
     };
+  }
+
+  onClickCloseConvo() {
+    this.trigger('clickCloseConvo');
   }
 
   get guid() {
@@ -66,6 +80,24 @@ export default class extends baseVw {
       }));
 
       // this._$deleteConfirm = null;
+
+      if (this.convoProfileHeader) this.convoProfileHeader.remove();
+
+      const convoProfileHeaderInitialState = {
+        guid: this.guid,
+      };
+
+      if (this.profile) {
+        convoProfileHeaderInitialState.handle = this.profile.get('handle');
+        convoProfileHeaderInitialState.avatarHashes = this.profile.get('avatarHashes');
+      }
+
+      this.convoProfileHeader = this.createChild(ConvoProfileHeader, {
+        initialState: convoProfileHeaderInitialState,
+      });
+
+      this.$('.js-convoProfileHeaderContainer')
+        .html(this.convoProfileHeader.render().el);
     });
 
     return this;

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import _ from 'underscore';
 import app from '../../app';
 import { getBody } from '../../utils/selectors';
-import { getCurrentConnection } from '../../utils/serverConnect';
+import { getSocket } from '../../utils/serverConnect';
 import { openSimpleMessage } from '../modals/SimpleMessage';
 import loadTemplate from '../../utils/loadTemplate';
 import ChatMessages from '../../collections/ChatMessages';
@@ -71,13 +71,10 @@ export default class extends baseVw {
     this.listenTo(this.messages, 'error', this.onMessagesFetchError);
     this.fetchMessages();
 
-    const serverConnection = getCurrentConnection();
+    const socket = getSocket();
 
-    if (serverConnection && serverConnection.status !== 'disconnected') {
-      this.listenTo(serverConnection.socket, 'message', this.onSocketMessage);
-    } else {
-      // There's no connection to the server. The connection modal will appear and
-      // a subsequent reconnect will re-start the app.
+    if (socket) {
+      this.listenTo(socket, 'message', this.onSocketMessage);
     }
   }
 

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -4,6 +4,7 @@ import ChatMessages from '../../collections/ChatMessages';
 import Profile from '../../models/profile/Profile';
 import baseVw from '../baseVw';
 import ConvoProfileHeader from './ConvoProfileHeader';
+import ConvoMessages from './ConvoMessages';
 
 export default class extends baseVw {
   constructor(options = {}) {
@@ -107,6 +108,7 @@ export default class extends baseVw {
     this.showLoadMessagesError = false;
     this.$loadMessagesError.addClass('hide');
     this.$el.removeClass('loadingMessages');
+    this.$convoMessagesWrap[0].scrollTop = this.$convoMessagesWrap[0].scrollHeight;
   }
 
   onMessagesFetchError() {
@@ -176,6 +178,11 @@ export default class extends baseVw {
     return returnVal;
   }
 
+  get $convoMessagesWrap() {
+    return this._$convoMessagesWrap ||
+      (this._$convoMessagesWrap = this.$('.js-convoMessagesWrap'));
+  }
+
   render() {
     loadTemplate('chat/conversation.html', (t) => {
       this.$el.html(t({
@@ -188,6 +195,7 @@ export default class extends baseVw {
       this._$subMenu = null;
       this._$messagesOverlay = null;
       this._$loadMessagesError = null;
+      this._$convoMessagesWrap = null;
 
       if (this.convoProfileHeader) this.convoProfileHeader.remove();
 
@@ -206,6 +214,14 @@ export default class extends baseVw {
 
       this.$('.js-convoProfileHeaderContainer')
         .html(this.convoProfileHeader.render().el);
+
+      if (this.ConvoMessages) this.ConvoMessages.remove();
+
+      this.convoMessages = new ConvoMessages({
+        collection: this.messages,
+      });
+
+      this.$('.js-convoMessagesContainer').html(this.convoMessages.render().el);
     });
 
     return this;

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -40,10 +40,6 @@ export default class extends baseVw {
     this.fetchedAllMessages = false;
     this.ignoreScroll = false;
 
-    if (this.options.chatHead) {
-      this.chatHead = this.options.chatHead;
-    }
-
     if (options.profile instanceof Profile) {
       this.profile = this.options.profile;
     } else {
@@ -491,7 +487,6 @@ export default class extends baseVw {
     loadTemplate('chat/conversation.html', (t) => {
       this.$el.html(t({
         guid: this.guid,
-        chatHead: this.chatHead && this.chatHead.toJSON() || {},
         profile: this.profile && this.profile.toJSON() || {},
         showLoadMessagesError: this.showLoadMessagesError,
         typingIndicator: this.getTypingIndicatorContent(),

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -25,6 +25,10 @@ export default class extends baseVw {
       throw new Error('Please provide the GUID of the person you are conversing with.');
     }
 
+    if (options.subject && options.subject.length > ChatMessage.max.subjectLength) {
+      throw new Error(`The subject cannot exceed ${ChatMessage.max.subjectLength} characters`);
+    }
+
     const opts = {
       subject: '',
       ...options,
@@ -245,6 +249,7 @@ export default class extends baseVw {
 
     // Send actual chat message if the Enter key was pressed
     if (e.which !== 13) return;
+
     const message = e.target.value.trim();
     if (!message) return;
     this.lastTypingSentAt = null;
@@ -493,6 +498,7 @@ export default class extends baseVw {
         profile: this.profile && this.profile.toJSON() || {},
         showLoadMessagesError: this.showLoadMessagesError,
         typingIndicator: this.getTypingIndicatorContent(),
+        maxMessageLength: ChatMessage.max.messageLength,
       }));
 
       this._$subMenu = null;

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -420,6 +420,7 @@ export default class extends baseVw {
     if (this._isOpen) return;
     this._isOpen = true;
     getBody().addClass('chatConvoOpen');
+    this.$messageInput.focus();
   }
 
   close() {
@@ -488,6 +489,11 @@ export default class extends baseVw {
       (this._$convoMessagesWindow = this.$('.js-convoMessagesWindow'));
   }
 
+  get $messageInput() {
+    return this._$messageInput ||
+      (this._$messageInput = this.$('.js-inputMessage'));
+  }
+
   render() {
     loadTemplate('chat/conversation.html', (t) => {
       this.$el.html(t({
@@ -503,6 +509,7 @@ export default class extends baseVw {
       this._$loadMessagesError = null;
       this._$convoMessagesWindow = null;
       this._$typingIndicator = null;
+      this._$messageInput = null;
 
       if (this.convoProfileHeader) this.convoProfileHeader.remove();
 

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -288,6 +288,7 @@ export default class extends baseVw {
     if (e.jsonData.message &&
       e.jsonData.message.subject === this.subject &&
       e.jsonData.message.peerId === this.guid) {
+      // incoming chat message
       const message = new ChatMessage({
         ...e.jsonData.message,
         outgoing: false,
@@ -302,7 +303,17 @@ export default class extends baseVw {
     } else if (e.jsonData.messageTyping &&
       e.jsonData.messageTyping.subject === this.subject &&
       e.jsonData.messageTyping.peerId === this.guid) {
+      // Conversant is typing...
       this.showTypingIndicator();
+    } else if (e.jsonData.messageRead &&
+      e.jsonData.messageRead.subject === this.subject &&
+      e.jsonData.messageRead.peerId === this.guid) {
+      console.log('i be happity hippity');
+      // Conversant read your message
+      if (this.convoMessages) {
+        console.log('i am iron man');
+        this.convoMessages.markMessageAsRead(e.jsonData.messageRead.messageId);
+      }
     }
   }
 

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -151,7 +151,7 @@ export default class extends baseVw {
 
     if (!this.firstSyncComplete) {
       this.firstSyncComplete = true;
-      this.setScrollTop(this.$convoMessagesWrap[0].scrollHeight);
+      this.setScrollTop(this.$convoMessagesWindow[0].scrollHeight);
       this.markConvoAsRead();
     }
   }
@@ -174,8 +174,8 @@ export default class extends baseVw {
     // As appropriate, update the scroll position.
     const prevScroll = {};
 
-    prevScroll.height = this.$convoMessagesWrap[0].scrollHeight;
-    prevScroll.top = this.$convoMessagesWrap[0].scrollTop;
+    prevScroll.height = this.$convoMessagesWindow[0].scrollHeight;
+    prevScroll.top = this.$convoMessagesWindow[0].scrollTop;
 
     this.convoMessages.render();
     this.topRenderedMessageMd = this.messages.at(0);
@@ -194,12 +194,12 @@ export default class extends baseVw {
 
         if (newMessage.get('outgoing')) {
           // It's our own message, so we'll auto scroll to the bottom.
-          this.setScrollTop(this.$convoMessagesWrap[0].scrollHeight);
+          this.setScrollTop(this.$convoMessagesWindow[0].scrollHeight);
         } else if (prevScroll.top >=
-          prevScroll.height - this.$convoMessagesWrap[0].clientHeight - 10) {
+          prevScroll.height - this.$convoMessagesWindow[0].clientHeight - 10) {
           // For an incoming message, if we were scrolled within 10px of the bottom at the
           // time the message came, we'll auto-scroll. Otherwise, we'll leave you where you were.
-          this.setScrollTop(this.$convoMessagesWrap[0].scrollHeight);
+          this.setScrollTop(this.$convoMessagesWindow[0].scrollHeight);
         }
       }
     } else if (opts.changes.added.length &&
@@ -208,7 +208,7 @@ export default class extends baseVw {
       // New page of messages added up top. We'll adjust the scroll position so there is no
       // jump as they are added in.
       this.setScrollTop(prevScroll.top +
-        (this.$convoMessagesWrap[0].scrollHeight - prevScroll.height - 60));
+        (this.$convoMessagesWindow[0].scrollHeight - prevScroll.height - 60));
 
       // the hardcode 60 is to account for the loading spinner that is going away
     }
@@ -292,11 +292,11 @@ export default class extends baseVw {
       throw new Error('Please provide a value as a number.');
     }
 
-    if (this.$convoMessagesWrap[0].scrollTop === value) return;
+    if (this.$convoMessagesWindow[0].scrollTop === value) return;
 
     if (silent) this.ignoreScroll = true;
 
-    this.$convoMessagesWrap[0].scrollTop = value;
+    this.$convoMessagesWindow[0].scrollTop = value;
   }
 
   markConvoAsRead() {
@@ -361,9 +361,9 @@ export default class extends baseVw {
     return returnVal;
   }
 
-  get $convoMessagesWrap() {
-    return this._$convoMessagesWrap ||
-      (this._$convoMessagesWrap = this.$('.js-convoMessagesWrap'));
+  get $convoMessagesWindow() {
+    return this._$convoMessagesWindow ||
+      (this._$convoMessagesWindow = this.$('.js-convoMessagesWindow'));
   }
 
   render() {
@@ -378,7 +378,7 @@ export default class extends baseVw {
       this._$subMenu = null;
       this._$messagesOverlay = null;
       this._$loadMessagesError = null;
-      this._$convoMessagesWrap = null;
+      this._$convoMessagesWindow = null;
 
       if (this.convoProfileHeader) this.convoProfileHeader.remove();
 
@@ -402,12 +402,12 @@ export default class extends baseVw {
 
       this.convoMessages = new ConvoMessages({
         collection: this.messages,
-        $scrollContainer: this.$convoMessagesWrap,
+        $scrollContainer: this.$convoMessagesWindow,
       });
 
       this.$('.js-convoMessagesContainer').html(this.convoMessages.render().el);
 
-      this.$convoMessagesWrap.on('scroll', this.throttledScroll);
+      this.$convoMessagesWindow.on('scroll', this.throttledScroll);
     });
 
     return this;

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -50,6 +50,7 @@ export default class extends baseVw {
           this.convoProfileHeader.setState({
             handle: model.get('handle'),
             avatarHashes: model.get('avatarHashes').toJSON(),
+            location: model.get('location'),
           });
         }
 
@@ -152,6 +153,7 @@ export default class extends baseVw {
     if (!this.firstSyncComplete) {
       this.firstSyncComplete = true;
       this.setScrollTop(this.$convoMessagesWindow[0].scrollHeight);
+
       if (this.isOpen) {
         this.markConvoAsRead();
       }
@@ -298,6 +300,7 @@ export default class extends baseVw {
       });
 
       this.messages.push(message);
+
       if (this.isOpen) {
         this.markConvoAsRead();
       }
@@ -507,6 +510,7 @@ export default class extends baseVw {
       if (this.profile) {
         convoProfileHeaderInitialState.handle = this.profile.get('handle');
         convoProfileHeaderInitialState.avatarHashes = this.profile.get('avatarHashes').toJSON();
+        convoProfileHeaderInitialState.location = this.profile.get('location');
       }
 
       this.convoProfileHeader = this.createChild(ConvoProfileHeader, {

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -107,8 +107,8 @@ export default class extends baseVw {
   }
 
   onMessagesSync(mdCl) {
-    // at this point, only interested in the collection sync (not any of its models)
-    if (!mdCl instanceof ChatMessages) return;
+    // Only interested in the collection sync (not any of its models).
+    if (!(mdCl instanceof ChatMessages)) return;
 
     this.showLoadMessagesError = false;
     this.$loadMessagesError.addClass('hide');

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -151,7 +151,10 @@ export default class extends baseVw {
     if (!this.firstSyncComplete) {
       this.firstSyncComplete = true;
       this.setScrollTop(this.$convoMessagesWindow[0].scrollHeight);
-      if (this.isOpen) this.markConvoAsRead();
+      if (this.isOpen) {
+        console.log('howdy yo');
+        this.markConvoAsRead();
+      }
     }
   }
 
@@ -295,7 +298,10 @@ export default class extends baseVw {
       });
 
       this.messages.push(message);
-      if (this.isOpen) this.markConvoAsRead();
+      if (this.isOpen) {
+        console.log('hello');
+        this.markConvoAsRead();
+      }
 
       // We'll consider them to be done typing if an acutal message came
       // in. If they re-start typing, we'll get another socket messsage.

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -151,7 +151,7 @@ export default class extends baseVw {
     if (!this.firstSyncComplete) {
       this.firstSyncComplete = true;
       this.setScrollTop(this.$convoMessagesWindow[0].scrollHeight);
-      this.markConvoAsRead();
+      if (this.isOpen) this.markConvoAsRead();
     }
   }
 
@@ -295,7 +295,7 @@ export default class extends baseVw {
       });
 
       this.messages.push(message);
-      this.markConvoAsRead();
+      if (this.isOpen) this.markConvoAsRead();
 
       // We'll consider them to be done typing if an acutal message came
       // in. If they re-start typing, we'll get another socket messsage.

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -422,7 +422,7 @@ export default class extends baseVw {
         chatHead: this.chatHead && this.chatHead.toJSON() || {},
         profile: this.profile && this.profile.toJSON() || {},
         showLoadMessagesError: this.showLoadMessagesError,
-        typingIndicator: this.getTypingIndicatorContent,
+        typingIndicator: this.getTypingIndicatorContent(),
       }));
 
       this._$subMenu = null;

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -226,6 +226,7 @@ export default class extends baseVw {
       // At least for now, ignoring any server failures and optimistically adding the new
       // message to the UI. Odds are really low of server failure and repurcussions minimal.
       this.messages.push(chatMessage);
+      this.trigger('newOutgoingMessage', { model: chatMessage });
     } else {
       // Developer error - this shouldn't happen.
       console.error('There was an error saving the chat message.');

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -1,0 +1,73 @@
+// import $ from 'jquery';
+// import _ from 'underscore';
+import Profile from '../../models/profile/Profile';
+import loadTemplate from '../../utils/loadTemplate';
+import baseVw from '../baseVw';
+
+export default class extends baseVw {
+  constructor(options = {}) {
+    if (!options.profile ||
+      (!(options.profile instanceof Profile) &&
+      !options.profile.then)) {
+      throw new Error('Please provide a profile model or a promise that provides' +
+        ' one when it resolves.');
+    }
+
+    if (!options.guid) {
+      throw new Error('Please provide the GUID of the person you are conversing with.');
+    }
+
+    super(options);
+    this.options = options;
+    this._guid = this.options.guid;
+
+    if (this.options.chatHead) {
+      this.chatHead = this.options.chatHead;
+    }
+
+    if (options.profile instanceof Profile) {
+      this.profile = this.options.profile;
+    } else {
+      // this.profile.done(() => {});
+    }
+
+    // this._state = {
+    //   status: 'not-connected',
+    //   ...options.initialState || {},
+    // };
+  }
+
+  className() {
+    return 'chatConversation clrP';
+  }
+
+  events() {
+    return {
+      // click: 'onClick',
+    };
+  }
+
+  get guid() {
+    return this._guid;
+  }
+
+  // remove() {
+  //   super.remove();
+  // }
+
+  render() {
+    loadTemplate('chat/conversation.html', (t) => {
+      this.$el.html(t({
+        // ...this.model.toJSON(),
+        guid: this.guid,
+        chatHead: this.chatHead && this.chatHead.toJSON() || {},
+        profile: this.profile && this.profile.toJSON() || {},
+        // ...this._state,
+      }));
+
+      // this._$deleteConfirm = null;
+    });
+
+    return this;
+  }
+}

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -1,4 +1,4 @@
-// import $ from 'jquery';
+import $ from 'jquery';
 // import _ from 'underscore';
 import Profile from '../../models/profile/Profile';
 import loadTemplate from '../../utils/loadTemplate';
@@ -53,7 +53,11 @@ export default class extends baseVw {
 
   events() {
     return {
+      click: 'onViewClick',
       'click .js-closeConvo': 'onClickCloseConvo',
+      'click .js-subMenuTrigger': 'onClickSubMenuTrigger',
+      'click .js-blockUser': 'onClickBlockUser',
+      'click .js-subMenu a': 'onClickSubMenuLink',
     };
   }
 
@@ -61,13 +65,61 @@ export default class extends baseVw {
     this.trigger('clickCloseConvo');
   }
 
+  onClickSubMenuTrigger() {
+    if (this.isSubmenuOpen()) {
+      this.hideSubMenu();
+    } else {
+      this.showSubMenu();
+    }
+
+    return false; // don't bubble to onViewClick
+  }
+
+  onViewClick(e) {
+    if (!$(e.target).closest('.js-subMenu').length) {
+      this.hideSubMenu();
+    }
+  }
+
+  onClickBlockUser() {
+    alert('coming soon...');
+  }
+
+  onClickSubMenuLink() {
+    this.hideSubMenu();
+  }
+
   get guid() {
     return this._guid;
+  }
+
+  isSubmenuOpen() {
+    return !this.$subMenu.hasClass('hide');
+  }
+
+  showSubMenu() {
+    this.$messagesOverlay.removeClass('hide');
+    this.$subMenu.removeClass('hide');
+  }
+
+  hideSubMenu() {
+    this.$messagesOverlay.addClass('hide');
+    this.$subMenu.addClass('hide');
   }
 
   // remove() {
   //   super.remove();
   // }
+
+  get $subMenu() {
+    return this._$subMenu ||
+      (this._$subMenu = this.$('.js-subMenu'));
+  }
+
+  get $messagesOverlay() {
+    return this._$messagesOverlay ||
+      (this._$messagesOverlay = this.$('.js-messagesOverlay'));
+  }
 
   render() {
     loadTemplate('chat/conversation.html', (t) => {
@@ -79,7 +131,8 @@ export default class extends baseVw {
         // ...this._state,
       }));
 
-      // this._$deleteConfirm = null;
+      this._$subMenu = null;
+      this._$messagesOverlay = null;
 
       if (this.convoProfileHeader) this.convoProfileHeader.remove();
 

--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -251,9 +251,11 @@ export default class extends baseVw {
   }
 
   onSocketMessage(e) {
-    if (e.jsonData && e.jsonData.message) {
+    const msg = e.jsonData.message;
+
+    if (msg && !msg.subject) {
       const message = new ChatMessage({
-        ...e.jsonData.message,
+        ...msg,
         outgoing: false,
       });
 

--- a/js/views/chat/ConvoMessage.js
+++ b/js/views/chat/ConvoMessage.js
@@ -1,4 +1,3 @@
-// import $ from 'jquery';
 import _ from 'underscore';
 import moment from 'moment';
 import loadTemplate from '../../utils/loadTemplate';
@@ -25,12 +24,6 @@ export default class extends baseVw {
     return 'convoMessage';
   }
 
-  events() {
-    return {
-      // 'click .js-btnConnect': 'onConnectClick',
-    };
-  }
-
   getState() {
     return this._state;
   }
@@ -52,11 +45,6 @@ export default class extends baseVw {
     return this;
   }
 
-  // remove() {
-  //   $(document).off('click', this.onDocumentClick);
-  //   super.remove();
-  // }
-
   render() {
     loadTemplate('chat/convoMessage.html', (t) => {
       this.$el.html(t({
@@ -64,8 +52,6 @@ export default class extends baseVw {
         ...this._state,
         moment,
       }));
-
-      // this._$deleteConfirm = null;
     });
 
     return this;

--- a/js/views/chat/ConvoMessage.js
+++ b/js/views/chat/ConvoMessage.js
@@ -1,0 +1,73 @@
+// import $ from 'jquery';
+import _ from 'underscore';
+import moment from 'moment';
+import loadTemplate from '../../utils/loadTemplate';
+import baseVw from '../baseVw';
+
+export default class extends baseVw {
+  constructor(options = {}) {
+    if (!options.model) {
+      throw new Error('Please provide a model.');
+    }
+
+    super(options);
+
+    this._state = {
+      showAvatar: true,
+      showTimestampLine: true,
+      ...options.initialState || {},
+    };
+
+    this.listenTo(this.model, 'change', () => this.render());
+  }
+
+  className() {
+    return 'convoMessage';
+  }
+
+  events() {
+    return {
+      // 'click .js-btnConnect': 'onConnectClick',
+    };
+  }
+
+  getState() {
+    return this._state;
+  }
+
+  setState(state, replace = false, renderOnChange = true) {
+    let newState;
+
+    if (replace) {
+      this._state = {};
+    } else {
+      newState = _.extend({}, this._state, state);
+    }
+
+    if (renderOnChange && !_.isEqual(this._state, newState)) {
+      this._state = newState;
+      this.render();
+    }
+
+    return this;
+  }
+
+  // remove() {
+  //   $(document).off('click', this.onDocumentClick);
+  //   super.remove();
+  // }
+
+  render() {
+    loadTemplate('chat/convoMessage.html', (t) => {
+      this.$el.html(t({
+        ...this.model.toJSON(),
+        ...this._state,
+        moment,
+      }));
+
+      // this._$deleteConfirm = null;
+    });
+
+    return this;
+  }
+}

--- a/js/views/chat/ConvoMessage.js
+++ b/js/views/chat/ConvoMessage.js
@@ -14,6 +14,7 @@ export default class extends baseVw {
     this._state = {
       showAvatar: true,
       showTimestampLine: true,
+      showAsRead: false,
       ...options.initialState || {},
     };
 

--- a/js/views/chat/ConvoMessage.js
+++ b/js/views/chat/ConvoMessage.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import _ from 'underscore';
 import moment from 'moment';
+import app from '../../app';
 import loadTemplate from '../../utils/loadTemplate';
 import baseVw from '../baseVw';
 
@@ -62,6 +63,7 @@ export default class extends baseVw {
         ...this._state,
         moment,
         message: $msgHtml.html(),
+        ownGuid: app.profile.id,
       }));
     });
 

--- a/js/views/chat/ConvoMessage.js
+++ b/js/views/chat/ConvoMessage.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import _ from 'underscore';
 import moment from 'moment';
 import loadTemplate from '../../utils/loadTemplate';
@@ -47,11 +48,20 @@ export default class extends baseVw {
   }
 
   render() {
+    const message = this.model.get('message');
+
+    // Give any links the emphasis color.
+    const $msgHtml = $(`<div>${message}</div>`);
+
+    $msgHtml.find('a')
+      .addClass('clrTEm');
+
     loadTemplate('chat/convoMessage.html', (t) => {
       this.$el.html(t({
         ...this.model.toJSON(),
         ...this._state,
         moment,
+        message: $msgHtml.html(),
       }));
     });
 

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -19,60 +19,11 @@ export default class extends baseVw {
     this.$scrollContainer = options.$scrollContainer;
     this.convoMessages = [];
 
-    // this.listenTo(this.collection, 'update', this.render);
-    // this.listenTo(this.collection, 'update', this.onUpdate);
     this.listenTo(app.profile.get('avatarHashes'), 'change', this.render);
   }
 
   className() {
     return 'chatConvoMessages';
-  }
-
-  onUpdate(cl, opts) {
-    const prevScroll = {};
-    const $scroll = this.$scrollContainer;
-
-    prevScroll.height = $scroll[0].scrollHeight;
-    prevScroll.top = $scroll[0].scrollTop;
-
-    this.render();
-
-    // Expecting either a new page of messages at the beginning of the collection or
-    // a new single message at the end of the collection. In either of those scenarios
-    // we'll adjust the scroll position as appopriate.
-
-    if (opts.changes.added.length === 1 &&
-      cl.indexOf(opts.changes.added[0]) === cl.length - 1) {
-      // New message at bottom.
-      if (prevScroll.top >= prevScroll.height - $scroll[0].clientHeight - 10) {
-        // If at the the time of creating the new message, we were scrolled within 10 pixels
-        // of the bottom of the container, then upon adding the new message, we'll scroll to
-        // the bottom
-      }
-    }
-
-    if (opts.changes.added.length === 1) {
-      // Single new message added.
-
-      const newMessage = opts.changes.added[0];
-
-      if (cl.indexOf(newMessage) === cl.length - 1) {
-        // It's the last message.
-
-        if (newMessage.get('outgoing')) {
-          // It's our own message, so we'll auto scroll to the bottom.
-          $scroll[0].scrollTop = $scroll[0].scrollHeight;
-        } else if (prevScroll.top >= prevScroll.height - $scroll[0].clientHeight - 10) {
-          // For an incoming message, if we were scrolled within 10px of the bottom at the
-          // time the message came, we'll auto-scroll. Otherwise, we'll leave you where you were.
-          $scroll[0].scrollTop = $scroll[0].scrollHeight;
-        }
-      }
-    } else if (opts.changes.added.length &&
-      cl.indexOf(opts.changes.added[opts.changes.added.length - 1]) !==
-      this.convoMessages[0].model) {
-      // New page of messages added up top. We'll scroll 
-    }
   }
 
   createMessage(model, options = {}) {

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -20,12 +20,6 @@ export default class extends baseVw {
     return 'chatConvoMessages';
   }
 
-  events() {
-    return {
-      // 'click .js-closeConvo': 'onClickCloseConvo',
-    };
-  }
-
   createMessage(model, options = {}) {
     if (!model) {
       throw new Error('Please provide a model.');

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -1,8 +1,4 @@
 import $ from 'jquery';
-// import _ from 'underscore';
-// import loadTemplate from '../../utils/loadTemplate';
-// import ChatMessages from '../../collections/ChatMessages';
-// import Profile from '../../models/profile/Profile';
 import baseVw from '../baseVw';
 import ConvoMessage from './ConvoMessage';
 
@@ -33,6 +29,7 @@ export default class extends baseVw {
     const messagesContainer = document.createDocumentFragment();
 
     this.collection.forEach(message => {
+      // Create Child !!!
       const convoMessage = new ConvoMessage({
         model: message,
       });

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -14,6 +14,7 @@ export default class extends baseVw {
     this.convoMessages = [];
 
     this.listenTo(this.collection, 'update', this.render);
+    this.listenTo(app.profile.get('avatarHashes'), 'change', this.render);
   }
 
   className() {
@@ -40,11 +41,16 @@ export default class extends baseVw {
       },
     });
 
+    this.convoMessages.push(convoMessage);
+
     return convoMessage;
   }
 
   render() {
     const messagesContainer = document.createDocumentFragment();
+
+    this.convoMessages.forEach(convoMessage => (convoMessage.remove()));
+    this.convoMessages = [];
 
     this.collection.forEach(message => {
       const convoMessage = this.createMessage(message);

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -1,0 +1,48 @@
+import $ from 'jquery';
+// import _ from 'underscore';
+// import loadTemplate from '../../utils/loadTemplate';
+// import ChatMessages from '../../collections/ChatMessages';
+// import Profile from '../../models/profile/Profile';
+import baseVw from '../baseVw';
+import ConvoMessage from './ConvoMessage';
+
+export default class extends baseVw {
+  constructor(options = {}) {
+    if (!options.collection) {
+      throw new Error('Please provide a chat messages collection.');
+    }
+
+    super(options);
+    this.options = options;
+    this.convoMessages = [];
+
+    this.listenTo(this.collection, 'update', this.render);
+  }
+
+  className() {
+    return 'chatConvoMessages';
+  }
+
+  events() {
+    return {
+      // 'click .js-closeConvo': 'onClickCloseConvo',
+    };
+  }
+
+  render() {
+    const messagesContainer = document.createDocumentFragment();
+
+    this.collection.forEach(message => {
+      const convoMessage = new ConvoMessage({
+        model: message,
+      });
+
+      $(messagesContainer).append(convoMessage.render().el);
+    });
+
+    this.$el.empty()
+      .append(messagesContainer);
+
+    return this;
+  }
+}

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -20,9 +20,6 @@ export default class extends baseVw {
     this.convoMessages = [];
 
     this.listenTo(app.profile.get('avatarHashes'), 'change', this.render);
-
-    console.log('moonie');
-    window.moonie = this;
   }
 
   className() {
@@ -55,8 +52,6 @@ export default class extends baseVw {
   }
 
   markMessageAsRead(id) {
-    console.log(`called with id: ${id}`);
-
     if (!id) {
       throw new Error('Please provide an id.');
     }
@@ -64,7 +59,10 @@ export default class extends baseVw {
     const message = this.collection.get(id);
 
     if (message) {
-      message.setState({ showAsRead: true });
+      const messageIndex = this.collection.indexOf(message);
+
+      this.convoMessages[messageIndex]
+        .setState({ showAsRead: true });
 
       // Only one message should be marked as read, so if there already was one,
       // we'll unmark it.

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -20,7 +20,7 @@ export default class extends baseVw {
     this.convoMessages = [];
 
     // this.listenTo(this.collection, 'update', this.render);
-    this.listenTo(this.collection, 'update', this.onUpdate);
+    // this.listenTo(this.collection, 'update', this.onUpdate);
     this.listenTo(app.profile.get('avatarHashes'), 'change', this.render);
   }
 
@@ -29,10 +29,6 @@ export default class extends baseVw {
   }
 
   onUpdate(cl, opts) {
-    // console.log('moo time');
-    // window.moo = opts;
-    // window.time = cl;
-
     const prevScroll = {};
     const $scroll = this.$scrollContainer;
 
@@ -65,11 +61,11 @@ export default class extends baseVw {
 
         if (newMessage.get('outgoing')) {
           // It's our own message, so we'll auto scroll to the bottom.
-          // $scroll[0].scrollTop = $scroll[0].scrollHeight;
+          $scroll[0].scrollTop = $scroll[0].scrollHeight;
         } else if (prevScroll.top >= prevScroll.height - $scroll[0].clientHeight - 10) {
           // For an incoming message, if we were scrolled within 10px of the bottom at the
           // time the message came, we'll auto-scroll. Otherwise, we'll leave you where you were.
-          // $scroll[0].scrollTop = $scroll[0].scrollHeight;
+          $scroll[0].scrollTop = $scroll[0].scrollHeight;
         }
       }
     } else if (opts.changes.added.length &&

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -9,16 +9,74 @@ export default class extends baseVw {
       throw new Error('Please provide a chat messages collection.');
     }
 
+    if (!options.$scrollContainer) {
+      // The scroll container should ideally be an ancestor of this view's element.
+      throw new Error('Please provide the DOM element that handles scrolling for this view.');
+    }
+
     super(options);
     this.options = options;
+    this.$scrollContainer = options.$scrollContainer;
     this.convoMessages = [];
 
-    this.listenTo(this.collection, 'update', this.render);
+    // this.listenTo(this.collection, 'update', this.render);
+    this.listenTo(this.collection, 'update', this.onUpdate);
     this.listenTo(app.profile.get('avatarHashes'), 'change', this.render);
   }
 
   className() {
     return 'chatConvoMessages';
+  }
+
+  onUpdate(cl, opts) {
+    // console.log('moo time');
+    // window.moo = opts;
+    // window.time = cl;
+
+    const prevScroll = {};
+    const $scroll = this.$scrollContainer;
+
+    prevScroll.height = $scroll[0].scrollHeight;
+    prevScroll.top = $scroll[0].scrollTop;
+
+    this.render();
+
+    // Expecting either a new page of messages at the beginning of the collection or
+    // a new single message at the end of the collection. In either of those scenarios
+    // we'll adjust the scroll position as appopriate.
+
+    if (opts.changes.added.length === 1 &&
+      cl.indexOf(opts.changes.added[0]) === cl.length - 1) {
+      // New message at bottom.
+      if (prevScroll.top >= prevScroll.height - $scroll[0].clientHeight - 10) {
+        // If at the the time of creating the new message, we were scrolled within 10 pixels
+        // of the bottom of the container, then upon adding the new message, we'll scroll to
+        // the bottom
+      }
+    }
+
+    if (opts.changes.added.length === 1) {
+      // Single new message added.
+
+      const newMessage = opts.changes.added[0];
+
+      if (cl.indexOf(newMessage) === cl.length - 1) {
+        // It's the last message.
+
+        if (newMessage.get('outgoing')) {
+          // It's our own message, so we'll auto scroll to the bottom.
+          // $scroll[0].scrollTop = $scroll[0].scrollHeight;
+        } else if (prevScroll.top >= prevScroll.height - $scroll[0].clientHeight - 10) {
+          // For an incoming message, if we were scrolled within 10px of the bottom at the
+          // time the message came, we'll auto-scroll. Otherwise, we'll leave you where you were.
+          // $scroll[0].scrollTop = $scroll[0].scrollHeight;
+        }
+      }
+    } else if (opts.changes.added.length &&
+      cl.indexOf(opts.changes.added[opts.changes.added.length - 1]) !==
+      this.convoMessages[0].model) {
+      // New page of messages added up top. We'll scroll 
+    }
   }
 
   createMessage(model, options = {}) {

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -10,7 +10,6 @@ export default class extends baseVw {
     }
 
     if (!options.$scrollContainer) {
-      // The scroll container should ideally be an ancestor of this view's element.
       throw new Error('Please provide the DOM element that handles scrolling for this view.');
     }
 

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import app from '../../app';
 import baseVw from '../baseVw';
 import ConvoMessage from './ConvoMessage';
 
@@ -25,15 +26,34 @@ export default class extends baseVw {
     };
   }
 
+  createMessage(model, options = {}) {
+    if (!model) {
+      throw new Error('Please provide a model.');
+    }
+
+    const initialState = {};
+
+    if (model.get('outgoing')) {
+      initialState.avatarHashes = app.profile.get('avatarHashes').toJSON();
+    }
+
+    const convoMessage = this.createChild(ConvoMessage, {
+      ...options,
+      model,
+      initialState: {
+        ...options.initialState,
+        ...initialState,
+      },
+    });
+
+    return convoMessage;
+  }
+
   render() {
     const messagesContainer = document.createDocumentFragment();
 
     this.collection.forEach(message => {
-      // Create Child !!!
-      const convoMessage = new ConvoMessage({
-        model: message,
-      });
-
+      const convoMessage = this.createMessage(message);
       $(messagesContainer).append(convoMessage.render().el);
     });
 

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -16,6 +16,8 @@ export default class extends baseVw {
 
     super(options);
     this.options = options;
+    // Profile of person you are conversing with
+    this.otherProfile = options.otherProfile;
     this.$scrollContainer = options.$scrollContainer;
     this.convoMessages = [];
 
@@ -24,6 +26,18 @@ export default class extends baseVw {
 
   className() {
     return 'chatConvoMessages';
+  }
+
+  /**
+   * Set the profile of the person you are conversing with.
+   */
+  setOtherProfile(profile) {
+    if (!profile) {
+      throw new Error('Please provide a Profile model of the person you are conversing with.');
+    }
+
+    this.otherProfile = profile;
+    this.render();
   }
 
   createMessage(model, options = {}) {
@@ -35,6 +49,8 @@ export default class extends baseVw {
 
     if (model.get('outgoing')) {
       initialState.avatarHashes = app.profile.get('avatarHashes').toJSON();
+    } else if (this.otherProfile) {
+      initialState.avatarHashes = this.otherProfile.get('avatarHashes').toJSON();
     }
 
     const convoMessage = this.createChild(ConvoMessage, {

--- a/js/views/chat/ConvoMessages.js
+++ b/js/views/chat/ConvoMessages.js
@@ -17,7 +17,7 @@ export default class extends baseVw {
     super(options);
     this.options = options;
     // Profile of person you are conversing with
-    this.otherProfile = options.otherProfile;
+    this.profile = options.profile;
     this.$scrollContainer = options.$scrollContainer;
     this.convoMessages = [];
 
@@ -31,40 +31,13 @@ export default class extends baseVw {
   /**
    * Set the profile of the person you are conversing with.
    */
-  setOtherProfile(profile) {
+  setProfile(profile) {
     if (!profile) {
       throw new Error('Please provide a Profile model of the person you are conversing with.');
     }
 
-    this.otherProfile = profile;
+    this.profile = profile;
     this.render();
-  }
-
-  createMessage(model, options = {}) {
-    if (!model) {
-      throw new Error('Please provide a model.');
-    }
-
-    const initialState = {};
-
-    if (model.get('outgoing')) {
-      initialState.avatarHashes = app.profile.get('avatarHashes').toJSON();
-    } else if (this.otherProfile) {
-      initialState.avatarHashes = this.otherProfile.get('avatarHashes').toJSON();
-    }
-
-    const convoMessage = this.createChild(ConvoMessage, {
-      ...options,
-      model,
-      initialState: {
-        ...options.initialState,
-        ...initialState,
-      },
-    });
-
-    this.convoMessages.push(convoMessage);
-
-    return convoMessage;
   }
 
   markMessageAsRead(id) {
@@ -90,6 +63,33 @@ export default class extends baseVw {
         }
       }
     }
+  }
+
+  createMessage(model, options = {}) {
+    if (!model) {
+      throw new Error('Please provide a model.');
+    }
+
+    const initialState = {};
+
+    if (model.get('outgoing')) {
+      initialState.avatarHashes = app.profile.get('avatarHashes').toJSON();
+    } else if (this.profile) {
+      initialState.avatarHashes = this.profile.get('avatarHashes').toJSON();
+    }
+
+    const convoMessage = this.createChild(ConvoMessage, {
+      ...options,
+      model,
+      initialState: {
+        ...options.initialState,
+        ...initialState,
+      },
+    });
+
+    this.convoMessages.push(convoMessage);
+
+    return convoMessage;
   }
 
   render() {

--- a/js/views/chat/ConvoProfileHeader.js
+++ b/js/views/chat/ConvoProfileHeader.js
@@ -1,0 +1,64 @@
+import _ from 'underscore';
+import loadTemplate from '../../utils/loadTemplate';
+import baseVw from '../baseVw';
+
+export default class extends baseVw {
+  constructor(options = {}) {
+    super(options);
+
+    this._state = {
+      status: 'not-connected',
+      ...options.initialState || {},
+    };
+  }
+
+  className() {
+    return 'flexVCent gutterH convoProfileHeader';
+  }
+
+  events() {
+    return {
+      // 'click .js-closeConvo': 'onClickCloseConvo',
+    };
+  }
+
+  getState() {
+    return this._state;
+  }
+
+  setState(state, replace = false) {
+    let newState;
+
+    if (replace) {
+      this._state = {};
+    } else {
+      newState = {
+        ...this._state,
+        ...state,
+      };
+    }
+
+    if (!_.isEqual(this._state, newState)) {
+      this._state = newState;
+      this.render();
+    }
+
+    return this;
+  }
+
+  // remove() {
+  //   super.remove();
+  // }
+
+  render() {
+    loadTemplate('chat/convoProfileHeader.html', (t) => {
+      this.$el.html(t({
+        ...this._state,
+      }));
+
+      // this._$deleteConfirm = null;
+    });
+
+    return this;
+  }
+}

--- a/js/views/chat/ConvoProfileHeader.js
+++ b/js/views/chat/ConvoProfileHeader.js
@@ -16,12 +16,6 @@ export default class extends baseVw {
     return 'flexVCent gutterH convoProfileHeader';
   }
 
-  events() {
-    return {
-      // 'click .js-closeConvo': 'onClickCloseConvo',
-    };
-  }
-
   getState() {
     return this._state;
   }
@@ -46,17 +40,11 @@ export default class extends baseVw {
     return this;
   }
 
-  // remove() {
-  //   super.remove();
-  // }
-
   render() {
     loadTemplate('chat/convoProfileHeader.html', (t) => {
       this.$el.html(t({
         ...this._state,
       }));
-
-      // this._$deleteConfirm = null;
     });
 
     return this;

--- a/js/views/userPage/UserPage.js
+++ b/js/views/userPage/UserPage.js
@@ -81,7 +81,8 @@ export default class extends baseVw {
 
   messageClick() {
     // activate the chat message
-    console.log('message');
+    // app.chat.openConversation(this.model.id, this.model);
+    app.chat.openConversation(this.model.id);
   }
 
   moreClick() {

--- a/js/views/userPage/UserPage.js
+++ b/js/views/userPage/UserPage.js
@@ -81,7 +81,6 @@ export default class extends baseVw {
 
   messageClick() {
     // activate the chat message
-    // app.chat.openConversation(this.model.id, this.model);
     app.chat.openConversation(this.model.id);
   }
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "is_js": "^0.8.0",
     "jquery": "^3.0.0",
     "jquery-zoom": "^1.7.18",
+    "moment": "^2.17.1",
     "multihashes": "^0.2.2",
     "node-polyglot": "^2.0.0",
     "open": "0.0.5",

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -183,7 +183,7 @@ ul, ol {
     top: 105px;
     right: $scrollbar; // don't cover scroll bars
     width: $chatClosed;
-    height: calc(100% - 150px);
+    height: calc(100% - 150px); // for now keep chat above "testing only" badge
     z-index: 2; // chat needs to be on top of modals
     @include chatOpeningTransition(width);
     overflow-y: auto;

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -210,10 +210,16 @@ ul, ol {
   #chatConvoContainer {
     position: fixed;
     right: 0;
-    bottom: 41px;
-    border-width: 1px;
-    border-style: solid;
+    bottom: 44px;
     z-index: 2; // chat needs to be on top of modals
+    width: 250px;
+    height: 360px;
+    transform: translateY(105%);
+    transition: transform 0.5s ease;
+
+    .chatConvoOpen & {
+      transform: translateY(0);
+    }
   }
 }
 

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -206,6 +206,15 @@ ul, ol {
       width: $chatOpen;
     }
   }
+
+  #chatConvoContainer {
+    position: fixed;
+    right: 0;
+    bottom: 41px;
+    border-width: 1px;
+    border-style: solid;
+    z-index: 2; // chat needs to be on top of modals
+  }
 }
 
 // turn off animations and transitions with this style

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -179,6 +179,7 @@ ul, ol {
   }
 
   #chatContainer {
+    background-color: orange;
     position: fixed;
     top: 105px;
     right: $scrollbar; // don't cover scroll bars
@@ -186,21 +187,21 @@ ul, ol {
     height: calc(100% - 100px);
     z-index: 2; // chat needs to be on top of modals
     @include chatOpeningTransition(width);
-    overflow-y: auto;
-    overflow-x: hidden;
+    // overflow-y: auto;
+    // overflow-x: hidden;
 
-    &::-webkit-scrollbar {
-      width: 0;
-    }
+    // &::-webkit-scrollbar {
+    //   width: 0;
+    // }
 
-    &:hover {
-      right: 0;
-      padding-right: $scrollbar;
+    // &:hover {
+    //   right: 0;
+    //   padding-right: $scrollbar;
 
-      &::-webkit-scrollbar {
-        width: $scrollbar;
-      }
-    }
+    //   &::-webkit-scrollbar {
+    //     width: $scrollbar;
+    //   }
+    // }
 
     .chatOpen & {
       width: $chatOpen;

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -205,11 +205,6 @@ ul, ol {
     .chatOpen & {
       width: $chatOpen;
     }
-
-    .chatWrapper {
-      justify-content: flex-start;
-      padding: $padSm $padSm $padSm 0;
-    }
   }
 }
 

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -112,7 +112,7 @@ ul, ol {
   // index containers and sections
   #pageNavContainer {
     position: relative;
-    z-index: 3;
+    z-index: 4;
   }
 
   #contentFrame {
@@ -179,7 +179,6 @@ ul, ol {
   }
 
   #chatContainer {
-    background-color: orange;
     position: fixed;
     top: 105px;
     right: $scrollbar; // don't cover scroll bars
@@ -187,21 +186,21 @@ ul, ol {
     height: calc(100% - 100px);
     z-index: 2; // chat needs to be on top of modals
     @include chatOpeningTransition(width);
-    // overflow-y: auto;
-    // overflow-x: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
 
-    // &::-webkit-scrollbar {
-    //   width: 0;
-    // }
+    &::-webkit-scrollbar {
+      width: 0;
+    }
 
-    // &:hover {
-    //   right: 0;
-    //   padding-right: $scrollbar;
+    &:hover {
+      right: 0;
+      padding-right: $scrollbar;
 
-    //   &::-webkit-scrollbar {
-    //     width: $scrollbar;
-    //   }
-    // }
+      &::-webkit-scrollbar {
+        width: $scrollbar;
+      }
+    }
 
     .chatOpen & {
       width: $chatOpen;

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -183,7 +183,7 @@ ul, ol {
     top: 105px;
     right: $scrollbar; // don't cover scroll bars
     width: $chatClosed;
-    height: calc(100% - 100px);
+    height: calc(100% - 150px);
     z-index: 2; // chat needs to be on top of modals
     @include chatOpeningTransition(width);
     overflow-y: auto;

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -210,12 +210,12 @@ ul, ol {
   #chatConvoContainer {
     position: fixed;
     right: 0;
-    bottom: 44px;
+    bottom: 42px;
     z-index: 2; // chat needs to be on top of modals
     width: 250px;
     height: 360px;
     transform: translateY(105%);
-    transition: transform 0.5s ease;
+    transition: transform 300ms ease;
 
     .chatConvoOpen & {
       transform: translateY(0);

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -301,3 +301,11 @@ input[type=range][class~="clrS"] {
     border-color: $border3;
   }
 }
+
+.chatHead {
+  &.active {
+    .headContent {
+      border-color: $border3;
+    }
+  }
+}

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -295,3 +295,9 @@ input[type=range][class~="clrS"] {
     border-color: $border;
   }
 }
+
+#chatConvoContainer {
+  .chatConversation {
+    border-color: $border3;
+  }
+}

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -46,7 +46,7 @@ $padHg: $pad * 2.5;
 $padGi: $pad * 4;
 $marg: 10px;
 $chatClosed: 48px;
-$chatOpen: 220px;
+$chatOpen: 225px;
 $pageWidth: 950px;
 $scrollbar: 8px;
 $modalContentInner: 957px;

--- a/styles/components/_modal.scss
+++ b/styles/components/_modal.scss
@@ -61,7 +61,7 @@
       .chatOpen & {
         left: 0;
         // adjust by 5px to visually center
-        margin-left: calc(((100% - (#{$modalContentInner + $chatOpen})) / 2) + 5px);
+        margin-left: calc(((100% - (#{$modalContentInner + $chatOpen})) / 2));
       }
 
       & > .cornerTR {

--- a/styles/components/_modal.scss
+++ b/styles/components/_modal.scss
@@ -60,8 +60,7 @@
 
       .chatOpen & {
         left: 0;
-        // adjust by 5px to visually center
-        margin-left: calc(((100% - (#{$modalContentInner + $chatOpen})) / 2));
+        margin-left: calc(((100% - (#{$modalContentInner + ($chatOpen - 5)})) / 2));
       }
 
       & > .cornerTR {

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -151,11 +151,11 @@
       margin-bottom: 5px;
     }
 
-    .convoMessage {
-      &:first-child {
-        margin-top: $pad;
-      }
+    .chatConvoMessages {
+      padding: 10px 0;
+    }
 
+    .convoMessage {
       .msgContentBox {
         padding: $padSm;
         margin-top: 3px;

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -58,24 +58,49 @@
 
     .topUnreadBanner, .bottomUnreadBanner {
       display: none;
+      padding: $pad;
+      font-size: $tx6;
+      position: fixed;
+      right: ($chatClosed / 2) - 8;
+      font-weight: bold;
+      border-radius: $corner;
+      @include chatOpeningTransition(all);
+
+      .fullText {
+        display: none
+      }
+
+      .chatOpen & {
+        right: $chatOpen / 2;
+        transform: translateX(50%);
+
+        .arrowOnly {
+          display: none;
+        }
+
+        .fullText {
+          display: inline;          
+        }
+      }
+
+      &:hover {
+        text-decoration: none;
+      }
     }
 
     &.outOfViewUnreadsAbove {
       .topUnreadBanner {
         display: block;
-        position: fixed;
         top: 105px; // todo: create $chatTop variable if we keep this implementation
-        right: $chatClosed / 2;
-        transform: translateX(50%);
-        @include chatOpeningTransition(right);
-
-        .chatOpen & {
-          right: $chatOpen / 2;
-        }
       }
     }
 
-    &.outOfViewUnreadsBelow {}
+    &.outOfViewUnreadsBelow {
+      .bottomUnreadBanner {
+        display: block;
+        bottom: 45px;
+      }      
+    }
   }
 }
 

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -123,6 +123,33 @@
     .convoProfileHeader {
       .handle {
         max-width: 128px;
+        display: block;
+        font-weight: bold;
+      }
+    }
+  }
+
+  .convoMessagesWrap {
+    padding-left: $padSm;
+    padding-right: $padSm;
+  }
+
+  .subMenu {
+    padding: $pad;
+    width: 130px;
+    border-style: solid;
+    border-width: 1px;
+    border-top-width: 0;
+    border-right-width: 0;
+    font-size: $tx6;
+    position: absolute;
+    right: 0;
+
+    & > * {
+      padding-bottom: $pad;
+
+      &:last-child {
+        padding: 0;
       }
     }
   }
@@ -133,8 +160,17 @@
 
     input[type=text] {
       border-width: 0;
-      height: 45px;
     }
+  }
+
+  .overlay {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    background-color: white;
+    opacity: 0.7;
   }
 }
 

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -157,7 +157,7 @@
       max-width: 190px;
       z-index: 1;
       padding: $padSm $pad;
-      transition: transform 0.25s ease;
+      transition: transform 0.3s ease;
 
       .typingUsername {
         max-width: 121px;

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -20,6 +20,29 @@
   // use for chat styles that only apply inside the chat sidebar
 
   .chatHead {
+    cursor: pointer;
+    position: relative;
+    padding-left: 5px;
+
+    .unreadBadge {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 20px;
+      height: 20px;
+      font-size: $tx5;
+      font-weight: bold;
+      text-align: center;
+      border-width: 1px;
+      border-style: solid;
+    }
+
+    .handleGuid {
+      max-width: 60px;
+      display: inline-block;
+      vertical-align: middle;
+    }
+
     &:first-child {
       margin-top: 5px;
     }

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -1,5 +1,10 @@
 #chatContainer {
   // use for chat styles that only apply inside the chat sidebar
+
+  .chatWrapper {
+    justify-content: flex-start;
+    padding: $padSm $padSm $padSm 0;
+  }  
 }
 
 .chat {

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -43,11 +43,18 @@
         }
       }
 
+      .headContent {
+        padding: $padSm;
+        max-height: 31px;
+      }
+
       .handleGuid {
         max-width: 60px;
         display: inline-block;
         vertical-align: middle;
       }
+
+
 
       &:first-child {
         margin-top: 5px;
@@ -179,6 +186,10 @@
           padding: $padSm;
           margin-top: 3px;
           display: inline-block;
+
+          img {
+            max-width: 100%;
+          }
         }
 
         .timestampLine {

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -28,13 +28,18 @@
       position: absolute;
       top: 0;
       left: 0;
-      width: 20px;
-      height: 20px;
-      font-size: $tx5;
+      width: 22px;
+      height: 22px;
+      line-height: 18px;
+      font-size: $tx5b;
       font-weight: bold;
       text-align: center;
       border-width: 1px;
       border-style: solid;
+
+      &.ellipsisShown {
+        line-height: 14px;
+      }
     }
 
     .handleGuid {

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -130,8 +130,49 @@
   }
 
   .convoMessagesWrap {
-    padding-left: $padSm;
-    padding-right: $padSm;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding-left: $pad;
+    padding-right: $pad;
+
+    .spinner {
+      display: none;
+      margin: 0 auto;
+      padding: $pad;
+    }
+
+    .messagesFetchError {
+      margin-top: 10px;
+      margin-bottom: 5px;
+    }
+  }
+
+  &.loadingMessages {
+    .spinner {
+      display: block;
+    }
+
+    &.noMessages {
+      .spinner {
+        @include center();
+        width: 55px;
+        height: 55px;
+      }
+
+      .messagesFetchError {
+        @include center();
+      }
+    }
+  }
+
+  &.noMessages {
+    .messagesFetchError {
+      @include center();
+      margin: 0;
+    }
   }
 
   .subMenu {
@@ -171,7 +212,34 @@
     left: 0;
     background-color: white;
     opacity: 0.7;
+    // display: none;
+
+    // .spinner {
+    //   display: none;
+    //   position: absolute;
+    //   top: 50%;
+    //   left: 50%;
+    //   transform: translate(-50%, -50%);
+    //   width: 55px;
+    //   height: 55px;
+    // }
   }
+
+  // &.overlayOn {
+  //   .overlay {
+  //     display: block;
+  //   }
+  // }
+
+  // &.loading {
+  //   .overlay {
+  //     display: block;
+
+  //     .spinner {
+  //       display: block;
+  //     }
+  //   }
+  // }
 }
 
 .chat {

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -110,6 +110,7 @@
   .convoHeader {
     border-bottom-style: solid;
     border-bottom-width: 1px;
+    z-index: 2;
 
     .btn {
       border-width: 0;
@@ -129,7 +130,7 @@
     }
   }
 
-  .convoMessagesWrap {
+  .convoMessagesWindow {
     position: absolute;
     top: 0;
     left: 0;
@@ -146,6 +147,25 @@
       padding: $pad;
     }
 
+    .typingIndicator {
+      position: fixed;
+      left: 50%;
+      transform: translate(-50%, -103%);
+      border-style: solid;
+      border-width: 1px;
+      border-top-width: 0;
+      max-width: 190px;
+      z-index: 1;
+      padding: $padSm $pad;
+      transition: transform 0.25s ease;
+
+      .typingUsername {
+        max-width: 121px;
+        display: inline-block;
+        vertical-align: middle;
+      }
+    }
+
     .messagesFetchError {
       margin-top: 10px;
       margin-bottom: 5px;
@@ -153,19 +173,19 @@
 
     .chatConvoMessages {
       padding: 10px 0;
-    }
 
-    .convoMessage {
-      .msgContentBox {
-        padding: $padSm;
-        margin-top: 3px;
-        display: inline-block;
-      }
+      .convoMessage {
+        .msgContentBox {
+          padding: $padSm;
+          margin-top: 3px;
+          display: inline-block;
+        }
 
-      .timestampLine {
-        position: absolute;
-        margin-top: 3px;
-      }
+        .timestampLine {
+          position: absolute;
+          margin-top: 3px;
+        }
+      }      
     }
   }
 
@@ -192,6 +212,12 @@
       @include center();
       margin: 0;
     }
+  }
+
+  &.isTyping {
+    .typingIndicator {
+      transform: translate(-50%, 0);
+    }    
   }
 
   .subMenu {

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -204,6 +204,7 @@
     font-size: $tx6;
     position: absolute;
     right: 0;
+    z-index: 1;
 
     & > * {
       padding-bottom: $pad;
@@ -231,6 +232,7 @@
     left: 0;
     background-color: white;
     opacity: 0.7;
+    z-index: 1;
   }
 
   .chatIcon {

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -220,6 +220,27 @@
     }    
   }
 
+  .deletingOverlay {
+    display: none;
+    font-size: $tx4;
+
+    & > div {
+      @include center();
+      width: 100%;
+      text-align: center;
+    }
+  }
+
+  &.isDeleting {
+    .deletingOverlay {
+      display: block;
+    }
+
+    .deleteConvoMenuItem {
+      @include disabled;
+    }
+  }
+
   .subMenu {
     padding: $pad;
     width: 130px;

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -186,6 +186,7 @@
           padding: $padSm;
           margin-top: 3px;
           display: inline-block;
+          word-break: break-word;
 
           img {
             max-width: 100%;

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -157,7 +157,7 @@
     .typingIndicator {
       position: fixed;
       left: 50%;
-      transform: translate(-50%, -103%);
+      transform: translate(-50%, -110%);
       border-style: solid;
       border-width: 1px;
       border-top-width: 0;

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -102,9 +102,35 @@
   }
 }
 
-#chatConvoContainer {
-  width: 250px;
-  height: 360px;
+.chatConversation {
+  border-width: 1px;
+  border-style: solid;  
+  height: 100%;
+
+  .convoHeader {
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+
+    .btn {
+      border-width: 0;
+      width: 20px;
+
+      &.ion-ios-close-empty {
+        font-size: $tx1;
+        margin-right: 5px;
+      }
+    }
+  }
+
+  .convoFooter {
+    border-top-style: solid;
+    border-top-width: 1px;
+
+    input[type=text] {
+      border-width: 0;
+      height: 45px;
+    }
+  }
 }
 
 .chat {

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -19,8 +19,6 @@
 #chatContainer {
   // use for chat styles that only apply inside the chat sidebar
 
-  // position: relative; // needs non static position - _base.scss gives it fixed
-
   .chat {
     .chatHead {
       cursor: pointer;
@@ -102,6 +100,11 @@
       }      
     }
   }
+}
+
+#chatConvoContainer {
+  width: 250px;
+  height: 360px;
 }
 
 .chat {

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -1,55 +1,27 @@
-#chatContainer {
-  position: relative;
+#chatCloseBtn {
+  position: absolute;
+  top: 65px;
+  right: -220px;
+  width: 40px;
+  height: 40px;
+  z-index: 3;
+  border-radius: 0;
+  font-size: $tx1;
+  border-right-width: 0;
+  border-bottom-width: 0;
+  @include chatOpeningTransition(right);
 
+  .chatOpen & {
+    right: 1px;
+  }
+}
+
+#chatContainer {
   // use for chat styles that only apply inside the chat sidebar
 
-  .chatCloseBtn {
-    // display: none;
-    position: absolute;
-    top: -40px;
-    right: 0;
-    width: 40px;
-    height: 40px; 
-    border-radius: 0;
-    font-size: $tx1;
-    border-right-width: 0;
-    border-bottom-width: 0;
-  }
-
-  .chatScrollWrapper {
-    // position: fixed;
-    // top: 105px;
-    // right: $scrollbar; // don't cover scroll bars
-    // width: $chatClosed;
-    // height: calc(100% - 100px);
-    height: 100%;
-    height: 300px;
-    // z-index: 2; // chat needs to be on top of modals
-    // @include chatOpeningTransition(width);
-    overflow-y: auto;
-    overflow-x: hidden;
-
-    &::-webkit-scrollbar {
-      width: 0;
-    }
-
-    &:hover {
-      right: 0;
-      padding-right: $scrollbar;
-
-      &::-webkit-scrollbar {
-        width: $scrollbar;
-      }
-    }
-
-    // .chatOpen & {
-    //   width: $chatOpen;
-    // }    
-    
-    .chatWrapper {
-      justify-content: flex-start;
-      padding: $padSm $padSm $padSm 0;
-      padding: $padSm 0 $padSm;
+  .chatHead {
+    &:first-child {
+      margin-top: 5px;
     }
   }
 }

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -223,8 +223,8 @@
   }
 
   .chatIcon {
-    width: 40px;
-    height: 40px;
+    width: 38px;
+    height: 38px;
   }
 }
 

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -19,38 +19,63 @@
 #chatContainer {
   // use for chat styles that only apply inside the chat sidebar
 
-  .chatHead {
-    cursor: pointer;
-    position: relative;
-    padding-left: 5px;
+  // position: relative; // needs non static position - _base.scss gives it fixed
 
-    .unreadBadge {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 22px;
-      height: 22px;
-      line-height: 18px;
-      font-size: $tx5b;
-      font-weight: bold;
-      text-align: center;
-      border-width: 1px;
-      border-style: solid;
+  .chat {
+    .chatHead {
+      cursor: pointer;
+      position: relative;
+      padding-left: 5px;
 
-      &.ellipsisShown {
-        line-height: 14px;
+      .unreadBadge {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 22px;
+        height: 22px;
+        line-height: 18px;
+        font-size: $tx5b;
+        font-weight: bold;
+        text-align: center;
+        border-width: 1px;
+        border-style: solid;
+
+        &.ellipsisShown {
+          line-height: 14px;
+        }
+      }
+
+      .handleGuid {
+        max-width: 60px;
+        display: inline-block;
+        vertical-align: middle;
+      }
+
+      &:first-child {
+        margin-top: 5px;
       }
     }
 
-    .handleGuid {
-      max-width: 60px;
-      display: inline-block;
-      vertical-align: middle;
+    .topUnreadBanner, .bottomUnreadBanner {
+      display: none;
     }
 
-    &:first-child {
-      margin-top: 5px;
+    &.outOfViewUnreadsAbove {
+      .topUnreadBanner {
+        display: block;
+        position: fixed;
+        top: 105px; // todo: create $chatTop variable if we keep this implementation
+        right: $chatClosed / 2;
+        transform: translateX(50%);
+        @include chatOpeningTransition(right);
+
+        .chatOpen & {
+          right: $chatOpen / 2;
+        }
+      }
     }
+
+    &.outOfViewUnreadsBelow {}
   }
 }
 

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -155,6 +155,17 @@
       &:first-child {
         margin-top: $pad;
       }
+
+      .msgContentBox {
+        padding: $padSm;
+        margin-top: 3px;
+        display: inline-block;
+      }
+
+      .timestampLine {
+        position: absolute;
+        margin-top: 3px;
+      }
     }
   }
 

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -54,8 +54,6 @@
         vertical-align: middle;
       }
 
-
-
       &:first-child {
         margin-top: 5px;
       }

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -1,10 +1,57 @@
 #chatContainer {
+  position: relative;
+
   // use for chat styles that only apply inside the chat sidebar
 
-  .chatWrapper {
-    justify-content: flex-start;
-    padding: $padSm $padSm $padSm 0;
-  }  
+  .chatCloseBtn {
+    // display: none;
+    position: absolute;
+    top: -40px;
+    right: 0;
+    width: 40px;
+    height: 40px; 
+    border-radius: 0;
+    font-size: $tx1;
+    border-right-width: 0;
+    border-bottom-width: 0;
+  }
+
+  .chatScrollWrapper {
+    // position: fixed;
+    // top: 105px;
+    // right: $scrollbar; // don't cover scroll bars
+    // width: $chatClosed;
+    // height: calc(100% - 100px);
+    height: 100%;
+    height: 300px;
+    // z-index: 2; // chat needs to be on top of modals
+    // @include chatOpeningTransition(width);
+    overflow-y: auto;
+    overflow-x: hidden;
+
+    &::-webkit-scrollbar {
+      width: 0;
+    }
+
+    &:hover {
+      right: 0;
+      padding-right: $scrollbar;
+
+      &::-webkit-scrollbar {
+        width: $scrollbar;
+      }
+    }
+
+    // .chatOpen & {
+    //   width: $chatOpen;
+    // }    
+    
+    .chatWrapper {
+      justify-content: flex-start;
+      padding: $padSm $padSm $padSm 0;
+      padding: $padSm 0 $padSm;
+    }
+  }
 }
 
 .chat {
@@ -13,5 +60,7 @@
   .chatIcon {
     border-width: 2px;
     border-style: solid;
+    width: 38px;
+    height: 38px;
   }
 }

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -135,8 +135,10 @@
     left: 0;
     right: 0;
     bottom: 0;
-    padding-left: $pad;
-    padding-right: $pad;
+    padding-left: $padSm;
+    padding-right: $padSm;
+    overflow-x: hidden;
+    overflow-y: auto;
 
     .spinner {
       display: none;
@@ -147,6 +149,12 @@
     .messagesFetchError {
       margin-top: 10px;
       margin-bottom: 5px;
+    }
+
+    .convoMessage {
+      &:first-child {
+        margin-top: $pad;
+      }
     }
   }
 
@@ -212,34 +220,12 @@
     left: 0;
     background-color: white;
     opacity: 0.7;
-    // display: none;
-
-    // .spinner {
-    //   display: none;
-    //   position: absolute;
-    //   top: 50%;
-    //   left: 50%;
-    //   transform: translate(-50%, -50%);
-    //   width: 55px;
-    //   height: 55px;
-    // }
   }
 
-  // &.overlayOn {
-  //   .overlay {
-  //     display: block;
-  //   }
-  // }
-
-  // &.loading {
-  //   .overlay {
-  //     display: block;
-
-  //     .spinner {
-  //       display: block;
-  //     }
-  //   }
-  // }
+  .chatIcon {
+    width: 40px;
+    height: 40px;
+  }
 }
 
 .chat {

--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -117,7 +117,12 @@
 
       &.ion-ios-close-empty {
         font-size: $tx1;
-        margin-right: 5px;
+      }
+    }
+
+    .convoProfileHeader {
+      .handle {
+        max-width: 128px;
       }
     }
   }


### PR DESCRIPTION
closes #354 
closes #386 
closes #384 

This doesn't include Emoji support. I'm starting on that now, so you'll still see commits coming into here, but wanted to have the review on this PR start, since it's a decent size feature.

Also @jjeffryes, some CSS tweaks will be needed to account for the close button. I'm not sure the best (least painful) way to approach those. Basically, the close button has different states depending on what's behind it:

1.) Overlay is behind it.
![image](https://cloud.githubusercontent.com/assets/794517/23480224/0d3b073e-fe7c-11e6-9dc8-ff4e8867ee11.png)

2.) Page with a tab bar behind it:
![image](https://cloud.githubusercontent.com/assets/794517/23480307/5c7ae08a-fe7c-11e6-89c7-4bd38abc1178.png)

2.) Page without a tab bar behind it (e.g. Connected Peers page). The Connected Peers is a dummy page. You may want to check the designs / @morebrownies to find out if there are any real pages without tab bars that we need to account for:
![image](https://cloud.githubusercontent.com/assets/794517/23480365/876def26-fe7c-11e6-9e16-dd2cfd18d855.png)

Ideally, the chat wouldn't have to be aware of what's behind it... but unless we come up with something clever, that might just have to be the case. We already have a root level class that tells us if a model is open, which would account for 1.

For 2 and 3, since the presence of a tab bar is determined by individual changes, each page would need to manage a top level class, which is not ideal, but if there's no other way, I suppose we could work a flag into the base view or create a pageView which all pages descend from.

Anyhow... good luck!



