### PR TITLE
Handle settings failing with a 404 error

### DIFF
--- a/js/start.js
+++ b/js/start.js
@@ -194,8 +194,8 @@ function isOnboardingNeeded() {
     .done(() => {
       onboardingNeededDeferred.resolve(false);
     })
-    .fail((xhr) => {
-      const jqXhr = xhr.length ? xhr[0] : xhr;
+    .fail((xhr, e) => {
+      const jqXhr = xhr && xhr.length ? xhr[0] : xhr || e;
 
       if (profileFailed || settingsFailed) {
         const retryOnboardingModelsDialog = new Dialog({


### PR DESCRIPTION
When the settings is blank, and 404s, the first argument in the fail handler is unknown, which blocks the user from being able to get past the initial screen. This PR will check for that, and use the second argument if the first is missing (the data is in the second argument when the call is a 404).