### PR TITLE
Purchasing Update

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -812,6 +812,12 @@
     "moderatedPayment": "Moderated Payment",
     "moderationDisclaimer": "Your payment will be held securly in escrow. If any issues arise, you’ll have the ability to open a dispute with a moderator. *The moderator service fee only applies if a dispute is opened.",
     "chooseModerator": "Choose This Moderator",
+    "confirmPayment": {
+      "title": "Everything look good?",
+      "msg": "If yes, please proceed to the final step.",
+      "confirm": "Yes",
+      "cancel": "Cancel"
+    },
     "errors": {
       "moderatorsTitle": "Moderator Data Failted to Load",
       "moderatorsMsg": "This listing has availble moderators, but they could not be loaded."

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -803,6 +803,8 @@
     "shippingTitle": "Shipping",
     "paymentTypeTitle": "Payment Type",
     "moderatorTitle": "Moderator",
+    "shippingTitle": "Shipping",
+    "newAddress": "New Address",
     "informationTitle": "Additional Information",
     "pay": "PAY",
     "pending": "Pending…",

--- a/js/models/listing/Listing.js
+++ b/js/models/listing/Listing.js
@@ -136,7 +136,7 @@ export default class extends BaseModel {
           app.getServerUrl(`ob/listing/${slug}`);
       } else {
         options.url = options.url ||
-          app.getServerUrl(`ipns/${this.guid}/listings/${slug}.json`);
+          app.getServerUrl(`ob/listing/${this.guid}/${slug}`);
       }
     } else {
       options.url = options.url || app.getServerUrl('ob/listing/');

--- a/js/models/purchase/Item.js
+++ b/js/models/purchase/Item.js
@@ -7,10 +7,7 @@ export default class extends BaseModel {
       listingHash: '',
       quantity: 0,
       options: new Options(),
-      shipping: {
-        name: '',
-        service: '',
-      },
+      shipping: {},
       memo: '',
       coupons: [], // just the coupon codes
     };

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -106,6 +106,26 @@
       <button class="btn width100 clrBAttGrad clrBrDec1 clrTOnEmph hide js-closeBtn">
         <%= ob.polyT('purchase.close') %>
       </button>
+      <% // confirmation box %>
+      <div id="confirmPay" class="confirmBox arrowBoxTop clrBr clrP clrT clrSh1 hide js-confirmPay">
+        <div class="flexColRows gutterVSm padLg">
+          <h3>
+            <%= ob.polyT('purchase.confirmPayment.title') %>
+          </h3>
+          <p class="tx5">
+            <%= ob.polyT('purchase.confirmPayment.msg') %>
+          </p>
+        </div>
+        <hr class="unleaded clrBr" />
+        <div class="flexHRight flexVCent gutterHLg pad tx5">
+          <a class="js-confirmPayCancel">
+            <%= ob.polyT('purchase.confirmPayment.cancel') %>
+          </a>
+          <a class="btn clrBAttGrad clrBrDec1 clrTOnEmph js-confirmPayConfirm">
+            <%= ob.polyT('purchase.confirmPayment.confirm') %>
+          </a>
+        </div>
+      </div>
     </section>
     <section class="receipt">
       <% // this will be a separate view tied to the order model %>

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -52,9 +52,9 @@
         </div>
       </section>
       <% if (ob.listing.shippingOptions && ob.listing.shippingOptions.length) { %>
-      <section class="contentBox padLg clrP clrBr clrSh3 s-shipping">
-        <% // inject shipping view here %>
-        This will be the shipping section. It's only visible if the listing has shipping data.
+      <section class="contentBox padLg clrP clrBr clrSh3 js-shipping">
+        <h2 class="h4 required"><%= ob.polyT('purchase.shippingTitle') %></h2>
+        <div class="js-shippingWrapper"></div>
       </section>
       <% } %>
       <section class="contentBox padLg clrP clrBr clrSh3">
@@ -68,17 +68,17 @@
             <div class="tx6 clrT2 margRSm"><%= ob.polyT('purchase.useShapeShift') %></div>
             <i class="shapeShiftIcon" style="background-image: url('../imgs/shapeShiftIcon.png');"></i>
           </div>
-          <div class="<% if (!hasModerators) print('hide') %>">
+          <% if (hasModerators) { %>
             <input
                 type="checkbox"
                 name="moderated"
                 checked
                 id="purchaseModerated">
             <label for="purchaseModerated"><%= ob.polyT('purchase.moderatedPayment') %></label>
-          </div>
-          <p class="clrT2 tx6 <% if (!hasModerators) print('hide') %>">
-            <%= ob.polyT('purchase.moderationDisclaimer') %>
-          </p>
+            <p class="clrT2 tx6">
+              <%= ob.polyT('purchase.moderationDisclaimer') %>
+            </p>
+          <% } %>
         </div>
       </section>
       <% if (hasModerators) { %>

--- a/js/templates/modals/purchase/shipping.html
+++ b/js/templates/modals/purchase/shipping.html
@@ -1,0 +1,1 @@
+Shipping

--- a/js/utils/templateHelpers.js
+++ b/js/utils/templateHelpers.js
@@ -13,7 +13,7 @@ export function polyT(...args) {
 
 export function parseEmojis(text, className = '', attrs = {}) {
   const parsed = twemoji.parse(text,
-      icon => (`../imgs/emojis/72X72/${icon}.png`));
+    icon => (`../imgs/emojis/72X72/${icon}.png`));
   const $parsed = $(`<div>${parsed}</div>`);
 
   $parsed.find('img')

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -318,21 +318,18 @@ export default class extends BaseModal {
       selectedVariants.push(variant);
     });
 
-    if (this.purchaseModal) {
-      // if the purchase modal somehow exists and is triggered again, move it to the top
-      this.purchaseModal.bringToTop();
-    } else {
-      this.purchaseModal = new Purchase({
-        listing: this.model,
-        variants: selectedVariants,
-        vendor: this.vendor,
-        removeOnClose: true,
-      })
-        .render()
-        .open();
+    if (this.purchaseModal) this.purchaseModale.remove();
 
-      this.purchaseModal.on('modal-will-remove', () => (this.purchaseModal = null));
-    }
+    this.purchaseModal = new Purchase({
+      listing: this.model,
+      variants: selectedVariants,
+      vendor: this.vendor,
+      removeOnClose: true,
+    })
+      .render()
+      .open();
+
+    this.purchaseModal.on('modal-will-remove', () => (this.purchaseModal = null));
   }
 
   get shipsFreeToMe() {
@@ -393,6 +390,7 @@ export default class extends BaseModal {
 
   remove() {
     if (this.editModal) this.editModal.remove();
+    if (this.purchaseModal) this.purchaseModal.remove();
     if (this.destroyRequest) this.destroyRequest.abort();
     super.remove();
   }

--- a/js/views/modals/purchase/Moderators.js
+++ b/js/views/modals/purchase/Moderators.js
@@ -164,7 +164,7 @@ export default class extends baseVw {
     }
   }
 
-  getSelectedIDs() {
+  get selectedIDs() {
     const IDs = [];
     this.modCards.forEach((mod) => {
       if (mod.cardState === 'selected') {

--- a/js/views/modals/purchase/Moderators.js
+++ b/js/views/modals/purchase/Moderators.js
@@ -150,7 +150,6 @@ export default class extends baseVw {
         ...opts,
       });
       this.listenTo(newModView, 'changeModerator', (data) => {
-        this.trigger('changeModerator', data);
         // if only one moderator should be selected, deselect the other moderators
         if (this.options.singleSelect && data.selected) this.deselectOthers(data.guid);
       });
@@ -163,6 +162,16 @@ export default class extends baseVw {
         newModView.changeSelectState('selected');
       }
     }
+  }
+
+  getSelectedIDs() {
+    const IDs = [];
+    this.modCards.forEach((mod) => {
+      if (mod.cardState === 'selected') {
+        IDs.push(mod.model.id);
+      }
+    });
+    return IDs;
   }
 
   deselectOthers(guid = '') {

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -81,6 +81,8 @@ export default class extends BaseModal {
       'click .js-payBtn': 'clickPayBtn',
       'click .js-pendingBtn': 'clickPendingBtn',
       'change #purchaseQuantity': 'changeQuantityInput',
+      'click .js-confirmPayConfirm': 'clickConfirmBtn',
+      'click .js-confirmPayCancel': 'closeConfirmPay',
       ...super.events(),
     };
   }
@@ -142,14 +144,16 @@ export default class extends BaseModal {
   }
 
   clickPayBtn() {
-    console.log(this.order.toJSON());
-    // should show confirm tooltip
-    this.purchaseListing();  // test code
+    this.$confirmPay.removeClass('hide');
   }
 
   clickConfirmBtn() {
     // confirm the purchase
     this.purchaseListing();
+  }
+
+  closeConfirmPay() {
+    this.$confirmPay.addClass('hide');
   }
 
   purchaseListing() {
@@ -199,6 +203,11 @@ export default class extends BaseModal {
         (this._$closeBtn = this.$('.js-closeBtn'));
   }
 
+  get $confirmPay() {
+    return this._$confirmPay ||
+      (this._$confirmPay = this.$('.js-confirmPay'));
+  }
+
   remove() {
     super.remove();
   }
@@ -225,6 +234,7 @@ export default class extends BaseModal {
       this._$payBtn = null;
       this._$pendingBtn = null;
       this._$closeBtn = null;
+      this._$confirmPay = null;
 
       this.$purchaseModerated = this.$('#purchaseModerated');
 

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -8,7 +8,7 @@ import BaseModal from '../BaseModal';
 import Order from '../../../models/purchase/Order';
 import Item from '../../../models/purchase/Item';
 import PopInMessage from '../../PopInMessage';
-import Moderators from './moderators';
+import Moderators from './Moderators';
 
 
 export default class extends BaseModal {
@@ -52,8 +52,6 @@ export default class extends BaseModal {
       singleSelect: true,
       selectFirst: true,
     });
-
-    this.listenTo(this.moderators, 'changeModerator', ((data) => this.changeModerator(data)));
 
     this.countryData = getTranslatedCountries(app.settings.get('language'))
         .map(countryObj => ({ id: countryObj.dataName, text: countryObj.name }));
@@ -130,15 +128,6 @@ export default class extends BaseModal {
     }
   }
 
-  changeModerator(data) {
-    if (data.selected) {
-      this.order.set('moderator', data.guid);
-    } else if (data.guid === this.order.get('moderator')) {
-      // the current moderator was deselected
-      this.order.set('moderator', '');
-    }
-  }
-
   changeQuantityInput(e) {
     this.order.get('items').at(0).set('quantity', $(e.target).val());
   }
@@ -157,6 +146,9 @@ export default class extends BaseModal {
   }
 
   purchaseListing() {
+    // set the moderator
+    this.order.set('moderator', this.moderators.getSelectedIDs());
+
     $.post({
       url: app.getServerUrl('ob/purchase'),
       data: JSON.stringify(this.order.toJSON()),

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -141,7 +141,7 @@ export default class extends BaseModal {
 
   purchaseListing() {
     // set the moderator
-    this.order.set('moderator', this.moderators.selectedIDs());
+    this.order.set('moderator', this.moderators.selectedIDs[0]);
 
     $.post({
       url: app.getServerUrl('ob/purchase'),

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -31,7 +31,7 @@ export default class extends BaseModal {
        and add them to the order as items here.
     */
     const item = new Item({
-      listingHash: this.listing.hash,
+      listingHash: this.listing.get('hash'),
       quantity: 1,
     });
     if (options.variants) item.get('options').add(options.variants);
@@ -138,18 +138,31 @@ export default class extends BaseModal {
   }
 
   changeQuantityInput(e) {
-    console.log(e);
-    // use a data attribute of the listingHash to associate this with the right item
-  }
-
-  changeQuantity(quantity, listingHash) {
-    // change the quantity of the item
-    console.log(quantity);
-    console.log(listingHash);
+    this.order.get('items').at(0).set('quantity', $(e.target).val());
   }
 
   clickPayBtn() {
-    console.log(this.order.attributes);
+    console.log(this.order.toJSON());
+    // should show confirm tooltip
+    this.purchaseListing();  // test code
+  }
+
+  clickConfirmBtn() {
+    // confirm the purchase
+    this.purchaseListing();
+  }
+
+  purchaseListing() {
+    $.post({
+      url: app.getServerUrl('ob/purchase'),
+      data: JSON.stringify(this.order.toJSON()),
+    })
+      .done((data) => {
+        console.log(data);
+      })
+      .fail((data) => {
+        console.log(data);
+      });
   }
 
   clickPendingBtn() {

--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -1,0 +1,43 @@
+import '../../../lib/select2';
+import app from '../../../app';
+import loadTemplate from '../../../utils/loadTemplate';
+import BaseModal from '../BaseModal';
+import Listing from '../../../models/listing/Listing';
+
+export default class extends BaseModal {
+  constructor(options = {}) {
+    super(options);
+    this.options = options;
+
+    if (!this.model || !(this.model instanceof Listing)) {
+      throw new Error('Please provide a listing model');
+    }
+
+    this.listenTo(app.settings.get('shippingAddresses'), 'update',
+      (cl, updateOpts) => {
+        if (updateOpts.changes.added.length ||
+          updateOpts.changes.removed.length) {
+          // update the shipping section with the changed address information
+          // TODO: add shipping code here
+        }
+      });
+  }
+
+  className() {
+    return 'shipping';
+  }
+
+  events() {
+    return {
+    };
+  }
+
+  render() {
+    loadTemplate('modals/purchase/shipping.html', t => {
+      this.$el.html(t({
+      }));
+    });
+
+    return this;
+  }
+}

--- a/styles/modules/modals/_purchase.scss
+++ b/styles/modules/modals/_purchase.scss
@@ -3,4 +3,8 @@
   .popInMessageHolder {
     top: 75px;
   }
+
+  #purchaseQuantity {
+    text-align: center;
+  }
 }

--- a/styles/modules/modals/_purchase.scss
+++ b/styles/modules/modals/_purchase.scss
@@ -7,4 +7,10 @@
   #purchaseQuantity {
     text-align: center;
   }
+
+  #confirmPay {
+    padding: 0;
+    top: 100%;
+    left: -50px;
+  }
 }


### PR DESCRIPTION
This PR stubs in shipping and makes a call to the purchase API for testing purposes.
- shipping is just an empty view and template at this point
- the order model is working
- the call to purchase only works for non-physical listings, since the shipping code isn't done. It outputs the results in the console.
- an update was made to the listing model url so it uses the right API to retrieve a listing hash.
- the moderators view as updated to have a method for retrieving the IDs of currently selected moderators. This allows the purchase view to pull that data when the order is finalized instead of tracking changes made to which moderator is selected. This will also be very useful if the settings store tab is refactored with the new moderators view.
- the confirmation tooltip was added. 