### PR TITLE
Prevents an overlap in variant inventory.

### DIFF
--- a/js/templates/modals/editListing/variantInventoryItem.html
+++ b/js/templates/modals/editListing/variantInventoryItem.html
@@ -9,13 +9,13 @@
   <td class="clrBr">
     <% if (ob.errors['productID']) print(ob.formErrorTmpl({ errors: ob.errors['productID'] })) %>
     <input type="text" class="clrBr clrP clrSh2" name="productID" value="<%= ob.productID %>" data-var-type="number" placeholder="<%= ob.polyT('editListing.variantInventory.placeholderSKU') %>" maxlength="<%= ob.max.productIdLength %>" />
-  </td>    
+  </td>
   <td class="clrBr unconstrainedWidth quantityCol">
     <% if (ob.errors['quantity']) print(ob.formErrorTmpl({ errors: ob.errors['quantity'] })) %>
     <div class="flexVCent gutterH">
       <input type="text" class="clrBr clrP clrSh2 js-quantity" name="quantity" value="<%= ob.infiniteInventory ? ob.infiniteQuantityChar : ob.quantity %>" data-var-type="number" placeholder="0" />
       <input type="checkbox" id="<%= `${ob.cid}_inventoryItemUnlimtedCheckbox` %>" class="centerLabel js-infiniteInventoryCheckbox" name="infiniteInventory" <% if (ob.infiniteInventory) print('checked') %>>
-      <label class="tx5b" for="<%= `${ob.cid}_inventoryItemUnlimtedCheckbox` %>"><%= ob.polyT('editListing.variantInventory.unlimitedQuantityLabel') %></label>
+      <label class="tx5b flexNoShrink" for="<%= `${ob.cid}_inventoryItemUnlimtedCheckbox` %>"><%= ob.polyT('editListing.variantInventory.unlimitedQuantityLabel') %></label>
     </div>
   </td>
 <% }); %}


### PR DESCRIPTION
A fix to the flex layout classes fixed a bug where children with long inline elements weren't shrinking correctly. This fix broke the layout in the variant inventory table, which relied on the inline element width not shrinking.

This was fixed by adding a flexNoShrink class to the child element that needed to maintain it's width.

Before:
![image](https://cloud.githubusercontent.com/assets/1584275/25151924/5bc12736-2455-11e7-9da1-b770b23ea662.png)

After:
![image](https://cloud.githubusercontent.com/assets/1584275/25151898/42e9f562-2455-11e7-8145-f512fa6abc0f.png)
