### PR TITLE
Restore flexExpand class that shouldn't have been removed

### DIFF
--- a/js/templates/chat/conversation.html
+++ b/js/templates/chat/conversation.html
@@ -1,5 +1,5 @@
 <div class="clrBr clrP clrBr flexVCent gutterH padSm convoHeader" style="height: 50px">
-  <div class="js-convoProfileHeaderContainer"></div>
+  <div class="flexExpand js-convoProfileHeaderContainer"></div>
   <div class="btnStrip flexNoShrink">
     <a class="btn clrBr clrP clrSh2 ion-android-more-vertical iconBtn js-subMenuTrigger"></a>
     <a class="btn clrBr clrP clrSh2 ion-ios-close-empty iconBtn js-closeConvo"></a>


### PR DESCRIPTION
Makes sure the right side buttons in the conversation container stay on the right side.