### PR TITLE
Categories key name change

### DIFF
--- a/js/collections/Listings.js
+++ b/js/collections/Listings.js
@@ -37,7 +37,7 @@ export default class extends Collection {
     const cats = [];
 
     this.models.forEach(listing => {
-      listing.get('category')
+      listing.get('categories')
         .forEach(cat => {
           if (cats.indexOf(cat) === -1) cats.push(cat);
         });

--- a/js/views/userPage/Store.js
+++ b/js/views/userPage/Store.js
@@ -345,7 +345,7 @@ export default class extends BaseVw {
       }
 
       if (this.filter.category !== 'all' &&
-        md.get('category').indexOf(this.filter.category) === -1) {
+        md.get('categories').indexOf(this.filter.category) === -1) {
         passesFilter = false;
       }
 

--- a/test/collections/listings.js
+++ b/test/collections/listings.js
@@ -9,11 +9,11 @@ describe('the Listings collection', () => {
       // Please Note: As of now, sorting only works on standard ascii characters.
 
       const listing = new Listings([{
-        category: ['uno', 'dos', 'tres'],
+        categories: ['uno', 'dos', 'tres'],
       }, {
-        category: ['one', 'two', 'three'],
+        categories: ['one', 'two', 'three'],
       }, {
-        category: ['raz', 'dwa', 'trzy'],
+        categories: ['raz', 'dwa', 'trzy'],
       }], { guid: 'QmZY1kx6VrNjgDB4SJDByxvSVuiBfsisRLdUMJRDppTTsS' });
 
       const expectedCats = ['dos', 'dwa', 'one', 'raz', 'three', 'tres', 'trzy', 'two', 'uno'];
@@ -22,11 +22,11 @@ describe('the Listings collection', () => {
 
     it('that returns a list of categories without duplicates', () => {
       const listing = new Listings([{
-        category: ['uno', 'dos', 'tres'],
+        categories: ['uno', 'dos', 'tres'],
       }, {
-        category: ['uno', 'two', 'three'],
+        categories: ['uno', 'two', 'three'],
       }, {
-        category: ['raz', 'dos', 'trzy'],
+        categories: ['raz', 'dos', 'trzy'],
       }], { guid: 'QmZY1kx6VrNjgDB4SJDByxvSVuiBfsisRLdUMJRDppTTsS' });
 
       const expectedCats = ['dos', 'raz', 'three', 'tres', 'trzy', 'two', 'uno'];


### PR DESCRIPTION
This PR accounts for the 'category' key changing to 'categories' in the listings API.

This PR needs to be test (and merged with around the same time) as this one on the server:
https://github.com/OpenBazaar/openbazaar-go/pull/441

!!!!! Be sure that server PR has the latest master merged into it. It didn't when I tested it. @cpacia said he'd rebase it, but in case it hasn't happened by the time you test this PR, you'll need to do it yourself.