### PR TITLE
Keep Radio Button Labels Same Size

### DIFF
--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -66,6 +66,7 @@
     padding-right: 5px;
     label {
       line-height: 2em;
+      min-height: 2em;
     }
   }
 


### PR DESCRIPTION
If the radio button label on a filter has no text, use min-height to keep it the same height as one with text.
Closes #434