### PR TITLE
fixing issue where a variable name was referring to a previous version…

### DIFF
--- a/js/views/chat/Conversation.js
+++ b/js/views/chat/Conversation.js
@@ -392,9 +392,9 @@ export default class extends baseVw {
   }
 
   onEmojiSelected(e) {
-    insertAtCursor(this.$inputMessage[0], emojis[e.emoji].name);
+    insertAtCursor(this.$messageInput[0], emojis[e.emoji].name);
     this.closeEmojiMenu();
-    this.$inputMessage.focus();
+    this.$messageInput.focus();
   }
 
   showTypingIndicator() {


### PR DESCRIPTION
… of a var name

A selector name had been renamed and a relevant piece of code was not updated to reference the new name. This fixes that issue.