### PR TITLE
Add tag on blur

### DIFF
--- a/js/views/modals/editListing/EditListing.js
+++ b/js/views/modals/editListing/EditListing.js
@@ -972,6 +972,7 @@ export default class extends BaseModal {
       this.$editListingTags.select2({
         multiple: true,
         tags: true,
+        selectOnClose: true,
         // ***
         // placeholder has issue where it won't show initially, will use
         // own element for this instead
@@ -1027,6 +1028,7 @@ export default class extends BaseModal {
       this.$editListingCategories.select2({
         multiple: true,
         tags: true,
+        selectOnClose: true,
         // dropdownParent needed to fully hide dropdown
         dropdownParent: this.$('#editListingCategoriesDropdown'),
         // This is necessary, see comment in select2 for tags above.

--- a/js/views/modals/editListing/EditListing.js
+++ b/js/views/modals/editListing/EditListing.js
@@ -983,6 +983,9 @@ export default class extends BaseModal {
         dropdownParent: this.$('#editListingTagsDropdown'),
         createTag: (params) => {
           let term = params.term;
+          if (term === '') {
+            return null; // don't add blank tags triggered by blur
+          }
 
           // we'll make the tag all lowercase and
           // replace spaces with dashes.

--- a/js/views/modals/editListing/EditListing.js
+++ b/js/views/modals/editListing/EditListing.js
@@ -973,6 +973,7 @@ export default class extends BaseModal {
         multiple: true,
         tags: true,
         selectOnClose: true,
+        tokenSeparators: [','],
         // ***
         // placeholder has issue where it won't show initially, will use
         // own element for this instead
@@ -1029,6 +1030,7 @@ export default class extends BaseModal {
         multiple: true,
         tags: true,
         selectOnClose: true,
+        tokenSeparators: [','],
         // dropdownParent needed to fully hide dropdown
         dropdownParent: this.$('#editListingCategoriesDropdown'),
         // This is necessary, see comment in select2 for tags above.

--- a/js/views/modals/editListing/Variant.js
+++ b/js/views/modals/editListing/Variant.js
@@ -64,6 +64,7 @@ export default class extends BaseView {
       this.$variantChoicesSelect.select2({
         multiple: true,
         tags: true,
+        selectOnClose: true,
         // dropdownParent needed to fully hide dropdown
         dropdownParent: this.$('.js-dropDownContainer'),
         matcher: () => false, // this is necessary

--- a/js/views/modals/editListing/Variant.js
+++ b/js/views/modals/editListing/Variant.js
@@ -65,6 +65,7 @@ export default class extends BaseView {
         multiple: true,
         tags: true,
         selectOnClose: true,
+        tokenSeparators: [','],
         // dropdownParent needed to fully hide dropdown
         dropdownParent: this.$('.js-dropDownContainer'),
         matcher: () => false, // this is necessary


### PR DESCRIPTION
This adds the very poorly documented selectOnClose: true, attribute to the tag only instances of select2 in the edit listing modal, so the tags are applied when the element loses focus.

This also sets the inputs to apply the tags when a comma is typed.