### PR TITLE
removing reference in the readme to non-dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Installation
 Running
 -------
 
-Use this option if you're actively developing on the client and want the client started along with some helper development processes.
-
 `npm start` will:
 - compile your Sass / re-compile on changes
 - run BrowserSync in watch mode so the app automatically refreshes on JS and HTML changes and dynamically injects any CSS / Sass changes**.

--- a/README.md
+++ b/README.md
@@ -11,16 +11,8 @@ Installation
   - `cd openbazaar-desktop`
 3. `npm install`
 
-Running in non-dev mode
--------------------
-
-Use this option if you're not actively developing on the client and just want to run the client from source.
-
-`npm run start-app` will:
-- launch the Electron app
-
-Running in dev mode
--------------------
+Running
+-------
 
 Use this option if you're actively developing on the client and want the client started along with some helper development processes.
 


### PR DESCRIPTION
Removing the reference in the readme to non-dev mode since it appears to have quirks. The first time it is run, it will generate this error:
https://github.com/OpenBazaar/openbazaar-desktop/issues/397

The first time you run it you would need to first run `npm process-index` and then `npm start-app`, but really there should be a separate task that handles both of those in one.

Rather than fix this half way, I'm just pulling out the non-dev mode reference for now and when the wrinkles are ironed out, we could add it back it.