### PR TITLE
Adjust css so table has even margins and full width inputs.

### DIFF
--- a/styles/modules/modals/_editListing.scss
+++ b/styles/modules/modals/_editListing.scss
@@ -30,7 +30,7 @@
         position: absolute;
         top: 0;
         left: 0;
-      }      
+      }
 
       .btn {
         width: 61px;
@@ -69,7 +69,7 @@
 
             &.addElement {
               cursor: default;
-              
+
               .imagesIcon {
                 font-size: 50px;
                 @include center;
@@ -110,7 +110,7 @@
 
         form {
           label {
-            font-weight: 400;          
+            font-weight: 400;
           }
 
           .servicesWrap {
@@ -120,7 +120,7 @@
 
               .btnRemoveService {
                 height: auto;
-                width: 50px;                
+                width: 50px;
               }
 
               &:first-child {
@@ -168,7 +168,7 @@
           .couponsContainer {
             display: block;
           }
-          
+
           .btnAddCoupon {
             display: none;
           }
@@ -189,7 +189,7 @@
 
             &::after {
               right: 94px;
-            }          
+            }
           }
 
           .btnRemoveCoupon {
@@ -204,7 +204,7 @@
           .variantsContainer {
             display: block;
           }
-          
+
           .addFirstVariant {
             display: none;
           }
@@ -220,7 +220,7 @@
             .select2-selection__choice {
               margin-top: 6px;
             }
-            
+
             .select2-search__field {
               height: 22px;
             }
@@ -242,11 +242,11 @@
       }
 
       .variantInventorySection {
-        padding-right: 0;
 
         table {
           border-spacing: 0;
           border-collapse: collapse;
+          width: 100%;
 
           th {
             text-align: left;
@@ -257,18 +257,17 @@
             border-style: solid;
             padding: $pad;
             word-break: break-word;
-            min-width: 125px;
+            min-width: 120px;
             max-width: 125px;
 
             input[type=text] {
-              width: 100px;
-              max-width: 100px;
+              width: 100%;
             }
 
             &:last-child {
               border-right-width: 0;
             }
-            
+
             &.unconstrainedWidth {
               white-space: nowrap;
               width: auto;

--- a/styles/modules/modals/_editListing.scss
+++ b/styles/modules/modals/_editListing.scss
@@ -257,15 +257,11 @@
             border-style: solid;
             padding: $pad;
             word-break: break-word;
-            min-width: 120px;
+            min-width: 90px;
             max-width: 125px;
 
             input[type=text] {
               width: 100%;
-            }
-
-            &:last-child {
-              border-right-width: 0;
             }
 
             &.unconstrainedWidth {


### PR DESCRIPTION
A few minor tweaks to the CSS so the variant inventory table has even margins, and the inputs fill their cells. It seemed more expedient to make this a PR than to put in a comment, since I'd already made the change in the web dev panel when checking why the right padding was 0.

Before:
![image](https://cloud.githubusercontent.com/assets/1584275/24123224/0a4e6962-0d95-11e7-8458-df1d2346a8d6.png)

After:
![image](https://cloud.githubusercontent.com/assets/1584275/24123193/f53db8a2-0d94-11e7-83af-4fdd05d6aa4c.png)
