### PR TITLE
Make color square in settings clickable UI #371

### DIFF
--- a/js/templates/modals/settings/page.html
+++ b/js/templates/modals/settings/page.html
@@ -205,14 +205,14 @@
           </div>
           <div class="col1">
               <input class="colorPicker clrBr js-primaryColorPicker" id="primaryColorPicker"
-                     data-hex-input-id="settingsPrimaryColor" type="color" value="<%= ob.colors.primary %>"
+                     data-hex-input-id="#settingsPrimaryColor" type="color" value="<%= ob.colors.primary %>"
                      placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.primary']) print(ob.formErrorTmpl({ errors: ob.errors['colors.primary'] })) %>
             <input type="text" class="clrBr clrSh2 js-primaryColorCode" name="colors.primary" id="settingsPrimaryColor"
                    value="<%= ob.colors.primary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>"
-                   data-color-picker-id="primaryColorPicker">
+                   data-color-picker-id="#primaryColorPicker">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -222,14 +222,14 @@
           </div>
           <div class="col1">
             <input class="colorPicker clrBr js-secondaryColorPicker" id="secondaryColorPicker"
-                     data-hex-input-id="settingsSecondaryColor" type="color" value="<%= ob.colors.secondary %>"
+                     data-hex-input-id="#settingsSecondaryColor" type="color" value="<%= ob.colors.secondary %>"
                      placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.secondary']) print(ob.formErrorTmpl({ errors: ob.errors['colors.secondary'] })) %>
             <input type="text" class="clrBr clrSh2 js-secondaryColorCode" name="colors.secondary" id="settingsSecondaryColor"
                    value="<%= ob.colors.secondary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>"
-                   data-color-picker-id="secondaryColorPicker">
+                   data-color-picker-id="#secondaryColorPicker">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -246,7 +246,7 @@
             <% if (ob.errors['colors.text']) print(ob.formErrorTmpl({ errors: ob.errors['colors.text'] })) %>
             <input type="text" class="clrBr clrSh2 js-textColorCode" name="colors.text" id="settingsTextColor"
                    value="<%= ob.colors.text %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderTextColor') %>"
-                   data-color-picker-id="textColorPicker">
+                   data-color-picker-id="#textColorPicker">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -256,14 +256,14 @@
           </div>
           <div class="col1">
             <input class="colorPicker clrBr js-highlightColorPicker" id="highlightColorPicker"
-                     data-hex-input-id="settingsHighlightColor" type="color" value="<%= ob.colors.highlight %>"
+                     data-hex-input-id="#settingsHighlightColor" type="color" value="<%= ob.colors.highlight %>"
                      placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.highlight']) print(ob.formErrorTmpl({ errors: ob.errors['colors.highlight'] })) %>
             <input type="text" class="clrBr clrSh2 js-highlightColorCode" name="colors.highlight" id="settingsHighlightColor"
                    value="<%= ob.colors.highlight %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightColor') %>"
-                   data-color-picker-id="highlightColorPicker">
+                   data-color-picker-id="#highlightColorPicker">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -273,14 +273,14 @@
           </div>
           <div class="col1">
             <input class="colorPicker clrBr js-highlightTextColorPicker" id="highlightTextColorPicker"
-                     data-hex-input-id="settingsHighlightTextColor" type="color" value="<%= ob.colors.highlightText %>"
+                     data-hex-input-id="#settingsHighlightTextColor" type="color" value="<%= ob.colors.highlightText %>"
                      placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['color.highlightText']) print(ob.formErrorTmpl({ errors: ob.errors['color.highlightText'] })) %>
             <input type="text" class="clrBr clrSh2 js-highlightTextColorCode" name="colors.highlightText" id="settingsHighlightTextColor"
                    value="<%= ob.colors.highlightText %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>"
-                   data-color-picker-id="highlightTextColorPicker">
+                   data-color-picker-id="#highlightTextColorPicker">
           </div>
         </div>
       </form>

--- a/js/templates/modals/settings/page.html
+++ b/js/templates/modals/settings/page.html
@@ -204,13 +204,13 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperPrimaryColor') %></div>
           </div>
           <div class="col1">
-              <input class="colorPicker clrBr js-primaryColorPicker" id="primaryColorPicker"
+              <input class="colorPicker clrBr js-colorPicker" id="primaryColorPicker"
                      data-hex-input-id="#settingsPrimaryColor" type="color" value="<%= ob.colors.primary %>"
                      placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.primary']) print(ob.formErrorTmpl({ errors: ob.errors['colors.primary'] })) %>
-            <input type="text" class="clrBr clrSh2 js-primaryColorCode" name="colors.primary" id="settingsPrimaryColor"
+            <input type="text" class="clrBr clrSh2 js-colorCode" name="colors.primary" id="settingsPrimaryColor"
                    value="<%= ob.colors.primary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>"
                    data-color-picker-id="#primaryColorPicker">
           </div>
@@ -221,13 +221,13 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperSecondaryColor') %></div>
           </div>
           <div class="col1">
-            <input class="colorPicker clrBr js-secondaryColorPicker" id="secondaryColorPicker"
+            <input class="colorPicker clrBr js-colorPicker" id="secondaryColorPicker"
                      data-hex-input-id="#settingsSecondaryColor" type="color" value="<%= ob.colors.secondary %>"
                      placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.secondary']) print(ob.formErrorTmpl({ errors: ob.errors['colors.secondary'] })) %>
-            <input type="text" class="clrBr clrSh2 js-secondaryColorCode" name="colors.secondary" id="settingsSecondaryColor"
+            <input type="text" class="clrBr clrSh2 js-colorCode" name="colors.secondary" id="settingsSecondaryColor"
                    value="<%= ob.colors.secondary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>"
                    data-color-picker-id="#secondaryColorPicker">
           </div>
@@ -238,13 +238,13 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperTextColor') %></div>
           </div>
           <div class="col1">
-            <input class="colorPicker clrBr js-textColorPicker" id="textColorPicker"
-                     data-hex-input-id="settingsTextColor" type="color" value="<%= ob.colors.text %>"
+            <input class="colorPicker clrBr js-colorPicker" id="textColorPicker"
+                     data-hex-input-id="#settingsTextColor" type="color" value="<%= ob.colors.text %>"
                      placeholder="<%= ob.polyT('settings.pageTab.placeholderTextColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.text']) print(ob.formErrorTmpl({ errors: ob.errors['colors.text'] })) %>
-            <input type="text" class="clrBr clrSh2 js-textColorCode" name="colors.text" id="settingsTextColor"
+            <input type="text" class="clrBr clrSh2 js-colorCode" name="colors.text" id="settingsTextColor"
                    value="<%= ob.colors.text %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderTextColor') %>"
                    data-color-picker-id="#textColorPicker">
           </div>
@@ -255,13 +255,13 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperHighlightColor') %></div>
           </div>
           <div class="col1">
-            <input class="colorPicker clrBr js-highlightColorPicker" id="highlightColorPicker"
+            <input class="colorPicker clrBr js-colorPicker" id="highlightColorPicker"
                      data-hex-input-id="#settingsHighlightColor" type="color" value="<%= ob.colors.highlight %>"
                      placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.highlight']) print(ob.formErrorTmpl({ errors: ob.errors['colors.highlight'] })) %>
-            <input type="text" class="clrBr clrSh2 js-highlightColorCode" name="colors.highlight" id="settingsHighlightColor"
+            <input type="text" class="clrBr clrSh2 js-colorCode" name="colors.highlight" id="settingsHighlightColor"
                    value="<%= ob.colors.highlight %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightColor') %>"
                    data-color-picker-id="#highlightColorPicker">
           </div>
@@ -272,13 +272,13 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperHighlightTextColor') %></div>
           </div>
           <div class="col1">
-            <input class="colorPicker clrBr js-highlightTextColorPicker" id="highlightTextColorPicker"
+            <input class="colorPicker clrBr js-colorPicker" id="highlightTextColorPicker"
                      data-hex-input-id="#settingsHighlightTextColor" type="color" value="<%= ob.colors.highlightText %>"
                      placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['color.highlightText']) print(ob.formErrorTmpl({ errors: ob.errors['color.highlightText'] })) %>
-            <input type="text" class="clrBr clrSh2 js-highlightTextColorCode" name="colors.highlightText" id="settingsHighlightTextColor"
+            <input type="text" class="clrBr clrSh2 js-colorCode" name="colors.highlightText" id="settingsHighlightTextColor"
                    value="<%= ob.colors.highlightText %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>"
                    data-color-picker-id="#highlightTextColorPicker">
           </div>

--- a/js/templates/modals/settings/page.html
+++ b/js/templates/modals/settings/page.html
@@ -204,12 +204,15 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperPrimaryColor') %></div>
           </div>
           <div class="col1">
-            <div class="previewBox clrBr" style="background-color: <%= ob.colors.primary %>;"></div>
+              <input class="colorPicker clrBr js-primaryColorPicker" id="primaryColorPicker"
+                     data-hex-input-id="settingsPrimaryColor" type="color" value="<%= ob.colors.primary %>"
+                     placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.primary']) print(ob.formErrorTmpl({ errors: ob.errors['colors.primary'] })) %>
-            <input type="text" class="clrBr clrSh2" name="colors.primary" id="settingsPrimaryColor"
-                   value="<%= ob.colors.primary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>">
+            <input type="text" class="clrBr clrSh2 js-primaryColorCode" name="colors.primary" id="settingsPrimaryColor"
+                   value="<%= ob.colors.primary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>"
+                   data-color-picker-id="primaryColorPicker">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -218,12 +221,15 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperSecondaryColor') %></div>
           </div>
           <div class="col1">
-            <div class="previewBox clrBr" style="background-color: <%= ob.colors.secondary %>;"></div>
+            <input class="colorPicker clrBr js-secondaryColorPicker" id="secondaryColorPicker"
+                     data-hex-input-id="settingsSecondaryColor" type="color" value="<%= ob.colors.secondary %>"
+                     placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.secondary']) print(ob.formErrorTmpl({ errors: ob.errors['colors.secondary'] })) %>
-            <input type="text" class="clrBr clrSh2" name="colors.secondary" id="settingsSecondaryColor"
-                   value="<%= ob.colors.secondary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>">
+            <input type="text" class="clrBr clrSh2 js-secondaryColorCode" name="colors.secondary" id="settingsSecondaryColor"
+                   value="<%= ob.colors.secondary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>"
+                   data-color-picker-id="secondaryColorPicker">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -232,12 +238,15 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperTextColor') %></div>
           </div>
           <div class="col1">
-            <div class="previewBox clrBr" style="background-color: <%= ob.colors.text %>;"></div>
+            <input class="colorPicker clrBr js-textColorPicker" id="textColorPicker"
+                     data-hex-input-id="settingsTextColor" type="color" value="<%= ob.colors.text %>"
+                     placeholder="<%= ob.polyT('settings.pageTab.placeholderTextColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.text']) print(ob.formErrorTmpl({ errors: ob.errors['colors.text'] })) %>
-            <input type="text" class="clrBr clrSh2" name="colors.text" id="settingsTextColor"
-                   value="<%= ob.colors.text %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderTextColor') %>">
+            <input type="text" class="clrBr clrSh2 js-textColorCode" name="colors.text" id="settingsTextColor"
+                   value="<%= ob.colors.text %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderTextColor') %>"
+                   data-color-picker-id="textColorPicker">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -246,12 +255,15 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperHighlightColor') %></div>
           </div>
           <div class="col1">
-            <div class="previewBox clrBr" style="background-color: <%= ob.colors.highlight %>;"></div>
+            <input class="colorPicker clrBr js-highlightColorPicker" id="highlightColorPicker"
+                     data-hex-input-id="settingsHighlightColor" type="color" value="<%= ob.colors.highlight %>"
+                     placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['colors.highlight']) print(ob.formErrorTmpl({ errors: ob.errors['colors.highlight'] })) %>
-            <input type="text" class="clrBr clrSh2" name="colors.highlight" id="settingsHighlightColor"
-                   value="<%= ob.colors.highlight %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightColor') %>">
+            <input type="text" class="clrBr clrSh2 js-highlightColorCode" name="colors.highlight" id="settingsHighlightColor"
+                   value="<%= ob.colors.highlight %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightColor') %>"
+                   data-color-picker-id="highlightColorPicker">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -260,12 +272,15 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperHighlightTextColor') %></div>
           </div>
           <div class="col1">
-            <div class="previewBox clrBr" style="background-color: <%= ob.colors.highlightText %>;"></div>
+            <input class="colorPicker clrBr js-highlightTextColorPicker" id="highlightTextColorPicker"
+                     data-hex-input-id="settingsHighlightTextColor" type="color" value="<%= ob.colors.highlightText %>"
+                     placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>">
           </div>
           <div class="col2">
             <% if (ob.errors['color.highlightText']) print(ob.formErrorTmpl({ errors: ob.errors['color.highlightText'] })) %>
-            <input type="text" class="clrBr clrSh2" name="colors.highlightText" id="settingsHighlightTextColor"
-                   value="<%= ob.colors.highlightText %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>">
+            <input type="text" class="clrBr clrSh2 js-highlightTextColorCode" name="colors.highlightText" id="settingsHighlightTextColor"
+                   value="<%= ob.colors.highlightText %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>"
+                   data-color-picker-id="highlightTextColorPicker">
           </div>
         </div>
       </form>

--- a/js/templates/modals/settings/page.html
+++ b/js/templates/modals/settings/page.html
@@ -204,15 +204,12 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperPrimaryColor') %></div>
           </div>
           <div class="col1">
-              <input class="colorPicker clrBr js-primaryColorPicker" id="primaryColorPicker"
-                     data-hex-input-id="settingsPrimaryColor" type="color" value="<%= ob.colors.primary %>"
-                     placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>">
+            <div class="previewBox clrBr" style="background-color: <%= ob.colors.primary %>;"></div>
           </div>
           <div class="col2">
             <% if (ob.errors['colors.primary']) print(ob.formErrorTmpl({ errors: ob.errors['colors.primary'] })) %>
-            <input type="text" class="clrBr clrSh2 js-primaryColorCode" name="colors.primary" id="settingsPrimaryColor"
-                   value="<%= ob.colors.primary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>"
-                   data-color-picker-id="primaryColorPicker">
+            <input type="text" class="clrBr clrSh2" name="colors.primary" id="settingsPrimaryColor"
+                   value="<%= ob.colors.primary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderPrimaryColor') %>">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -221,15 +218,12 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperSecondaryColor') %></div>
           </div>
           <div class="col1">
-            <input class="colorPicker clrBr js-secondaryColorPicker" id="secondaryColorPicker"
-                     data-hex-input-id="settingsSecondaryColor" type="color" value="<%= ob.colors.secondary %>"
-                     placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>">
+            <div class="previewBox clrBr" style="background-color: <%= ob.colors.secondary %>;"></div>
           </div>
           <div class="col2">
             <% if (ob.errors['colors.secondary']) print(ob.formErrorTmpl({ errors: ob.errors['colors.secondary'] })) %>
-            <input type="text" class="clrBr clrSh2 js-secondaryColorCode" name="colors.secondary" id="settingsSecondaryColor"
-                   value="<%= ob.colors.secondary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>"
-                   data-color-picker-id="secondaryColorPicker">
+            <input type="text" class="clrBr clrSh2" name="colors.secondary" id="settingsSecondaryColor"
+                   value="<%= ob.colors.secondary %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderSecondaryColor') %>">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -238,15 +232,12 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperTextColor') %></div>
           </div>
           <div class="col1">
-            <input class="colorPicker clrBr js-textColorPicker" id="textColorPicker"
-                     data-hex-input-id="settingsTextColor" type="color" value="<%= ob.colors.text %>"
-                     placeholder="<%= ob.polyT('settings.pageTab.placeholderTextColor') %>">
+            <div class="previewBox clrBr" style="background-color: <%= ob.colors.text %>;"></div>
           </div>
           <div class="col2">
             <% if (ob.errors['colors.text']) print(ob.formErrorTmpl({ errors: ob.errors['colors.text'] })) %>
-            <input type="text" class="clrBr clrSh2 js-textColorCode" name="colors.text" id="settingsTextColor"
-                   value="<%= ob.colors.text %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderTextColor') %>"
-                   data-color-picker-id="textColorPicker">
+            <input type="text" class="clrBr clrSh2" name="colors.text" id="settingsTextColor"
+                   value="<%= ob.colors.text %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderTextColor') %>">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -255,15 +246,12 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperHighlightColor') %></div>
           </div>
           <div class="col1">
-            <input class="colorPicker clrBr js-highlightColorPicker" id="highlightColorPicker"
-                     data-hex-input-id="settingsHighlightColor" type="color" value="<%= ob.colors.highlight %>"
-                     placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>">
+            <div class="previewBox clrBr" style="background-color: <%= ob.colors.highlight %>;"></div>
           </div>
           <div class="col2">
             <% if (ob.errors['colors.highlight']) print(ob.formErrorTmpl({ errors: ob.errors['colors.highlight'] })) %>
-            <input type="text" class="clrBr clrSh2 js-highlightColorCode" name="colors.highlight" id="settingsHighlightColor"
-                   value="<%= ob.colors.highlight %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightColor') %>"
-                   data-color-picker-id="highlightColorPicker">
+            <input type="text" class="clrBr clrSh2" name="colors.highlight" id="settingsHighlightColor"
+                   value="<%= ob.colors.highlight %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightColor') %>">
           </div>
         </div>
         <div class="flexRow gutterH">
@@ -272,15 +260,12 @@
             <div class="clrT2 txSm"><%= ob.polyT('settings.pageTab.helperHighlightTextColor') %></div>
           </div>
           <div class="col1">
-            <input class="colorPicker clrBr js-highlightTextColorPicker" id="highlightTextColorPicker"
-                     data-hex-input-id="settingsHighlightTextColor" type="color" value="<%= ob.colors.highlightText %>"
-                     placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>">
+            <div class="previewBox clrBr" style="background-color: <%= ob.colors.highlightText %>;"></div>
           </div>
           <div class="col2">
             <% if (ob.errors['color.highlightText']) print(ob.formErrorTmpl({ errors: ob.errors['color.highlightText'] })) %>
-            <input type="text" class="clrBr clrSh2 js-highlightTextColorCode" name="colors.highlightText" id="settingsHighlightTextColor"
-                   value="<%= ob.colors.highlightText %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>"
-                   data-color-picker-id="highlightTextColorPicker">
+            <input type="text" class="clrBr clrSh2" name="colors.highlightText" id="settingsHighlightTextColor"
+                   value="<%= ob.colors.highlightText %>" placeholder="<%= ob.polyT('settings.pageTab.placeholderHighlightTextColor') %>">
           </div>
         </div>
       </form>

--- a/js/views/baseVw.js
+++ b/js/views/baseVw.js
@@ -38,8 +38,8 @@ export default class baseVw extends View {
   getFormData(selector) {
     const $formFields = selector instanceof $ ?
       selector : this.$(selector ||
-        `select[name], input[name], 
-        textarea[name]:not([class*="trumbowyg"]), 
+        `select[name], input[name],
+        textarea[name]:not([class*="trumbowyg"]),
         div[contenteditable][name]`
       );
     const data = {};
@@ -148,6 +148,51 @@ export default class baseVw extends View {
     }
 
     super.delegateEvents();
+  }
+
+  /**
+   * Returns a given jQuery Element or a locally cached version for optimization.
+   * NOTE: Ensure that child views call super.render() in their render function to clear the cache
+   *       since the DOM elements in the cache will then be stale references.
+   * @param {selector} string - The jQuery selector for the Element.
+   *
+   * @return {element} JQuery The element(s) found in the View's Dom or the View's Cache
+   */
+  getCachedElement(selector) {
+    let element;
+
+    // Ensure we have our cached elements map.
+    if (!this._cachedElementMap) {
+      this._cachedElementMap = new Map();
+    }
+
+    // If the cache has the element, we shall use it.
+    if (this._cachedElementMap.has(selector)) {
+      element = this._cachedElementMap.get(selector);
+    } else {
+      // The cache does not not have the element, therefore query with jQuery and cache it.
+      element = this.$(selector);
+      this._cachedElementMap.set(selector, element);
+    }
+
+    return element;
+  }
+
+  /** Clears the cached elements map. */
+  clearCachedElementMap() {
+     // Clear the cache map.
+    if (this._cachedElementMap) {
+      this._cachedElementMap.clear();
+    }
+  }
+
+  /** It is necessary to call super.render() in child views' render methods if using
+   *  getCachedElement()
+   *  @param {this} Render requires this to be returned.
+   */
+  render() {
+    this.clearCachedElementMap();
+    return this;
   }
 
   // Will call the remove method of any child views.

--- a/js/views/modals/Settings/Page.js
+++ b/js/views/modals/Settings/Page.js
@@ -45,23 +45,23 @@ export default class extends baseVw {
 
   /** Handles when a hex color code is entered by updating color picker. */
   handleColorCodeEntered(event) {
-    const colorPickerId = $(event.target).data('color-picker-id');
-    const $colorPicker = $(`${colorPickerId}`);
-    const newHexColorCode = event.target.value;
-
-    // If the text passes a basic RegExp for a valid 6 digit hex value,
-    // update the color picker's color.
+    var colorPickerId = $(event.target).data('color-picker-id'),
+        $colorPicker = $("#" + colorPickerId),
+        newHexColorCode = event.target.value;
+    
+    // If the text passes a basic RegExp for a valid 6 digit hex value, update the color picker's color.
     if (/[0-9A-F]{6}/i.test(newHexColorCode)) {
       $colorPicker.val(newHexColorCode);
-    }
+    } 
+
   }
 
   /** Handles when a color is chosen from the color picker by updating hex color code text. */
   handleColorChosen(event) {
-    const hexInputId = $(event.target).data('hex-input-id');
-    const $hexInputEl = $(`${hexInputId}`);
-    const newColor = event.target.value;
-
+    var hexInputId = $(event.target).data('hex-input-id'),
+        $hexInputEl = $("#" + hexInputId),
+        newColor = event.target.value;
+    
     $hexInputEl.val(newColor);
   }
 
@@ -272,7 +272,7 @@ export default class extends baseVw {
       installRichEditor(this.$('#settingsAbout'), {
         topLevelClass: 'clrBr',
       });
-
+      
       const avatarPrev = this.$('.js-avatarPreview');
       const avatarInpt = this.$('#avatarInput');
       this.avatarCropper = this.$('#avatarCropper');

--- a/js/views/modals/Settings/Page.js
+++ b/js/views/modals/Settings/Page.js
@@ -30,7 +30,39 @@ export default class extends baseVw {
       'click .js-avatarRight': 'avatarRightClick',
       'click .js-headerLeft': 'headerLeftClick',
       'click .js-headerRight': 'headerRightClick',
+      'change .js-primaryColorPicker': 'handleColorChosen',
+      'change .js-secondaryColorPicker': 'handleColorChosen',
+      'change .js-textColorPicker': 'handleColorChosen',
+      'change .js-highlightColorPicker': 'handleColorChosen',
+      'change .js-highlightTextColorPicker': 'handleColorChosen',
+      'change .js-primaryColorCode': 'handleColorCodeEntered',
+      'change .js-secondaryColorCode': 'handleColorCodeEntered',
+      'change .js-textColorCode': 'handleColorCodeEntered',
+      'change .js-highlightColorCode': 'handleColorCodeEntered',
+      'change .js-textHightlightColorCode': 'handleColorCodeEntered',
     };
+  }
+
+  /** Handles when a hex color code is entered by updating color picker. */
+  handleColorCodeEntered(event) {
+    var colorPickerId = $(event.target).data('color-picker-id'),
+        $colorPicker = $("#" + colorPickerId),
+        newHexColorCode = event.target.value;
+    
+    // If the text passes a basic RegExp for a valid 6 digit hex value, update the color picker's color.
+    if (/[0-9A-F]{6}/i.test(newHexColorCode)) {
+      $colorPicker.val(newHexColorCode);
+    } 
+
+  }
+
+  /** Handles when a color is chosen from the color picker by updating hex color code text. */
+  handleColorChosen(event) {
+    var hexInputId = $(event.target).data('hex-input-id'),
+        $hexInputEl = $("#" + hexInputId),
+        newColor = event.target.value;
+    
+    $hexInputEl.val(newColor);
   }
 
   avatarRotate(direction) {
@@ -240,7 +272,7 @@ export default class extends baseVw {
       installRichEditor(this.$('#settingsAbout'), {
         topLevelClass: 'clrBr',
       });
-
+      
       const avatarPrev = this.$('.js-avatarPreview');
       const avatarInpt = this.$('#avatarInput');
       this.avatarCropper = this.$('#avatarCropper');

--- a/js/views/modals/Settings/Page.js
+++ b/js/views/modals/Settings/Page.js
@@ -45,23 +45,23 @@ export default class extends baseVw {
 
   /** Handles when a hex color code is entered by updating color picker. */
   handleColorCodeEntered(event) {
-    var colorPickerId = $(event.target).data('color-picker-id'),
-        $colorPicker = $("#" + colorPickerId),
-        newHexColorCode = event.target.value;
-    
-    // If the text passes a basic RegExp for a valid 6 digit hex value, update the color picker's color.
+    const colorPickerId = $(event.target).data('color-picker-id');
+    const $colorPicker = $(`${colorPickerId}`);
+    const newHexColorCode = event.target.value;
+
+    // If the text passes a basic RegExp for a valid 6 digit hex value,
+    // update the color picker's color.
     if (/[0-9A-F]{6}/i.test(newHexColorCode)) {
       $colorPicker.val(newHexColorCode);
-    } 
-
+    }
   }
 
   /** Handles when a color is chosen from the color picker by updating hex color code text. */
   handleColorChosen(event) {
-    var hexInputId = $(event.target).data('hex-input-id'),
-        $hexInputEl = $("#" + hexInputId),
-        newColor = event.target.value;
-    
+    const hexInputId = $(event.target).data('hex-input-id');
+    const $hexInputEl = $(`${hexInputId}`);
+    const newColor = event.target.value;
+
     $hexInputEl.val(newColor);
   }
 
@@ -272,7 +272,7 @@ export default class extends baseVw {
       installRichEditor(this.$('#settingsAbout'), {
         topLevelClass: 'clrBr',
       });
-      
+
       const avatarPrev = this.$('.js-avatarPreview');
       const avatarInpt = this.$('#avatarInput');
       this.avatarCropper = this.$('#avatarCropper');

--- a/js/views/modals/Settings/Page.js
+++ b/js/views/modals/Settings/Page.js
@@ -37,7 +37,7 @@ export default class extends baseVw {
 
   /** Handles when a hex color code is entered by updating color picker. */
   handleColorCodeEntered(event) {
-    const colorPickerId = $(event.target).data('color-picker-id');
+    const colorPickerId = this.$(event.target).data('color-picker-id');
     const $colorPicker = this.getCachedElement(colorPickerId);
     const newHexColorCode = event.target.value;
 
@@ -50,32 +50,11 @@ export default class extends baseVw {
 
   /** Handles when a color is chosen from the color picker by updating hex color code text. */
   handleColorChosen(event) {
-    const hexInputId = $(event.target).data('hex-input-id');
+    const hexInputId = this.$(event.target).data('hex-input-id');
     const $hexInput = this.getCachedElement(hexInputId);
     const newColor = event.target.value;
 
     $hexInput.val(newColor);
-  }
-
-  /** Returns a given jquery Element or a locally cached version in this view for optimization. */
-  getCachedElement(elementId) {
-    let element;
-
-    // Ensure we have our cached elements map.
-    if (!this._cachedElementMap) {
-      this._cachedElementMap = new Map();
-    }
-
-    // If the cache has the element, we shall use it.
-    if (this._cachedElementMap.has(elementId)) {
-      element =  this._cachedElementMap.get(elementId);
-    } else {
-      // The cache does not not have the element, therefore query with jQuery and cache it.
-      element = $(elementId);
-      this._cachedElementMap.set(elementId, element);
-    }
-
-    return element;
   }
 
   avatarRotate(direction) {
@@ -247,6 +226,8 @@ export default class extends baseVw {
   }
 
   render() {
+    super.render();
+
     let avatarURI = false;
     let headerURI = false;
 

--- a/js/views/modals/Settings/Page.js
+++ b/js/views/modals/Settings/Page.js
@@ -46,12 +46,12 @@ export default class extends baseVw {
   /** Handles when a hex color code is entered by updating color picker. */
   handleColorCodeEntered(event) {
     const colorPickerId = $(event.target).data('color-picker-id');
-    const $colorPicker = $(`${colorPickerId}`);
+    const $colorPicker = this.getCachedElement(colorPickerId);
     const newHexColorCode = event.target.value;
 
     // If the text passes a basic RegExp for a valid 6 digit hex value,
     // update the color picker's color.
-    if (/[0-9A-F]{6}/i.test(newHexColorCode)) {
+    if (/^#([0-9a-f]{6})$/i.test(newHexColorCode)) {
       $colorPicker.val(newHexColorCode);
     }
   }
@@ -59,10 +59,31 @@ export default class extends baseVw {
   /** Handles when a color is chosen from the color picker by updating hex color code text. */
   handleColorChosen(event) {
     const hexInputId = $(event.target).data('hex-input-id');
-    const $hexInputEl = $(`${hexInputId}`);
+    const $hexInput = this.getCachedElement(hexInputId);
     const newColor = event.target.value;
 
-    $hexInputEl.val(newColor);
+    $hexInput.val(newColor);
+  }
+
+  /** Returns a given jquery Element or a locally cached version in this view for optimization. */
+  getCachedElement(elementId) {
+    let element;
+
+    // Ensure we have our cached elements map.
+    if (!this._cachedElementMap) {
+      this._cachedElementMap = new Map();
+    }
+
+    // If the cache has the element, we shall use it.
+    if (this._cachedElementMap.has(elementId)) {
+      element =  this._cachedElementMap.get(elementId);
+    } else {
+      // The cache does not not have the element, therefore query with jQuery and cache it.
+      element = $(elementId);
+      this._cachedElementMap.set(elementId, element);
+    }
+
+    return element;
   }
 
   avatarRotate(direction) {

--- a/js/views/modals/Settings/Page.js
+++ b/js/views/modals/Settings/Page.js
@@ -30,16 +30,8 @@ export default class extends baseVw {
       'click .js-avatarRight': 'avatarRightClick',
       'click .js-headerLeft': 'headerLeftClick',
       'click .js-headerRight': 'headerRightClick',
-      'change .js-primaryColorPicker': 'handleColorChosen',
-      'change .js-secondaryColorPicker': 'handleColorChosen',
-      'change .js-textColorPicker': 'handleColorChosen',
-      'change .js-highlightColorPicker': 'handleColorChosen',
-      'change .js-highlightTextColorPicker': 'handleColorChosen',
-      'change .js-primaryColorCode': 'handleColorCodeEntered',
-      'change .js-secondaryColorCode': 'handleColorCodeEntered',
-      'change .js-textColorCode': 'handleColorCodeEntered',
-      'change .js-highlightColorCode': 'handleColorCodeEntered',
-      'change .js-textHightlightColorCode': 'handleColorCodeEntered',
+      'change .js-colorPicker': 'handleColorChosen',
+      'change .js-colorCode': 'handleColorCodeEntered',
     };
   }
 

--- a/styles/modules/modals/_settings.scss
+++ b/styles/modules/modals/_settings.scss
@@ -98,11 +98,9 @@
   }
 
   .settingsPage {
-    .previewBox {
+    .colorPicker {
       width: $formElementHeight;
       height: $formElementHeight;
-      border-style: solid;
-      border-width: 1px;
     }
   }
 


### PR DESCRIPTION
This is the first step to implement a color picker for color values in page settings. The native HTML5 color picker is used, therefore there are limitations to how much we can control is visually. The dark grey/black border around the color square is not something we're able to change until we implement our own color picker. Also, the UI that is instantiated for picking a color is completely not controllable by our view. For example, the OS X color picker will stay open until the user closes it even if the app is closed or restarted.