### PR TITLE
No listings state

### DIFF
--- a/js/views/userPage/Store.js
+++ b/js/views/userPage/Store.js
@@ -158,7 +158,7 @@ export default class extends BaseVw {
     const startTime = Date.now();
 
     xhr.always(() => {
-      if (xhr.state() === 'rejected') {
+      if (xhr.state() === 'rejected' && xhr.status !== 404) {
         // if fetch is triggered by retry button and
         // it immediately fails, it looks like nothing happend,
         // so, we'll make sure it takes a minimum time.
@@ -529,14 +529,14 @@ export default class extends BaseVw {
     if (this.shippingChangePopIn) this.shippingChangePopIn.remove();
 
     const isFetching = this.fetch && this.fetch.state() === 'pending';
-    const fetchFailed = this.fetch && this.fetch.state() === 'rejected';
+    const fetchFailed = this.fetch && this.fetch.state() === 'rejected'
+      && this.fetch.status !== 404;
 
     loadTemplate('userPage/store.html', (t) => {
       this.$el.html(t({
         isFetching,
         fetchFailed,
-        fetchFailReason: this.fetch && this.fetch.state() === 'rejected' &&
-          this.fetch.responseText || '',
+        fetchFailReason: this.fetchFailed && this.fetch.responseText || '',
         filter: this.filter,
         countryList: this.countryList,
         shipsToSelected: this.filter.shipsTo || 'any',


### PR DESCRIPTION
This branch gives a UX friendly no listings state when viewing another person's store:
![image](https://cloud.githubusercontent.com/assets/794517/24172839/fe7cdf80-0e46-11e7-87c7-3cf2187135df.png)

Previously, in this case, a cryptic IPFS error was being shown:
`Path Resolve error: no link named "index.json" under QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`

I think @morebrownies will quite appreciate this one :)
