### PR TITLE
A couple of route tweaks.

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -60,7 +60,15 @@ export default class ObRouter extends Router {
 
   setAddressBarText() {
     const route = this.standardizedRoute();
-    app.pageNav.setAddressBar(route.startsWith('ob://') ? route : `ob://${route}`);
+    let displayRoute;
+
+    if (!route) {
+      displayRoute = '';
+    } else {
+      displayRoute = route.startsWith('ob://') ? route : `ob://${route}`;
+    }
+
+    app.pageNav.setAddressBar(displayRoute);
   }
 
   execute(callback, args) {

--- a/js/start.js
+++ b/js/start.js
@@ -436,7 +436,14 @@ function start() {
         app.pageNav.navigable = true;
         app.pageNav.setAppProfile();
         app.loadingModal.close();
-        location.hash = location.hash || app.profile.id;
+
+        // When starting the app the route is set to empty. We'll change that to be the
+        // user's profile.
+        if (!location.hash) {
+          const href = location.href.replace(/(javascript:|#).*$/, '');
+          location.replace(`${href}#${app.profile.id}`);
+        }
+
         Backbone.history.start();
 
         // load chat


### PR DESCRIPTION
When the app starts up, it has an empty route, in which case we were setting location.hash to the users own page. The execution of this approach was less than ideal in that a.) it resulted in `ob://` appearing initially in the address bar b.) even though ultimately the user correctly landed on their own page, pressing back would take them back to the empty route and the 'Page Not Found' page.

This PR fixes A, by displaying nothing in the address bar until we know the user's guid, at which point we replace the url in a way where the empty route doesn't have a history entry.