### PR TITLE
Fix variant break

### DIFF
--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -28,7 +28,7 @@
       <a class="js-deleteConfirmCancel"><%= ob.polyT('listingDetail.confirmDelete.btnCancel') %></a>
       <a class="btn clrBAttGrad clrBrDec1 clrTOnEmph js-deleteConfirmed"><%= ob.polyT('listingDetail.confirmDelete.btnConfirm') %></a>
     </div>
-  </div>  
+  </div>
   <% } %>
 </div>
 
@@ -59,7 +59,7 @@
           <div class="flexColRows flexHCent gutterV">
             <% ob.item.options.forEach((item) => { %>
               <div class="flexVCent gutterHLg">
-                <div class="col4 h5 txUnl wordBreak"><%= item.name %></div>
+                <div class="col4 h5 txUnl"><%= item.name %></div>
                 <div class="col8">
                   <select class="js-variantSelect" name="<%= item.name %>">
                     <% item.variants.forEach((variant) => { %>

--- a/styles/components/_type.scss
+++ b/styles/components/_type.scss
@@ -140,10 +140,6 @@ a .txNoUnd:hover {
   overflow: hidden;
 }
 
-.wordBreak {
-  word-break: break-all;
-}
-
 .clamp {
   /* adds an ellipses to the end of wrapped text after 1 line */
   overflow: hidden;


### PR DESCRIPTION
- removes the wordBreak class from the option name in the listings detail. It was applying break-all, which caused words to break awkwardly. The container inherits break-word, which displays most words in a more expected way.
- since the wordBreak class is not used anywhere else, it was removed.
- Closes #487