### PR TITLE
Fixes text overflow problem in chat header.

### DIFF
--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -1,6 +1,6 @@
 <div class="clrBr clrP clrBr flexVCent gutterH padSm convoHeader" style="height: 50px">
-  <div class="js-convoProfileHeaderContainer flexExpand"></div>
-  <div class="btnStrip">
+  <div class="js-convoProfileHeaderContainer"></div>
+  <div class="btnStrip flexNoShrink">
     <a class="btn clrBr clrP clrSh2 ion-android-more-vertical iconBtn js-subMenuTrigger"></a>
     <a class="btn clrBr clrP clrSh2 ion-ios-close-empty iconBtn js-closeConvo"></a>
   </div>

--- a/js/templates/chat/convoProfileHeader.html
+++ b/js/templates/chat/convoProfileHeader.html
@@ -1,5 +1,5 @@
 <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" href="<%= ob.guid %>" style="<%= ob.getAvatarBgImage(ob.avatarHashes || {}) %>"></a>
 <div class="tx6">
   <a class="rowTn handle noOverflow clrT" href="<%= ob.guid %>"><%= ob.handle ? `@${ob.handle}` : ob.guid %></a>
-  <div><%= ob.location ? `📍${ob.location}` : '' %></div>
+  <div class="clamp2"><%= ob.location ? `📍${ob.location}` : '' %></div>
 </div>

--- a/styles/components/_layout.scss
+++ b/styles/components/_layout.scss
@@ -10,6 +10,7 @@
 
   & > * {
     flex: 0 1 auto; // children won't grow, but will shrink
+    min-width: 0; // prevent children with long text from causing an overflow
   }
 
   &.reverse {


### PR DESCRIPTION
This fixes an issue where a long location can disrupt the layout of the chat conversation header.

It also adds a min-width of zero to children of flex objects. This prevents children with long text from overflowing (a flex child object will only shrink to the size of the largest inline content otherwise). 

Before:
![image](https://cloud.githubusercontent.com/assets/1584275/24840380/344a0ae6-1d3a-11e7-95b8-ab2f2a8bc8d2.png)

After:
![image](https://cloud.githubusercontent.com/assets/1584275/24840388/4e3b70ac-1d3a-11e7-9e91-52424bd7ad75.png)
