### PR TITLE
Add context menu for windows

### DIFF
--- a/js/start.js
+++ b/js/start.js
@@ -76,6 +76,11 @@ app.localSettings.on('change:language', (localSettings, lang) => {
   .open();
 });
 
+window.addEventListener('contextmenu', (e) => {
+  e.preventDefault();
+  ipcRenderer.send('contextmenu-click');
+}, false);
+
 // Instantiating our Server Configs collection now since the page nav
 // utilizes it. We'll fetch it later on.
 app.serverConfigs = new ServerConfigs();

--- a/main.js
+++ b/main.js
@@ -349,7 +349,7 @@ function createWindow() {
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 
-  ipcMain.on('contextmenu-click', (e) => {
+  ipcMain.on('contextmenu-click', () => {
     menu.popup();
   });
 

--- a/main.js
+++ b/main.js
@@ -211,6 +211,15 @@ function createWindow() {
         {
           role: 'togglefullscreen',
         },
+        {
+          role: 'zoomin',
+        },
+        {
+          role: 'zoomout',
+        },
+        {
+          role: 'resetzoom',
+        },
       ],
     },
     {
@@ -337,6 +346,10 @@ function createWindow() {
 
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
+
+  ipcMain.on('contextmenu-click', (e) => {
+    menu.popup();
+  });
 
   // put logic here to set tray icon based on OS
   const osTrayIcon = 'openbazaar-mac-system-tray.png';

--- a/main.js
+++ b/main.js
@@ -213,9 +213,11 @@ function createWindow() {
         },
         {
           role: 'zoomin',
+          accelerator: 'CommandOrControl+=',
         },
         {
           role: 'zoomout',
+          accelerator: 'CommandOrControl+-',
         },
         {
           role: 'resetzoom',


### PR DESCRIPTION
Adds a right click menu, and zoom options under the View sub-menu.
Also adds keyboard commands identical to Chrome for zooming in and out (command or control + =, command or control + -).

Closes #241 and partially solves #435 (it allows zooming, but I don't believe the zoom persists between sessions of the app. At least it doesn't when running the app from the command line).