### PR TITLE
Fix long variant choice breaks layout

### DIFF
--- a/js/templates/modals/editListing/variant.html
+++ b/js/templates/modals/editListing/variant.html
@@ -1,8 +1,8 @@
-<div class="col6">
+<div class="col6 simpleFlexCol">
   <% if (ob.errors['name']) print(ob.formErrorTmpl({ errors: ob.errors['name'] })) %>
   <input type="text" class="clrBr clrP clrSh2 variantNameInput js-variantNameInput" name="name" value="<%= ob.name %>" placeholder="<%= ob.polyT('editListing.variants.titlePlaceholder') %>" maxlength="<%= ob.max.nameLength %>">
 </div>
-<div class="col6">
+<div class="col6 simpleFlexCol">
   <% if (ob.errors['variants']) print(ob.formErrorTmpl({ errors: ob.errors['variants'] })) %>
   <div class="flexRow marginTopAuto">
     <div class="select2TagFlexWrap">

--- a/js/templates/modals/editListing/variant.html
+++ b/js/templates/modals/editListing/variant.html
@@ -1,20 +1,22 @@
-<div class="col6 simpleFlexCol">
+<div class="col6">
   <% if (ob.errors['name']) print(ob.formErrorTmpl({ errors: ob.errors['name'] })) %>
   <input type="text" class="clrBr clrP clrSh2 variantNameInput js-variantNameInput" name="name" value="<%= ob.name %>" placeholder="<%= ob.polyT('editListing.variants.titlePlaceholder') %>" maxlength="<%= ob.max.nameLength %>">
 </div>
-<div class="col6 simpleFlexCol">
+<div class="col6">
   <% if (ob.errors['variants']) print(ob.formErrorTmpl({ errors: ob.errors['variants'] })) %>
   <div class="flexRow marginTopAuto">
-    <div class="select2TagsWrap">
-      <!-- WARNING! Styling is dependant on the following elements being in this order. -->
-      <select multiple name="variants" class="clrBr clrP select2Tags" style="width: 100%">
-        <% ob.variants.forEach(variant =>
-            print(`<option value="${variant}" selected>${variant}</option>`)) %>
-      </select>
-      <div class="placeholder tagsPlaceholder js-variantChoicesPlaceholder"><%= ob.polyT('editListing.variants.choicesPlaceholder') %></div>
-      <!-- needed to properly hide the select2 dropdown which we don't want on a tagging field -->
-      <div class="tagsDropdown js-dropDownContainer"></div>
-    </div>                
+    <div class="select2TagFlexWrap">
+      <div class="select2TagsWrap">
+        <!-- WARNING! Styling is dependant on the following elements being in this order. -->
+        <select multiple name="variants" class="clrBr clrP select2Tags" style="width: 100%">
+          <% ob.variants.forEach(variant =>
+              print(`<option value="${variant}" selected>${variant}</option>`)) %>
+        </select>
+        <div class="placeholder tagsPlaceholder js-variantChoicesPlaceholder"><%= ob.polyT('editListing.variants.choicesPlaceholder') %></div>
+        <!-- needed to properly hide the select2 dropdown which we don't want on a tagging field -->
+        <div class="tagsDropdown js-dropDownContainer"></div>
+      </div>
+    </div>
     <a class="iconBtn ion-trash-b clrBr clrP margLSm js-btnRemoveVariant btnRemoveVariant"></a>
   </div>
 </div>

--- a/styles/components/_select2.scss
+++ b/styles/components/_select2.scss
@@ -172,3 +172,10 @@
 .select2TagsWrapDropDown {
   @extend .select2TagsWrap;
 }
+
+.select2TagFlexWrap {
+  // if the select2 tag input has to be in a flex row with other elements, it will overflow the
+  // row if a tag is too long. Wrap select2TagsWrap in this class to prevent that.
+  flex-grow: 1;
+  overflow: hidden;
+}

--- a/styles/modules/modals/_editListing.scss
+++ b/styles/modules/modals/_editListing.scss
@@ -261,11 +261,15 @@
             border-style: solid;
             padding: $pad;
             word-break: break-word;
-            min-width: 90px;
+           // min-width: 90px;
             max-width: 125px;
 
             input[type=text] {
               width: 100%;
+            }
+
+            &.quantityCol input[type=text] {
+              width: 4em;
             }
 
             &.unconstrainedWidth {

--- a/styles/modules/modals/_editListing.scss
+++ b/styles/modules/modals/_editListing.scss
@@ -261,15 +261,11 @@
             border-style: solid;
             padding: $pad;
             word-break: break-word;
-           // min-width: 90px;
+            min-width: 90px;
             max-width: 125px;
 
             input[type=text] {
               width: 100%;
-            }
-
-            &.quantityCol input[type=text] {
-              width: 4em;
             }
 
             &.unconstrainedWidth {


### PR DESCRIPTION
This adds a wrapper class so long tags don't break out of flex containers due to the tag wrapper having a 100% width when the tag input has siblings.

**Before:**
![image](https://cloud.githubusercontent.com/assets/1584275/24202934/a8788194-0eea-11e7-9405-552d7df7814d.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/1584275/24202905/9a80f422-0eea-11e7-9822-b09379f76d2f.png)
