### PR TITLE
Tweaks to the table layout in the combos.

### DIFF
--- a/js/templates/modals/editListing/variant.html
+++ b/js/templates/modals/editListing/variant.html
@@ -1,20 +1,22 @@
-<div class="col6 simpleFlexCol">
+<div class="col6">
   <% if (ob.errors['name']) print(ob.formErrorTmpl({ errors: ob.errors['name'] })) %>
   <input type="text" class="clrBr clrP clrSh2 variantNameInput js-variantNameInput" name="name" value="<%= ob.name %>" placeholder="<%= ob.polyT('editListing.variants.titlePlaceholder') %>" maxlength="<%= ob.max.nameLength %>">
 </div>
-<div class="col6 simpleFlexCol">
+<div class="col6">
   <% if (ob.errors['variants']) print(ob.formErrorTmpl({ errors: ob.errors['variants'] })) %>
   <div class="flexRow marginTopAuto">
-    <div class="select2TagsWrap">
-      <!-- WARNING! Styling is dependant on the following elements being in this order. -->
-      <select multiple name="variants" class="clrBr clrP select2Tags" style="width: 100%">
-        <% ob.variants.forEach(variant =>
-            print(`<option value="${variant}" selected>${variant}</option>`)) %>
-      </select>
-      <div class="placeholder tagsPlaceholder js-variantChoicesPlaceholder"><%= ob.polyT('editListing.variants.choicesPlaceholder') %></div>
-      <!-- needed to properly hide the select2 dropdown which we don't want on a tagging field -->
-      <div class="tagsDropdown js-dropDownContainer"></div>
-    </div>                
+    <div class="select2TagFlexWrap">
+      <div class="select2TagsWrap">
+        <!-- WARNING! Styling is dependant on the following elements being in this order. -->
+        <select multiple name="variants" class="clrBr clrP select2Tags" style="width: 100%">
+          <% ob.variants.forEach(variant =>
+              print(`<option value="${variant}" selected>${variant}</option>`)) %>
+        </select>
+        <div class="placeholder tagsPlaceholder js-variantChoicesPlaceholder"><%= ob.polyT('editListing.variants.choicesPlaceholder') %></div>
+        <!-- needed to properly hide the select2 dropdown which we don't want on a tagging field -->
+        <div class="tagsDropdown js-dropDownContainer"></div>
+      </div>
+    </div>
     <a class="iconBtn ion-trash-b clrBr clrP margLSm js-btnRemoveVariant btnRemoveVariant"></a>
   </div>
 </div>

--- a/styles/components/_select2.scss
+++ b/styles/components/_select2.scss
@@ -172,3 +172,10 @@
 .select2TagsWrapDropDown {
   @extend .select2TagsWrap;
 }
+
+.select2TagFlexWrap {
+  // if the select2 tag input has to be in a flex row with other elements, it will overflow the
+  // row if a tag is too long. Wrap select2TagsWrap in this class to prevent that.
+  flex-grow: 1;
+  overflow: hidden;
+}

--- a/styles/modules/modals/_editListing.scss
+++ b/styles/modules/modals/_editListing.scss
@@ -261,11 +261,15 @@
             border-style: solid;
             padding: $pad;
             word-break: break-word;
-            min-width: 90px;
+           // min-width: 90px;
             max-width: 125px;
 
             input[type=text] {
               width: 100%;
+            }
+
+            &.quantityCol input[type=text] {
+              width: 4em;
             }
 
             &.unconstrainedWidth {


### PR DESCRIPTION
I found a bug where a long tag in the variant can break the layout. This patch adds a wrapper class to be used when a select2 tag input is used in a flex container, which will prevent it from growing beyond the size of the container.

This also has a few small tweaks to the combo table that will even out the columns a bit.

**Long tag before:**
![image](https://cloud.githubusercontent.com/assets/1584275/24156526/2e5a270e-0e2d-11e7-96a6-b4ed2f07662a.png)

**Long tag after:**
![image](https://cloud.githubusercontent.com/assets/1584275/24156672/8aebd760-0e2d-11e7-8376-0367ae9eea00.png)

**Tweaked combo table:**
![image](https://cloud.githubusercontent.com/assets/1584275/24156626/6f834e36-0e2d-11e7-874b-ef820c0c34fb.png)

