### PR TITLE
Order detail summary continued

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1038,7 +1038,15 @@
       }
     },
     "fulfillOrderTab": {
-      "heading": "Fulfill Order"
+      "heading": "Fulfill Order",
+      "shippingCarrierLabel": "Shipping Carrier",
+      "shippingCarrierPlaceholder": "UPS, FedEx, DHL, etc",
+      "trackingLabel": "Tracking #",
+      "trackingPlaceholder": "optional",
+      "fileUrlLabel": "File URL",
+      "fileUrlPlaceholder": "Link to file(s)",
+      "passwordLabel": "Password",
+      "passwordPlaceholder": "Password to file (optional)"
     }
   },
   "orderUtil": {
@@ -1182,6 +1190,10 @@
     "missingAddress": "Please choose a valid shipping address.",
     "missingShippingOption": "Please choose a valid shipping option.",
     "needsModerator": "You must select a moderator to make a Moderated Payment."
+  },
+  "orderFulfillmentModelErrors": {
+    "provideShipper": "Please provide a shipping carrier.",
+    "provideUrl": "Please provide a file url."
   },
   "bitcoinCurrencyUnits": {
     "BTC": "BTC",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -945,6 +945,7 @@
       "discussion": "Discussion",
       "contract": "Contract (JSON)"
     },
+    "backToSummary": "Back to summary",
     "discussionTab": {
       "roleVendor": "vendor",
       "roleBuyer": "buyer",
@@ -959,6 +960,7 @@
       "retryLink": "retry"      
     },
     "contractTab": {
+      "heading": "Contract (JSON)",
       "buyerContractNotAvailable": "The buyer's contract is currently unavailable until they next come online.",
       "vendorContractNotAvailable": "The vendor's contract is currently unavailable until the next time they come online.",
       "buyerVendorContractVerified": "Both the buyer's and vendor's contracts have been verified as authentic.",
@@ -1034,6 +1036,9 @@
       "payForOrder": {
         "heading": "Pay for your order"
       }
+    },
+    "fulfillOrderTab": {
+      "heading": "Fulfill Order"
     }
   },
   "orderUtil": {

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1009,14 +1009,24 @@
         "buyerOrderAccepted": "Thank you for your purchase!",
         "modOrderAccepted": "The vendor order has accepted the order.",
         "refundBtn": "Refund",
-        "fulfillBtn": "Fulfill Order"
+        "fulfillBtn": "Fulfill Order",
+        "refundConfirm": {
+          "title": "Are you sure?",
+          "body": "The original amount in bitcoin will be returned to the buyer",
+          "btnCancel": "Cancel",
+          "btnConfirm": "Yes, Refund"
+        }
       },
       "fulfilled": {
         "heading": "Fulfilled",
         "shippedByLabel": "Order Shipped via:",
         "trackingNumberLabel": "Tracking #:",
         "noteFromLabel": "Note from %{store}:",
-        "copyLink": "Copy"
+        "copyLink": "Copy",
+        "digitalReadyForDlHeading": "Digital files are ready for download!",
+        "digitalReadyForDlText": "The files have been delivered. DOwnload when you're ready.",
+        "urlLabel": "File URL",
+        "passwordLabel": "Password"
       },
       "orderDetails": {
         "progressBarStates": {
@@ -1065,7 +1075,8 @@
     "failedAcceptHeading": "There was an error accepting the order.",
     "failedRejectHeading": "There was an error rejecting the order.",
     "failedCancelHeading": "There was an error canceling the order.",
-    "failedFulfillHeading": "There was an error fulfilling the order."
+    "failedFulfillHeading": "There was an error fulfilling the order.",
+    "failedRefundHeading": "There was an error refunding the order."
   },
   "exchangeRatesSyncer": {
     "fetchingRatesStatusMsg": "Fetching exchange rates…",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -972,6 +972,7 @@
     "summaryTab": {
       "orderNumber": "Order #: %{orderId}",      
       "copyLink": "Copy",
+      "notApplicable": "n/a",
       "payment": {
         "firstPaymentHeading": "Payment Details",
         "paymentHeading": "Payment Details #%{paymentNumber}",
@@ -1010,6 +1011,13 @@
         "refundBtn": "Refund",
         "fulfillBtn": "Fulfill Order"
       },
+      "fulfilled": {
+        "heading": "Fulfilled",
+        "shippedByLabel": "Order Shipped via:",
+        "trackingNumberLabel": "Tracking #:",
+        "noteFromLabel": "Note from %{store}:",
+        "copyLink": "Copy"
+      },
       "orderDetails": {
         "progressBarStates": {
           "paid": "Paid",
@@ -1024,7 +1032,6 @@
           "disputed": "Disputed"
         },
         "heading": "Order Details",
-        "notApplicable": "n/a",
         "shipToHeading": "Ship to",
         "couponHeading": "Coupons",
         "quantityHeading": "Quantity",
@@ -1046,13 +1053,19 @@
       "fileUrlLabel": "File URL",
       "fileUrlPlaceholder": "Link to file(s)",
       "passwordLabel": "Password",
-      "passwordPlaceholder": "Password to file (optional)"
+      "passwordPlaceholder": "Password to file (optional)",
+      "noteLabel": "Note",
+      "notePlaceholder": "optional",
+      "noteHelperTextDigital": "The buyer will receive a notification containing the file information",
+      "btnCancel": "Cancel",
+      "btnSubmit": "Submit"
     }
   },
   "orderUtil": {
     "failedAcceptHeading": "There was an error accepting the order.",
     "failedRejectHeading": "There was an error rejecting the order.",
-    "failedCancelHeading": "There was an error canceling the order."
+    "failedCancelHeading": "There was an error canceling the order.",
+    "failedFulfillHeading": "There was an error fulfilling the order."
   },
   "exchangeRatesSyncer": {
     "fetchingRatesStatusMsg": "Fetching exchange rates…",
@@ -1193,7 +1206,8 @@
   },
   "orderFulfillmentModelErrors": {
     "provideShipper": "Please provide a shipping carrier.",
-    "provideUrl": "Please provide a file url."
+    "provideUrl": "Please provide a file url.",
+    "invalidUrl": "Please provide a valid url."
   },
   "bitcoinCurrencyUnits": {
     "BTC": "BTC",

--- a/js/models/BaseModel.js
+++ b/js/models/BaseModel.js
@@ -103,7 +103,7 @@ export default class extends Model {
 
     if (typeof key === 'object') {
       attrs = key;
-      opts = val;
+      opts = val || {};
     } else {
       (attrs = {})[key] = val;
     }
@@ -111,7 +111,7 @@ export default class extends Model {
     const previousAttrs = this.toJSON();
 
     // todo: will it break things if we unset a nested attribute?
-    if (!options.unset) {
+    if (!opts.unset) {
       // let's work off of a clone since we modify attrs
       attrs = JSON.parse(JSON.stringify(attrs));
 
@@ -238,8 +238,10 @@ export default class extends Model {
       this.set(JSON.parse(JSON.stringify(this.lastSyncedAttrs)));
     } else {
       this.clear();
-      this.set(this.defaults || {});
+      this.set(_.result(this, 'defaults', {}));
     }
+
+    this.validationError = null;
   }
 
   clone() {

--- a/js/models/order/Contract.js
+++ b/js/models/order/Contract.js
@@ -8,6 +8,13 @@ export default class extends BaseModel {
     };
   }
 
+  get type() {
+    return this.get('vendorListings')
+      .at(0)
+      .get('metadata')
+      .get('contractType');
+  }
+
   parse(response) {
     return {
       ...response,

--- a/js/models/order/Order.js
+++ b/js/models/order/Order.js
@@ -51,13 +51,6 @@ export default class extends BaseModel {
 
     response.paymentAddressTransactions = response.paymentAddressTransactions || [];
 
-    if (response.refundAddressTransaction && !response.refundAddressTransaction.txid) {
-      // Before an actual refund is present, the refundAddressTransaction is set with
-      // some dummy values. We'll just clear it out in that case since the lack of
-      // that object is a clearer indicator that there is no refund.
-      delete response.refundAddressTransaction;
-    }
-
     return response;
   }
 }

--- a/js/models/order/orderFulfillment/DigitalDelivery.js
+++ b/js/models/order/orderFulfillment/DigitalDelivery.js
@@ -1,0 +1,27 @@
+import app from '../../../app';
+import BaseModel from '../../BaseModel';
+
+export default class extends BaseModel {
+  defaults() {
+    return {
+      url: '',
+      password: '',
+    };
+  }
+
+  validate(attrs) {
+    const errObj = {};
+    const addError = (fieldName, error) => {
+      errObj[fieldName] = errObj[fieldName] || [];
+      errObj[fieldName].push(error);
+    };
+
+    if (!attrs.url || (typeof attrs.url === 'string' && !attrs.url.trim())) {
+      addError('url', app.polyglot.t('orderFulfillmentModelErrors.provideUrl'));
+    }
+
+    if (Object.keys(errObj).length) return errObj;
+
+    return undefined;
+  }
+}

--- a/js/models/order/orderFulfillment/DigitalDelivery.js
+++ b/js/models/order/orderFulfillment/DigitalDelivery.js
@@ -1,3 +1,4 @@
+import is from 'is_js';
 import app from '../../../app';
 import BaseModel from '../../BaseModel';
 
@@ -18,6 +19,8 @@ export default class extends BaseModel {
 
     if (!attrs.url || (typeof attrs.url === 'string' && !attrs.url.trim())) {
       addError('url', app.polyglot.t('orderFulfillmentModelErrors.provideUrl'));
+    } else if (!is.url(attrs.url)) {
+      addError('url', app.polyglot.t('orderFulfillmentModelErrors.invalidUrl'));
     }
 
     if (Object.keys(errObj).length) return errObj;

--- a/js/models/order/orderFulfillment/OrderFulfillment.js
+++ b/js/models/order/orderFulfillment/OrderFulfillment.js
@@ -1,0 +1,47 @@
+import BaseModel from '../../BaseModel';
+import PhysicalDelivery from './PhysicalDelivery';
+import DigitalDelivery from './DigitalDelivery';
+
+export default class extends BaseModel {
+  constructor(attrs  = {}, options) {
+    if (!options.contractType) {
+      throw new Error('Please provide the contract type.');
+    }
+
+    if (options.contractType === 'DIGITAL_GOOD') {
+      attrs.digitalDelivery = new DigitalDelivery();
+    } else if (options.contractType === 'PHYSICAL_GOOD') {
+      attrs.physicalDelivery = new PhysicalDelivery();
+    }
+
+    super(attrs, options);
+    this.contractType = options.contractType;
+  }
+
+  get idAttribute() {
+    return 'orderId';
+  }
+
+  get nested() {
+    return {
+      physicalDelivery: PhysicalDelivery,
+      digitalDelivery: DigitalDelivery,
+    };
+  }
+
+  // validate(attrs) {
+  //   const errObj = {};
+  //   const addError = (fieldName, error) => {
+  //     errObj[fieldName] = errObj[fieldName] || [];
+  //     errObj[fieldName].push(error);
+  //   };
+
+  //   if (!attrs.shipper || (typeof attrs.shipper === 'string' && !attrs.shipper.trim())) {
+  //     addError('shipper', app.polyglot.t('orderFulfillmentModelErrors.provideShipper'));
+  //   }
+
+  //   if (Object.keys(errObj).length) return errObj;
+
+  //   return undefined;
+  // }  
+}

--- a/js/models/order/orderFulfillment/OrderFulfillment.js
+++ b/js/models/order/orderFulfillment/OrderFulfillment.js
@@ -1,13 +1,19 @@
+import app from '../../../app';
 import BaseModel from '../../BaseModel';
 import PhysicalDelivery from './PhysicalDelivery';
 import DigitalDelivery from './DigitalDelivery';
 
 export default class extends BaseModel {
-  constructor(attrs  = {}, options) {
+  constructor(attrs = {}, options = {}) {
     if (!options.contractType) {
       throw new Error('Please provide the contract type.');
     }
 
+    // Since the contract type is not available on this when
+    // the defaults are initially called, we need to set the
+    // initial contract type dependant attributes here. We also
+    // set them in defaults, so if the model is reset, they'll
+    // be restored properly.
     if (options.contractType === 'DIGITAL_GOOD') {
       attrs.digitalDelivery = new DigitalDelivery();
     } else if (options.contractType === 'PHYSICAL_GOOD') {
@@ -16,6 +22,22 @@ export default class extends BaseModel {
 
     super(attrs, options);
     this.contractType = options.contractType;
+  }
+
+  defaults() {
+    const defaults = {};
+
+    if (this.contractType === 'DIGITAL_GOOD') {
+      defaults.digitalDelivery = new DigitalDelivery();
+    } else if (this.contractType === 'PHYSICAL_GOOD') {
+      defaults.physicalDelivery = new PhysicalDelivery();
+    }
+
+    return defaults;
+  }
+
+  url() {
+    return app.getServerUrl('ob/orderfulfillment/');
   }
 
   get idAttribute() {
@@ -29,19 +51,33 @@ export default class extends BaseModel {
     };
   }
 
-  // validate(attrs) {
-  //   const errObj = {};
-  //   const addError = (fieldName, error) => {
-  //     errObj[fieldName] = errObj[fieldName] || [];
-  //     errObj[fieldName].push(error);
-  //   };
+  validate() {
+    const errObj = this.mergeInNestedErrors();
+    if (Object.keys(errObj).length) return errObj;
+    return undefined;
+  }
 
-  //   if (!attrs.shipper || (typeof attrs.shipper === 'string' && !attrs.shipper.trim())) {
-  //     addError('shipper', app.polyglot.t('orderFulfillmentModelErrors.provideShipper'));
-  //   }
+  sync(method, model, options) {
+    options.attrs = options.attrs || this.toJSON();
 
-  //   if (Object.keys(errObj).length) return errObj;
+    if (method === 'create' || method === 'update') {
+      options.type = 'POST';
 
-  //   return undefined;
-  // }  
+      // The server is expecting an array for any physicalDelivery or
+      // digitalDelivery options in order to support multiple listings.
+      // Since the client and design aren't supporting that at this time,
+      // we'll convert to an array here. Once we support it, the nested
+      // models should be changed to nested collections.
+      if (options.attrs.physicalDelivery) {
+        options.attrs.physicalDelivery = [options.attrs.physicalDelivery];
+      }
+
+      if (options.attrs.digitalDelivery) {
+        options.attrs.digitalDelivery = [options.attrs.digitalDelivery];
+      }
+    }
+
+    return super.sync(method, model, options);
+  }
+
 }

--- a/js/models/order/orderFulfillment/PhysicalDelivery.js
+++ b/js/models/order/orderFulfillment/PhysicalDelivery.js
@@ -1,0 +1,27 @@
+import app from '../../../app';
+import BaseModel from '../../BaseModel';
+
+export default class extends BaseModel {
+  defaults() {
+    return {
+      shipper: '',
+      trackingNumber: '',
+    };
+  }
+
+  validate(attrs) {
+    const errObj = {};
+    const addError = (fieldName, error) => {
+      errObj[fieldName] = errObj[fieldName] || [];
+      errObj[fieldName].push(error);
+    };
+
+    if (!attrs.shipper || (typeof attrs.shipper === 'string' && !attrs.shipper.trim())) {
+      addError('shipper', app.polyglot.t('orderFulfillmentModelErrors.provideShipper'));
+    }
+
+    if (Object.keys(errObj).length) return errObj;
+
+    return undefined;
+  }
+}

--- a/js/startup/index.js
+++ b/js/startup/index.js
@@ -19,9 +19,16 @@ export function fixLinuxZoomIssue() {
   }
 }
 
+/**
+ * For most cases, this handler will be able to identify an external link because
+ * it will be prefaced with an "external" protocol (e.g. http, ftp). An exception
+ * to this is any user based url (e.g. www.espn.com). In that case, add a
+ * 'data-open-external' attribute to the url to force it to be opened externally.
+ */
 export function handleLinks() {
   $(document).on('click', 'a:not([data-bypass])', (e) => {
     const $a = $(e.target).closest('a');
+    const openExternally = $a.data('openExternal') !== undefined;
     let href = $a.attr('href');
 
     // Anchor without href is likely being handled programatically.
@@ -30,12 +37,12 @@ export function handleLinks() {
     const link = document.createElement('a');
     link.setAttribute('href', href);
 
-    if (link.protocol !== location.protocol) {
-      // external link
-      if (link.protocol === 'ob2:') {
-        Backbone.history.navigate(href.slice(6), true);
+    if (link.protocol !== location.protocol || openExternally) {
+      if (link.protocol === 'ob:' && !openExternally) {
+        Backbone.history.navigate(href.slice(5), true);
       } else {
-        shell.openExternal(href);
+        // external link
+        shell.openExternal(link.protocol === 'file:' ? `http://${href}` : href);
       }
     } else {
       if (!href.startsWith('#')) {

--- a/js/templates/modals/orderDetail/contract.html
+++ b/js/templates/modals/orderDetail/contract.html
@@ -1,8 +1,8 @@
 <div class="padLg flexVCent">
   <div class="backToSummaryWrap">
-    <a class="js-backToSummary clrTEm txU">Back to summary</a>
+    <a class="js-backToSummary clrTEm txU"><%= ob.polyT(`orderDetail.backToSummary`) %></a>
   </div>
-  <div class="txCtr txB tx3 flexExpand">Contract (JSON)</div>
+  <div class="txCtr txB tx3 flexExpand"><%= ob.polyT(`orderDetail.contractTab.heading`) %></div>
 </div>
 <hr class="clrBr rowMd" />
 <% if (!ob.isCase) { %>

--- a/js/templates/modals/orderDetail/fulfillOrder.html
+++ b/js/templates/modals/orderDetail/fulfillOrder.html
@@ -1,0 +1,27 @@
+<div class="padLg flexVCent">
+  <div class="backToSummaryWrap">
+    <a class="js-backToSummary clrTEm txU"><%= ob.polyT(`orderDetail.backToSummary`) %></a>
+  </div>
+  <div class="txCtr txB tx3 flexExpand"><%= ob.polyT(`orderDetail.fulfillOrderTab.heading`) %></div>
+</div>
+<hr class="clrBr rowMd" />
+<form class="padKids padStack pad clrP clrBr">
+  <div class="flexRow gutterH">
+    <div class="col3">
+      <label for="shippingCarrier" class="required">Shipping Carrier</label>
+    </div>
+    <div class="col7">
+      <% if (ob.errors.physicalDeliveryShipper) print(ob.formErrorTmpl({ errors: ob.errors.physicalDeliveryShipper })) %>
+      <input type="text" class="clrBr clrSh2" name="physicalDelivery.shipper" id="shippingCarrier" value="<%= ob.physicalDeliveryShipper %>" placeholder="<%= ob.polyT('settings.addressesTab.placeholderName') %>" />
+    </div>
+  </div>
+  <div class="flexRow gutterH">
+    <div class="col3">
+      <label for="shippingCarrier" class="required">Shipping Carrier</label>
+    </div>
+    <div class="col7">
+      <% if (ob.errors.physicalDeliveryShipper) print(ob.formErrorTmpl({ errors: ob.errors.physicalDeliveryShipper })) %>
+      <input type="text" class="clrBr clrSh2" name="physicalDelivery.shipper" id="shippingCarrier" value="<%= ob.physicalDeliveryShipper %>" placeholder="<%= ob.polyT('settings.addressesTab.placeholderName') %>" />
+    </div>
+  </div>  
+</form>

--- a/js/templates/modals/orderDetail/fulfillOrder.html
+++ b/js/templates/modals/orderDetail/fulfillOrder.html
@@ -5,44 +5,64 @@
   <div class="txCtr txB tx3 flexExpand"><%= ob.polyT(`orderDetail.fulfillOrderTab.heading`) %></div>
 </div>
 <hr class="clrBr rowMd" />
-<form class="padKids padStack pad clrP clrBr">
+<form class="padKids padStack pad clrP clrBr js-fulfillForm">
   <% if (ob.contractType === 'PHYSICAL_GOOD') { %>
   <div class="flexRow gutterH">
     <div class="col3">
-      <label for="shippingCarrier" class="required"><%= ob.polyT(`orderDetail.fulfillOrderTab.shippingCarrierLabel`) %></label>
+      <label for="fulfillOrderShippingCarrier" class="required"><%= ob.polyT(`orderDetail.fulfillOrderTab.shippingCarrierLabel`) %></label>
     </div>
     <div class="col7">
       <% if (ob.errors['physicalDelivery.shipper']) print(ob.formErrorTmpl({ errors: ob.errors['physicalDelivery.shipper'] })) %>
-      <input type="text" class="clrBr clrSh2" name="physicalDelivery.shipper" id="shippingCarrier" value="<%= ob.physicalDelivery.shipper %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.shippingCarrierPlaceholder`) %>" />
+      <input type="text" class="clrBr clrSh2" name="physicalDelivery.shipper" id="fulfillOrderShippingCarrier" value="<%= ob.physicalDelivery.shipper %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.shippingCarrierPlaceholder`) %>" />
     </div>
   </div>
   <div class="flexRow gutterH">
     <div class="col3">
-      <label for="password" class="required"><%= ob.polyT(`orderDetail.fulfillOrderTab.trackingLabel`) %></label>
+      <label for="fulfillOrderTrackingNumber"><%= ob.polyT(`orderDetail.fulfillOrderTab.trackingLabel`) %></label>
     </div>
     <div class="col7">
       <% if (ob.errors['physicalDelivery.trackingNumber']) print(ob.formErrorTmpl({ errors: ob.errors['physicalDelivery.trackingNumber'] })) %>
-      <input type="text" class="clrBr clrSh2" name="physicalDelivery.trackingNumber" id="password" value="<%= ob.physicalDelivery.trackingNumber %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.trackingPlaceholder`) %>" />
+      <input type="text" class="clrBr clrSh2" name="physicalDelivery.trackingNumber" id="fulfillOrderTrackingNumber" value="<%= ob.physicalDelivery.trackingNumber %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.trackingPlaceholder`) %>" />
     </div>
   </div>
   <% } else if (ob.contractType === 'DIGITAL_GOOD') { %>
   <div class="flexRow gutterH">
     <div class="col3">
-      <label for="fileUrl" class="required"><%= ob.polyT(`orderDetail.fulfillOrderTab.fileUrlLabel`) %></label>
+      <label for="fulfillOrderFileUrl" class="required"><%= ob.polyT(`orderDetail.fulfillOrderTab.fileUrlLabel`) %></label>
     </div>
     <div class="col7">
       <% if (ob.errors['digitalDelivery.url']) print(ob.formErrorTmpl({ errors: ob.errors['digitalDelivery.url'] })) %>
-      <input type="text" class="clrBr clrSh2" name="digitalDelivery.url" id="fileUrl" value="<%= ob.digitalDelivery.url %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.fileUrlPlaceholder`) %>" />
+      <input type="text" class="clrBr clrSh2" name="digitalDelivery.url" id="fulfillOrderFileUrl" value="<%= ob.digitalDelivery.url %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.fileUrlPlaceholder`) %>" />
     </div>
   </div>
   <div class="flexRow gutterH">
     <div class="col3">
-      <label for="password" class="required"><%= ob.polyT(`orderDetail.fulfillOrderTab.passwordLabel`) %></label>
+      <label for="fulfillOrderPassword"><%= ob.polyT(`orderDetail.fulfillOrderTab.passwordLabel`) %></label>
     </div>
     <div class="col7">
       <% if (ob.errors['digitalDelivery.password']) print(ob.formErrorTmpl({ errors: ob.errors['digitalDelivery.password'] })) %>
-      <input type="text" class="clrBr clrSh2" name="digitalDelivery.password" id="fileUrl" value="<%= ob.digitalDelivery.password %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.passwordPlaceholder`) %>" />
+      <input type="password" class="clrBr clrSh2" name="digitalDelivery.password" id="fulfillOrderPassword" value="<%= ob.digitalDelivery.password %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.passwordPlaceholder`) %>" />
     </div>
   </div>
   <% } %>
+  <div class="flexRow gutterH rowHg">
+    <div class="col3">
+      <label for="fulfillOrderNote"><%= ob.polyT(`orderDetail.fulfillOrderTab.noteLabel`) %></label>
+    </div>
+    <div class="col7">
+      <% if (ob.errors['note']) print(ob.formErrorTmpl({ errors: ob.errors['note'] })) %>
+    <textarea rows="6" name="note" class="clrBr clrP clrSh2 <% if (ob.contractType === 'DIGITAL_GOOD') print('rowSm') %>" id="fulfillOrderNote" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.notePlaceholder`) %>"><%= ob.note %></textarea>
+    <% if (ob.contractType === 'DIGITAL_GOOD') { %>
+    <div class="clrT2 txSm"><%= ob.polyT(`orderDetail.fulfillOrderTab.noteHelperTextDigital`) %></div>
+    <% } %>
+    </div>
+  </div>
 </form>
+<hr class="clrBr" />
+<div class="buttonBar flexHRight flexVCent gutterHLg">
+  <a class="js-cancel <% if (ob.fulfillingOrder) print('disabled') %>"><%= ob.polyT(`orderDetail.fulfillOrderTab.btnCancel`) %></a>
+  <%= ob.processingButton({
+    className: `btn clrBAttGrad clrBrDec1 clrTOnEmph js-submit ${ob.fulfillingOrder ? 'processing' : ''}`,
+    btnText: ob.polyT(`orderDetail.fulfillOrderTab.btnSubmit`),
+  }) %>
+</div>

--- a/js/templates/modals/orderDetail/fulfillOrder.html
+++ b/js/templates/modals/orderDetail/fulfillOrder.html
@@ -6,22 +6,43 @@
 </div>
 <hr class="clrBr rowMd" />
 <form class="padKids padStack pad clrP clrBr">
+  <% if (ob.contractType === 'PHYSICAL_GOOD') { %>
   <div class="flexRow gutterH">
     <div class="col3">
-      <label for="shippingCarrier" class="required">Shipping Carrier</label>
+      <label for="shippingCarrier" class="required"><%= ob.polyT(`orderDetail.fulfillOrderTab.shippingCarrierLabel`) %></label>
     </div>
     <div class="col7">
-      <% if (ob.errors.physicalDeliveryShipper) print(ob.formErrorTmpl({ errors: ob.errors.physicalDeliveryShipper })) %>
-      <input type="text" class="clrBr clrSh2" name="physicalDelivery.shipper" id="shippingCarrier" value="<%= ob.physicalDeliveryShipper %>" placeholder="<%= ob.polyT('settings.addressesTab.placeholderName') %>" />
+      <% if (ob.errors['physicalDelivery.shipper']) print(ob.formErrorTmpl({ errors: ob.errors['physicalDelivery.shipper'] })) %>
+      <input type="text" class="clrBr clrSh2" name="physicalDelivery.shipper" id="shippingCarrier" value="<%= ob.physicalDelivery.shipper %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.shippingCarrierPlaceholder`) %>" />
     </div>
   </div>
   <div class="flexRow gutterH">
     <div class="col3">
-      <label for="shippingCarrier" class="required">Shipping Carrier</label>
+      <label for="password" class="required"><%= ob.polyT(`orderDetail.fulfillOrderTab.trackingLabel`) %></label>
     </div>
     <div class="col7">
-      <% if (ob.errors.physicalDeliveryShipper) print(ob.formErrorTmpl({ errors: ob.errors.physicalDeliveryShipper })) %>
-      <input type="text" class="clrBr clrSh2" name="physicalDelivery.shipper" id="shippingCarrier" value="<%= ob.physicalDeliveryShipper %>" placeholder="<%= ob.polyT('settings.addressesTab.placeholderName') %>" />
+      <% if (ob.errors['physicalDelivery.trackingNumber']) print(ob.formErrorTmpl({ errors: ob.errors['physicalDelivery.trackingNumber'] })) %>
+      <input type="text" class="clrBr clrSh2" name="physicalDelivery.trackingNumber" id="password" value="<%= ob.physicalDelivery.trackingNumber %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.trackingPlaceholder`) %>" />
     </div>
-  </div>  
+  </div>
+  <% } else if (ob.contractType === 'DIGITAL_GOOD') { %>
+  <div class="flexRow gutterH">
+    <div class="col3">
+      <label for="fileUrl" class="required"><%= ob.polyT(`orderDetail.fulfillOrderTab.fileUrlLabel`) %></label>
+    </div>
+    <div class="col7">
+      <% if (ob.errors['digitalDelivery.url']) print(ob.formErrorTmpl({ errors: ob.errors['digitalDelivery.url'] })) %>
+      <input type="text" class="clrBr clrSh2" name="digitalDelivery.url" id="fileUrl" value="<%= ob.digitalDelivery.url %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.fileUrlPlaceholder`) %>" />
+    </div>
+  </div>
+  <div class="flexRow gutterH">
+    <div class="col3">
+      <label for="password" class="required"><%= ob.polyT(`orderDetail.fulfillOrderTab.passwordLabel`) %></label>
+    </div>
+    <div class="col7">
+      <% if (ob.errors['digitalDelivery.password']) print(ob.formErrorTmpl({ errors: ob.errors['digitalDelivery.password'] })) %>
+      <input type="text" class="clrBr clrSh2" name="digitalDelivery.password" id="fileUrl" value="<%= ob.digitalDelivery.password %>" placeholder="<%= ob.polyT(`orderDetail.fulfillOrderTab.passwordPlaceholder`) %>" />
+    </div>
+  </div>
+  <% } %>
 </form>

--- a/js/templates/modals/orderDetail/summaryTab/accepted.html
+++ b/js/templates/modals/orderDetail/summaryTab/accepted.html
@@ -15,12 +15,25 @@
         <% if (ob.showRefundButton) { %>
           <% if (ob.refundOrderInProgress) { %>
             <span class="posR">
-              <% // including invisible cancel link to properly space the spinner %>
+              <% // including invisible refund link to properly space the spinner %>
               <a class="txU tx6 invisible"><%= ob.polyT('orderDetail.summaryTab.accepted.refundBtn') %></a>
               <%= ob.spinner({ className: 'spinnerSm center' }) %>
             </span>
           <% } else { %>
-            <a class="txU tx6 js-refundOrder <% if (ob.refundConfirmOn) print('disabled') %> <% if (ob.fulfillInProgress) print('disabled') %>"><%= ob.polyT('orderDetail.summaryTab.accepted.refundBtn') %></a>
+            <div class="posR">
+              <a class="txU tx6 js-refundOrder <% if (ob.refundConfirmOn) print('disabled') %> <% if (ob.fulfillInProgress) print('disabled') %>"><%= ob.polyT('orderDetail.summaryTab.accepted.refundBtn') %></a>
+              <% if (ob.refundConfirmOn) { %>
+              <div class="js-refundConfirm confirmBox refundConfirm tx5 arrowBoxTop clrBr clrP clrT">
+                <div class="tx3 txB rowSm"><%= ob.polyT('orderDetail.summaryTab.accepted.refundConfirm.title') %></div>
+                <p><%= ob.polyT('orderDetail.summaryTab.accepted.refundConfirm.body') %></p>
+                <hr class="clrBr row" />
+                <div class="flexHRight flexVCent gutterHLg buttonBar">
+                  <a class="js-refundConfirmCancel"><%= ob.polyT('orderDetail.summaryTab.accepted.refundConfirm.btnCancel') %></a>
+                  <a class="btn clrBAttGrad clrBrDec1 clrTOnEmph js-refundConfirmed"><%= ob.polyT('orderDetail.summaryTab.accepted.refundConfirm.btnConfirm') %></a>
+                </div>
+              </div>
+              <% } %>
+            </div>
           <%  } %>
         <%  } %>
         <% if (ob.showFulfillButton) { %>

--- a/js/templates/modals/orderDetail/summaryTab/fulfilled.html
+++ b/js/templates/modals/orderDetail/summaryTab/fulfilled.html
@@ -21,15 +21,42 @@
     <div class="statusIconCol"><span class="clrBr ion-cube"></span></div>
     <div class="flexExpand tx5">
       <div class="rowTn txB"><%= ob.polyT('orderDetail.summaryTab.fulfilled.shippedByLabel') %> <span><%= physicalDelivery.shipper %></span></div>
-      <div class="rowHg">
+      <div class="row">
         <span><%= ob.polyT('orderDetail.summaryTab.fulfilled.trackingNumberLabel') %></span> <%= physicalDelivery.trackingNumber || ob.polyT('orderDetail.summaryTab.notApplicable') %>
         <% if (physicalDelivery.trackingNumber) { %>
         <a class="clrTEm js-copyTrackingNumber"><%= ob.polyT('orderDetail.summaryTab.fulfilled.copyLink') %></a>
+        <a class="hide js-trackingCopiedToClipboard"><%= ob.polyT('copiedToClipboard') %></a>
         <% } %>
       </div>
+      <div class="rowTn"><%= ob.polyT('orderDetail.summaryTab.fulfilled.noteFromLabel', { store: ob.storeName }) %></div>
+      <div><%= ob.note || ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
     </div>
   </div>
   <% } else if (ob.contractType === 'DIGITAL_GOOD') { %>
+  <div class="flex gutterH clrT">
+    <div class="statusIconCol clrT"><span class="clrBr ion-ios-folder"></span></div>
+    <div class="flexExpand tx5">
+      <div class="rowTn txB"><%= ob.polyT('orderDetail.summaryTab.fulfilled.digitalReadyForDlHeading') %></div>
+      <div class="row">
+      <%= ob.polyT('orderDetail.summaryTab.fulfilled.digitalReadyForDlText') %>
+      </div>
+      <div class="rowTn txB"><%= ob.polyT('orderDetail.summaryTab.fulfilled.urlLabel') %></div>
+      <div class="<% if (ob.showPassword) print('row') %>">
+        <a class="clrTEm" href="<%= ob.url %>" data-open-external><%= ob.url %></a>
+      </div>
+      <% if (ob.showPassword) { %>
+      <div class="rowTn txB"><%= ob.polyT('orderDetail.summaryTab.fulfilled.passwordLabel') %></div>
+      <div><%= ob.password || ob.polyT('orderDetail.summaryTab.notApplicable') %></div> 
+      <% } %>
+    </div>
+  </div>
   <% } else if (ob.contractType === 'SERVICE') { %>
+  <div class="flex gutterH clrT">
+    <div class="statusIconCol clrT"><span class="clrBr ion-ios-body"></span></div>
+    <div class="flexExpand tx5">
+      <div class="rowTn"><%= ob.polyT('orderDetail.summaryTab.fulfilled.noteFromLabel', { store: ob.storeName }) %></div>
+      <div><%= ob.note || ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
+    </div>
+  </div>  
   <% } %>
 </div>

--- a/js/templates/modals/orderDetail/summaryTab/fulfilled.html
+++ b/js/templates/modals/orderDetail/summaryTab/fulfilled.html
@@ -1,0 +1,35 @@
+<h2 class="tx4 margRTn"><%= ob.polyT('orderDetail.summaryTab.fulfilled.heading') %></h2>
+<% if (ob.timestamp) { %>
+<span class="clrT2 tx5b"><%= ob.moment(ob.timestamp).format('lll') %></span>
+<% } %>
+
+<div class="border clrBr padMd">
+  <% if (ob.contractType === 'PHYSICAL_GOOD') { %>
+  <div class="flex gutterH clrT">
+    <%
+      let statusIcon = 'ion-ios-folder';
+      let statusIconClass = 'clrT';
+
+      if (ob.contractType === 'PHYSICAL_GOOD') {
+        statusIcon = 'ion-cube';
+      } else if (ob.contractType === 'SERVICE') {
+        statusIcon = 'ion-ios-body';
+      }
+
+      const physicalDelivery = ob.physicalDelivery && ob.physicalDelivery[0] || {};
+    %>
+    <div class="statusIconCol"><span class="clrBr ion-cube"></span></div>
+    <div class="flexExpand tx5">
+      <div class="rowTn txB"><%= ob.polyT('orderDetail.summaryTab.fulfilled.shippedByLabel') %> <span><%= physicalDelivery.shipper %></span></div>
+      <div class="rowHg">
+        <span><%= ob.polyT('orderDetail.summaryTab.fulfilled.trackingNumberLabel') %></span> <%= physicalDelivery.trackingNumber || ob.polyT('orderDetail.summaryTab.notApplicable') %>
+        <% if (physicalDelivery.trackingNumber) { %>
+        <a class="clrTEm js-copyTrackingNumber"><%= ob.polyT('orderDetail.summaryTab.fulfilled.copyLink') %></a>
+        <% } %>
+      </div>
+    </div>
+  </div>
+  <% } else if (ob.contractType === 'DIGITAL_GOOD') { %>
+  <% } else if (ob.contractType === 'SERVICE') { %>
+  <% } %>
+</div>

--- a/js/templates/modals/orderDetail/summaryTab/fulfilled.html
+++ b/js/templates/modals/orderDetail/summaryTab/fulfilled.html
@@ -6,18 +6,7 @@
 <div class="border clrBr padMd">
   <% if (ob.contractType === 'PHYSICAL_GOOD') { %>
   <div class="flex gutterH clrT">
-    <%
-      let statusIcon = 'ion-ios-folder';
-      let statusIconClass = 'clrT';
-
-      if (ob.contractType === 'PHYSICAL_GOOD') {
-        statusIcon = 'ion-cube';
-      } else if (ob.contractType === 'SERVICE') {
-        statusIcon = 'ion-ios-body';
-      }
-
-      const physicalDelivery = ob.physicalDelivery && ob.physicalDelivery[0] || {};
-    %>
+    <% const physicalDelivery = ob.physicalDelivery && ob.physicalDelivery[0] || {}; %>
     <div class="statusIconCol"><span class="clrBr ion-cube"></span></div>
     <div class="flexExpand tx5">
       <div class="rowTn txB"><%= ob.polyT('orderDetail.summaryTab.fulfilled.shippedByLabel') %> <span><%= physicalDelivery.shipper %></span></div>
@@ -33,6 +22,7 @@
     </div>
   </div>
   <% } else if (ob.contractType === 'DIGITAL_GOOD') { %>
+  <% const digitalDelivery = ob.digitalDelivery && ob.digitalDelivery[0] || {}; %>  
   <div class="flex gutterH clrT">
     <div class="statusIconCol clrT"><span class="clrBr ion-ios-folder"></span></div>
     <div class="flexExpand tx5">
@@ -42,11 +32,11 @@
       </div>
       <div class="rowTn txB"><%= ob.polyT('orderDetail.summaryTab.fulfilled.urlLabel') %></div>
       <div class="<% if (ob.showPassword) print('row') %>">
-        <a class="clrTEm" href="<%= ob.url %>" data-open-external><%= ob.url %></a>
+        <a class="clrTEm" href="<%= digitalDelivery.url %>" data-open-external><%= digitalDelivery.url %></a>
       </div>
       <% if (ob.showPassword) { %>
       <div class="rowTn txB"><%= ob.polyT('orderDetail.summaryTab.fulfilled.passwordLabel') %></div>
-      <div><%= ob.password || ob.polyT('orderDetail.summaryTab.notApplicable') %></div> 
+      <div class="row"><%= digitalDelivery.password || ob.polyT('orderDetail.summaryTab.notApplicable') %></div> 
       <% } %>
       <div class="rowTn"><%= ob.polyT('orderDetail.summaryTab.fulfilled.noteFromLabel', { store: ob.storeName }) %></div>
       <div><%= ob.note ? ob.parseEmojis(ob.note) : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>      

--- a/js/templates/modals/orderDetail/summaryTab/fulfilled.html
+++ b/js/templates/modals/orderDetail/summaryTab/fulfilled.html
@@ -29,7 +29,7 @@
         <% } %>
       </div>
       <div class="rowTn"><%= ob.polyT('orderDetail.summaryTab.fulfilled.noteFromLabel', { store: ob.storeName }) %></div>
-      <div><%= ob.note || ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
+      <div><%= ob.note ? ob.parseEmojis(ob.note) : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
     </div>
   </div>
   <% } else if (ob.contractType === 'DIGITAL_GOOD') { %>
@@ -48,6 +48,8 @@
       <div class="rowTn txB"><%= ob.polyT('orderDetail.summaryTab.fulfilled.passwordLabel') %></div>
       <div><%= ob.password || ob.polyT('orderDetail.summaryTab.notApplicable') %></div> 
       <% } %>
+      <div class="rowTn"><%= ob.polyT('orderDetail.summaryTab.fulfilled.noteFromLabel', { store: ob.storeName }) %></div>
+      <div><%= ob.note ? ob.parseEmojis(ob.note) : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>      
     </div>
   </div>
   <% } else if (ob.contractType === 'SERVICE') { %>
@@ -55,7 +57,7 @@
     <div class="statusIconCol clrT"><span class="clrBr ion-ios-body"></span></div>
     <div class="flexExpand tx5">
       <div class="rowTn"><%= ob.polyT('orderDetail.summaryTab.fulfilled.noteFromLabel', { store: ob.storeName }) %></div>
-      <div><%= ob.note || ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
+      <div><%= ob.note ? ob.parseEmojis(ob.note) : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
     </div>
   </div>  
   <% } %>

--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -1,4 +1,3 @@
-<% console.log('boom'); window.boom = ob %>
 <%
   if (ob.order.shipping) {
     var addressLine3 = `${ob.order.shipping.city ? `${ob.order.shipping.city}${ob.order.shipping.state ? ',' : ''}` : ''}${ob.order.shipping.state ? ` ${ob.order.shipping.state}` : ''}`;

--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -108,7 +108,7 @@
       <hr class="clrBr" />
       <div class="gutterVTn">
         <div class="txB">Memo</div>
-        <div><%= item.memo ? item.memo : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
+        <div><%= item.memo ? ob.parseEmojis(item.memo) : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
       </div>
     </div>
   </div>

--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -72,7 +72,7 @@
               <a class="clrTEm" href="<%= mapUrl %>"><%= ob.polyT('orderDetail.summaryTab.orderDetails.viewOnMap') %></a>
             </div>
             <% } else { %>
-              <%= ob.polyT('orderDetail.summaryTab.orderDetails.notApplicable') %>
+              <%= ob.polyT('orderDetail.summaryTab.notApplicable') %>
             <% } %>
             <span class="clrT2 hide orderDetailsCopiedToClipboard js-orderDetailsCopiedToClipboard"><%= ob.polyT('copiedToClipboard') %></span>
         </div>
@@ -84,7 +84,7 @@
                 <% if (item.couponCodes && item.couponCodes.length) { %>
                   <div><%= item.couponCodes.join(', ') %></div>
                 <% } else { %>
-                  <div><%= ob.polyT('orderDetail.summaryTab.orderDetails.notApplicable') %></div>
+                  <div><%= ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
                 <% } %>              
               </div>
               <div class="col6">
@@ -108,7 +108,7 @@
       <hr class="clrBr" />
       <div class="gutterVTn">
         <div class="txB">Memo</div>
-        <div><%= item.memo ? item.memo : ob.polyT('orderDetail.summaryTab.orderDetails.notApplicable') %></div>
+        <div><%= item.memo ? item.memo : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
       </div>
     </div>
   </div>

--- a/js/templates/modals/orderDetail/summaryTab/orderDetailsModerator.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetailsModerator.html
@@ -5,5 +5,5 @@
   %>
   <div><%= ob.name %><% print(modLink ? ` ${modLink}` : '') %></div>
 <% } else { %>
-  <%= ob.polyT('orderDetail.summaryTab.orderDetails.notApplicable') %>
+  <%= ob.polyT('orderDetail.summaryTab.notApplicable') %>
 <% } %>

--- a/js/templates/modals/orderDetail/summaryTab/payment.html
+++ b/js/templates/modals/orderDetail/summaryTab/payment.html
@@ -108,7 +108,7 @@
                     <a class="js-rejectConfirmCancel"><%= ob.polyT('orderDetail.summaryTab.payment.rejectConfirm.btnCancel') %></a>
                     <a class="btn clrBAttGrad clrBrDec1 clrTOnEmph js-rejectConfirmed"><%= ob.polyT('orderDetail.summaryTab.payment.rejectConfirm.btnConfirm') %></a>
                   </div>
-                </div>                
+                </div>
               </div>
             <%  } %>
             <%= ob.processingButton({

--- a/js/views/modals/orderDetail/FulfillOrder.js
+++ b/js/views/modals/orderDetail/FulfillOrder.js
@@ -1,0 +1,55 @@
+import _ from 'underscore';
+import loadTemplate from '../../../utils/loadTemplate';
+import BaseVw from '../../baseVw';
+
+export default class extends BaseVw {
+  constructor(options = {}) {
+    super(options);
+
+    if (!this.model) {
+      throw new Error('Please provide an OrderFulfillment model.');
+    }
+
+    this._state = {
+      contractType: 'PHYSICAL_GOOD',
+      ...options.initialState || {},
+    };
+  }
+
+  className() {
+    return 'fulfillOrderTab';
+  }
+
+  getState() {
+    return this._state;
+  }
+
+  setState(state, replace = false, renderOnChange = true) {
+    let newState;
+
+    if (replace) {
+      this._state = {};
+    } else {
+      newState = _.extend({}, this._state, state);
+    }
+
+    if (renderOnChange && !_.isEqual(this._state, newState)) {
+      this._state = newState;
+      this.render();
+    }
+
+    return this;
+  }
+
+  render() {
+    loadTemplate('modals/orderDetail/fulfillOrder.html', (t) => {
+      this.$el.html(t({
+        ...this._state,
+        ...this.model.toJSON(),
+        errors: this.model.validationError || {},
+      }));
+    });
+
+    return this;
+  }
+}

--- a/js/views/modals/orderDetail/FulfillOrder.js
+++ b/js/views/modals/orderDetail/FulfillOrder.js
@@ -10,41 +10,48 @@ export default class extends BaseVw {
       throw new Error('Please provide an OrderFulfillment model.');
     }
 
-    this._state = {
-      contractType: 'PHYSICAL_GOOD',
-      ...options.initialState || {},
-    };
+    if (!options.contractType) {
+      throw new Error('Please provide the contract type.');
+    }
+
+    this.contractType = options.contractType;
+
+    // this._state = {
+    //   contractType: 'PHYSICAL_GOOD',
+    //   ...options.initialState || {},
+    // };
   }
 
   className() {
     return 'fulfillOrderTab';
   }
 
-  getState() {
-    return this._state;
-  }
+  // getState() {
+  //   return this._state;
+  // }
 
-  setState(state, replace = false, renderOnChange = true) {
-    let newState;
+  // setState(state, replace = false, renderOnChange = true) {
+  //   let newState;
 
-    if (replace) {
-      this._state = {};
-    } else {
-      newState = _.extend({}, this._state, state);
-    }
+  //   if (replace) {
+  //     this._state = {};
+  //   } else {
+  //     newState = _.extend({}, this._state, state);
+  //   }
 
-    if (renderOnChange && !_.isEqual(this._state, newState)) {
-      this._state = newState;
-      this.render();
-    }
+  //   if (renderOnChange && !_.isEqual(this._state, newState)) {
+  //     this._state = newState;
+  //     this.render();
+  //   }
 
-    return this;
-  }
+  //   return this;
+  // }
 
   render() {
     loadTemplate('modals/orderDetail/fulfillOrder.html', (t) => {
       this.$el.html(t({
-        ...this._state,
+        // ...this._state,
+        contractType: this.contractType,
         ...this.model.toJSON(),
         errors: this.model.validationError || {},
       }));

--- a/js/views/modals/orderDetail/OrderDetail.js
+++ b/js/views/modals/orderDetail/OrderDetail.js
@@ -5,7 +5,7 @@ import { getSocket } from '../../../utils/serverConnect';
 import _ from 'underscore';
 import loadTemplate from '../../../utils/loadTemplate';
 import Case from '../../../models/order/Case';
-import { Model } from 'backbone';
+import OrderFulfillment from '../../../models/order/orderFulfillment/OrderFulfillment';
 import BaseModal from '../BaseModal';
 import ProfileBox from './ProfileBox';
 import Summary from './summaryTab/Summary';
@@ -339,9 +339,20 @@ export default class extends BaseModal {
     return view;
   }
 
+  // This should not be called on a Case.
   createFulfillOrderTabView() {
+    // const contractType = this.model.get('contract')
+    //   .get('vendorListings')
+    //   .at(0)
+    //   .get('metadata')
+    //   .get('contractType');
+
+    // const contractType = 'PHYSICAL_GOOD';
+    const contractType = 'DIGITAL_GOOD';
+
     const view = this.createChild(FulfillOrder, {
-      model: new Model(),
+      model: new OrderFulfillment({}, { contractType }),
+      contractType,
     });
 
     return view;

--- a/js/views/modals/orderDetail/OrderDetail.js
+++ b/js/views/modals/orderDetail/OrderDetail.js
@@ -5,11 +5,13 @@ import { getSocket } from '../../../utils/serverConnect';
 import _ from 'underscore';
 import loadTemplate from '../../../utils/loadTemplate';
 import Case from '../../../models/order/Case';
+import { Model } from 'backbone';
 import BaseModal from '../BaseModal';
 import ProfileBox from './ProfileBox';
 import Summary from './summaryTab/Summary';
 import Discussion from './Discussion';
 import Contract from './Contract';
+import FulfillOrder from './FulfillOrder';
 
 export default class extends BaseModal {
   constructor(options = {}) {
@@ -19,7 +21,8 @@ export default class extends BaseModal {
         fetchFailed: false,
         fetchError: '',
       },
-      initialTab: 'summary',
+      // initialTab: 'summary',
+      initialTab: 'fulfillOrder',
       ...options,
     };
 
@@ -333,6 +336,14 @@ export default class extends BaseModal {
     });
 
     this.listenTo(view, 'clickBackToSummary', () => this.selectTab('summary'));
+    return view;
+  }
+
+  createFulfillOrderTabView() {
+    const view = this.createChild(FulfillOrder, {
+      model: new Model(),
+    });
+
     return view;
   }
 

--- a/js/views/modals/orderDetail/OrderDetail.js
+++ b/js/views/modals/orderDetail/OrderDetail.js
@@ -347,11 +347,7 @@ export default class extends BaseModal {
 
   // This should not be called on a Case.
   createFulfillOrderTabView() {
-    const contractType = this.model.get('contract')
-      .get('vendorListings')
-      .at(0)
-      .get('metadata')
-      .get('contractType');
+    const contractType = this.model.get('contract').type;
 
     const model = new OrderFulfillment({ orderId: this.model.id },
       { contractType });

--- a/js/views/modals/orderDetail/summaryTab/Accepted.js
+++ b/js/views/modals/orderDetail/summaryTab/Accepted.js
@@ -52,15 +52,6 @@ export default class extends BaseVw {
       }
     });
 
-    this.listenTo(orderEvents, 'fulfillOrderComplete refundOrderComplete', e => {
-      if (e.id === this.orderId) {
-        this.setState({
-          showRefundButton: false,
-          showFulfillButton: false,
-        });
-      }
-    });
-
     this.boundOnDocClick = this.onDocumentClick.bind(this);
     $(document).on('click', this.boundOnDocClick);
   }

--- a/js/views/modals/orderDetail/summaryTab/Accepted.js
+++ b/js/views/modals/orderDetail/summaryTab/Accepted.js
@@ -34,7 +34,7 @@ export default class extends BaseVw {
       }
     });
 
-    this.listenTo(orderEvents, 'fulfillOrderComplete, fulfillOrderFail', e => {
+    this.listenTo(orderEvents, 'fulfillOrderComplete fulfillOrderFail', e => {
       if (e.id === this.orderId) {
         this.setState({ fulfillInProgress: false });
       }
@@ -46,7 +46,7 @@ export default class extends BaseVw {
       }
     });
 
-    this.listenTo(orderEvents, 'refundOrderComplete, refundOrderFail', e => {
+    this.listenTo(orderEvents, 'refundOrderComplete refundOrderFail', e => {
       if (e.id === this.orderId) {
         this.setState({ refundOrderInProgress: false });
       }

--- a/js/views/modals/orderDetail/summaryTab/Accepted.js
+++ b/js/views/modals/orderDetail/summaryTab/Accepted.js
@@ -52,6 +52,15 @@ export default class extends BaseVw {
       }
     });
 
+    this.listenTo(orderEvents, 'fulfillOrderComplete refundOrderComplete', e => {
+      if (e.id === this.orderId) {
+        this.setState({
+          showRefundButton: false,
+          showFulfillButton: false,
+        });
+      }
+    });
+
     this.boundOnDocClick = this.onDocumentClick.bind(this);
     $(document).on('click', this.boundOnDocClick);
   }

--- a/js/views/modals/orderDetail/summaryTab/Accepted.js
+++ b/js/views/modals/orderDetail/summaryTab/Accepted.js
@@ -1,5 +1,12 @@
+import $ from 'jquery';
 import _ from 'underscore';
 import moment from 'moment';
+import {
+  fulfillingOrder,
+  refundingOrder,
+  refundOrder,
+  events as orderEvents,
+} from '../../../../utils/order';
 import loadTemplate from '../../../../utils/loadTemplate';
 import BaseVw from '../../../baseVw';
 
@@ -7,16 +14,46 @@ export default class extends BaseVw {
   constructor(options = {}) {
     super(options);
 
+    if (!options.orderId) {
+      throw new Error('Please provide the order id.');
+    }
+
+    this.orderId = options.orderId;
     this._state = {
       infoText: '',
       showRefundButton: false,
       showFulfillButton: false,
       avatarHashes: {},
       refundConfirmOn: false,
-      refundOrderInProgress: false,
-      fulfillInProgress: false,
       ...options.initialState || {},
     };
+
+    this.listenTo(orderEvents, 'fulfillingOrder', e => {
+      if (e.id === this.orderId) {
+        this.setState({ fulfillInProgress: true });
+      }
+    });
+
+    this.listenTo(orderEvents, 'fulfillOrderComplete, fulfillOrderFail', e => {
+      if (e.id === this.orderId) {
+        this.setState({ fulfillInProgress: false });
+      }
+    });
+
+    this.listenTo(orderEvents, 'refundingOrder', e => {
+      if (e.id === this.orderId) {
+        this.setState({ refundOrderInProgress: true });
+      }
+    });
+
+    this.listenTo(orderEvents, 'refundOrderComplete, refundOrderFail', e => {
+      if (e.id === this.orderId) {
+        this.setState({ refundOrderInProgress: false });
+      }
+    });
+
+    this.boundOnDocClick = this.onDocumentClick.bind(this);
+    $(document).on('click', this.boundOnDocClick);
   }
 
   className() {
@@ -26,7 +63,35 @@ export default class extends BaseVw {
   events() {
     return {
       'click .js-fulfillOrder': 'onClickFulfillOrder',
+      'click .js-refundOrder': 'onClickRefundOrder',
+      'click .js-refundConfirmed': 'onClickRefundConfirmed',
+      'click .js-refundConfirm': 'onClickRefundConfirmBox',
+      'click .js-refundConfirmCancel': 'onClickRefundConfirmCancel',
     };
+  }
+
+  onClickRefundOrder() {
+    this.setState({ refundConfirmOn: true });
+    return false;
+  }
+
+  onClickRefundConfirmBox() {
+    // ensure event doesn't bubble so onDocumentClick doesn't
+    // close the confirmBox.
+    return false;
+  }
+
+  onClickRefundConfirmCancel() {
+    this.setState({ refundConfirmOn: false });
+  }
+
+  onDocumentClick() {
+    this.setState({ refundConfirmOn: false });
+  }
+
+  onClickRefundConfirmed() {
+    this.setState({ refundConfirmOn: false });
+    refundOrder(this.orderId);
   }
 
   onClickFulfillOrder() {
@@ -59,6 +124,8 @@ export default class extends BaseVw {
       this.$el.html(t({
         ...this._state,
         moment,
+        fulfillInProgress: fulfillingOrder(this.orderId),
+        refundOrderInProgress: refundingOrder(this.orderId),
       }));
     });
 

--- a/js/views/modals/orderDetail/summaryTab/Fulfilled.js
+++ b/js/views/modals/orderDetail/summaryTab/Fulfilled.js
@@ -7,31 +7,27 @@ export default class extends BaseVw {
   constructor(options = {}) {
     super(options);
 
+    if (!options.dataObject) {
+      throw new Error('Please provide a vendorOrderFulfillment data object.');
+    }
+
     this._state = {
-      infoText: '',
-      showRefundButton: false,
-      showFulfillButton: false,
-      avatarHashes: {},
-      refundConfirmOn: false,
-      refundOrderInProgress: false,
-      fulfillInProgress: false,
+      contractType: 'PHYSICAL_GOOD',
       ...options.initialState || {},
     };
+
+    this.dataObject = options.dataObject;
   }
 
   className() {
-    return 'acceptedEvent rowLg';
+    return 'fulfilledEvent rowLg';
   }
 
-  events() {
-    return {
-      'click .js-fulfillOrder': 'onClickFulfillOrder',
-    };
-  }
-
-  onClickFulfillOrder() {
-    this.trigger('clickFulfillOrder');
-  }
+  // events() {
+  //   return {
+  //     'click .js-fulfillOrder': 'onClickFulfillOrder',
+  //   };
+  // }
 
   getState() {
     return this._state;
@@ -55,9 +51,10 @@ export default class extends BaseVw {
   }
 
   render() {
-    loadTemplate('modals/orderDetail/summaryTab/accepted.html', (t) => {
+    loadTemplate('modals/orderDetail/summaryTab/fulfilled.html', (t) => {
       this.$el.html(t({
         ...this._state,
+        ...this.dataObject || {},
         moment,
       }));
     });

--- a/js/views/modals/orderDetail/summaryTab/Fulfilled.js
+++ b/js/views/modals/orderDetail/summaryTab/Fulfilled.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import _ from 'underscore';
 import moment from 'moment';
 import { clipboard } from 'electron';

--- a/js/views/modals/orderDetail/summaryTab/Fulfilled.js
+++ b/js/views/modals/orderDetail/summaryTab/Fulfilled.js
@@ -1,5 +1,8 @@
+import $ from 'jquery';
 import _ from 'underscore';
 import moment from 'moment';
+import { clipboard } from 'electron';
+import '../../../../utils/velocity';
 import loadTemplate from '../../../../utils/loadTemplate';
 import BaseVw from '../../../baseVw';
 
@@ -13,6 +16,7 @@ export default class extends BaseVw {
 
     this._state = {
       contractType: 'PHYSICAL_GOOD',
+      showPassword: false,
       ...options.initialState || {},
     };
 
@@ -23,11 +27,28 @@ export default class extends BaseVw {
     return 'fulfilledEvent rowLg';
   }
 
-  // events() {
-  //   return {
-  //     'click .js-fulfillOrder': 'onClickFulfillOrder',
-  //   };
-  // }
+  events() {
+    return {
+      'click .js-copyTrackingNumber': 'onClickCopyTrackingNumber',
+    };
+  }
+
+  onClickCopyTrackingNumber() {
+    clipboard.writeText(this.dataObject.physicalDelivery[0].trackingNumber);
+    this.$trackingCopiedToClipboard
+      .velocity('stop')
+      .velocity('fadeIn', {
+        complete: () => {
+          this.$trackingCopiedToClipboard
+            .velocity('fadeOut', { delay: 1000 });
+        },
+      });
+  }
+
+  get $trackingCopiedToClipboard() {
+    return this._$copiedToClipboard ||
+      (this._$copiedToClipboard = this.$('.js-trackingCopiedToClipboard'));
+  }
 
   getState() {
     return this._state;
@@ -57,6 +78,8 @@ export default class extends BaseVw {
         ...this.dataObject || {},
         moment,
       }));
+
+      this._$copiedToClipboard = null;
     });
 
     return this;

--- a/js/views/modals/orderDetail/summaryTab/Payments.js
+++ b/js/views/modals/orderDetail/summaryTab/Payments.js
@@ -70,11 +70,11 @@ export default class extends baseVw {
       this.onCancelOrderAlways);
     this.listenTo(orderEvents, 'cancelOrderComplete', this.onAcceptOrderComplete);
     this.listenTo(orderEvents, 'acceptingOrder', this.onAcceptingOrder);
-    this.listenTo(orderEvents, 'acceptOrderComplete, acceptOrderFail',
+    this.listenTo(orderEvents, 'acceptOrderComplete acceptOrderFail',
       this.onAcceptOrderAlways);
     this.listenTo(orderEvents, 'acceptOrderComplete', this.onAcceptOrderComplete);
     this.listenTo(orderEvents, 'rejectingOrder', this.onRejectingOrder);
-    this.listenTo(orderEvents, 'rejectOrderComplete, rejectOrderFail',
+    this.listenTo(orderEvents, 'rejectOrderComplete rejectOrderFail',
       this.onRejectOrderAlways);
     this.listenTo(orderEvents, 'rejectOrderComplete', this.onRejectOrderComplete);
   }

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -82,13 +82,21 @@ export default class extends BaseVw {
     this.buyer = opts.buyer;
     this.moderator = opts.moderator;
 
-    this.listenTo(this.model, 'change:state', () => {
+    this.listenTo(this.model, 'change:state', (md, state) => {
       this.stateProgressBar.setState(this.progressBarState);
       if (this.payments) this.payments.render();
       if (this.shouldShowAcceptedSection()) {
         if (!this.accepted) this.renderAcceptedView();
       } else {
         if (this.accepted) this.accepted.remove();
+      }
+
+      if (state === 'REFUNDED' && this.accepted) {
+        this.accepted.setState({
+          showRefundButton: false,
+          showFulfillButton: false,
+          infoText: app.polyglot.t('orderDetail.summaryTab.accepted.vendorReceived'),
+        });
       }
     });
 

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -149,7 +149,7 @@ export default class extends BaseVw {
     });
 
     this.listenTo(this.contract, 'change:vendorOrderFulfillment',
-      () => this.appendFulfilledView());
+      () => this.renderFulfilledView());
 
     const serverSocket = getSocket();
 

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -91,7 +91,7 @@ export default class extends BaseVw {
         if (this.accepted) this.accepted.remove();
       }
 
-      if (state === 'REFUNDED' && this.accepted) {
+      if (state === 'REFUNDED' || state === 'FULFILLED' && this.accepted) {
         this.accepted.setState({
           showRefundButton: false,
           showFulfillButton: false,

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -179,6 +179,10 @@ export default class extends BaseVw {
             e.jsonData.notification.refund.orderId === this.model.id) {
             // A notification the buyer will get when the vendor has refunded their order.
             this.model.fetch();
+          } else if (e.jsonData.notification.orderFulfillment &&
+            e.jsonData.notification.orderFulfillment.orderId === this.model.id) {
+            // A notification the buyer will get when the vendor has fulfilled their order.
+            this.model.fetch();
           }
         }
       });

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -143,7 +143,7 @@ export default class extends BaseVw {
 
     this.listenTo(orderEvents, 'refundOrderComplete', e => {
       if (e.id === this.model.id) {
-        this.model.setState('state', 'REFUNDED');
+        this.model.set('state', 'REFUNDED');
         this.model.fetch();
       }
     });
@@ -174,6 +174,10 @@ export default class extends BaseVw {
           } else if (e.jsonData.notification.orderConfirmation &&
             e.jsonData.notification.orderConfirmation.orderId === this.model.id) {
             // A notification the buyer will get when the vendor has accepted an offline order.
+            this.model.fetch();
+          } else if (e.jsonData.notification.refund &&
+            e.jsonData.notification.refund.orderId === this.model.id) {
+            // A notification the buyer will get when the vendor has refunded their order.
             this.model.fetch();
           }
         }

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -411,3 +411,11 @@ input[type=range][class~="clrS"] {
     }
   }
 }
+
+.orderDetail {
+  .fulfilledEvent {
+    .ion-cube {
+      color: #64452c;
+    }
+  }
+}

--- a/styles/modules/modals/_orderDetail.scss
+++ b/styles/modules/modals/_orderDetail.scss
@@ -57,6 +57,12 @@
     padding: $padMd;
   }
 
+  .backToSummaryWrap {
+    position: absolute;
+    max-width: 250px;
+    left: $padLg;
+  }  
+
   .discussionTab {
     position: relative;
     overflow: hidden;
@@ -219,12 +225,6 @@
   }
 
   .contractTab {
-    .backToSummaryWrap {
-      position: absolute;
-      max-width: 250px;
-      left: $padLg;
-    }
-
     .renderjson {
       padding: $pad;
       overflow: auto;
@@ -307,6 +307,13 @@
         transform: translateY(-2px);
         font-size: $tx6;
       }
+    }
+  }
+
+  .fulfillOrderTab {
+    hr {
+      margin-left: $padLg;
+      margin-right: $padLg;
     }
   }
 }

--- a/styles/modules/modals/_orderDetail.scss
+++ b/styles/modules/modals/_orderDetail.scss
@@ -284,6 +284,22 @@
             padding-top: 8px;
           }
         }
+
+        &.ion-ios-folder {
+          font-size: 15px;
+
+          &::before {
+            padding-top: 9px;
+          }
+        }
+
+        &.ion-ios-body {
+          font-size: 20px;
+
+          &::before {
+            padding-top: 7px;
+          }          
+        }
       }
     }    
 
@@ -314,6 +330,14 @@
         position: absolute;
         transform: translateY(-2px);
         font-size: $tx6;
+      }
+    }
+
+    .acceptedEvent {
+      .refundConfirm {
+        left: 50%;
+        transform: translateX(-50%);
+        top: 39px;        
       }
     }
   }

--- a/styles/modules/modals/_orderDetail.scss
+++ b/styles/modules/modals/_orderDetail.scss
@@ -252,26 +252,6 @@
     }
 
     .payment, .refunded {
-      .statusIconCol {
-        text-align: center;
-        flex-shrink: 0;
-
-        span {
-          width: 35px;
-          height: 35px;
-          display: inline-block;
-          border-radius: 50%;
-          border-style: solid;
-          border-width: 1px;
-          font-size: 30px;
-
-          &.ion-ios-checkmark-empty {
-            font-size: 36px;
-            line-height: 1;
-          }
-        }
-      }
-
       .rejectConfirm {
         left: 50%;
         transform: translateX(-50%);
@@ -279,12 +259,42 @@
       }
     }
 
-    .acceptedEvent {
-      .avatarCol {
-        flex-shrink: 0;
+    .statusIconCol {
+      text-align: center;
+      flex-shrink: 0;
+
+      span {
         width: 35px;
         height: 35px;
+        display: inline-block;
+        border-radius: 50%;
+        border-style: solid;
+        border-width: 1px;
+        font-size: 30px;
+
+        &.ion-ios-checkmark-empty {
+          font-size: 36px;
+          line-height: 1;
+        }
+
+        &.ion-cube {
+          font-size: 17px;
+
+          &::before {
+            padding-top: 8px;
+          }
+        }
       }
+    }    
+
+    .avatarCol {
+      flex-shrink: 0;
+      width: 35px;
+      height: 35px;
+      border-width: 2px;
+      border-style: solid;
+      width: 38px;
+      height: 38px;        
     }
 
     .orderDetails {
@@ -302,8 +312,6 @@
 
       .orderDetailsCopiedToClipboard {
         position: absolute;
-        // right: $padSm;
-        // top: 5px;
         transform: translateY(-2px);
         font-size: $tx6;
       }
@@ -314,6 +322,10 @@
     hr {
       margin-left: $padLg;
       margin-right: $padLg;
+    }
+    
+    .buttonBar {
+      padding: $padMd $padLg $padLg;
     }
   }
 }


### PR DESCRIPTION
The PR adds the following functionality to the Order Details overlay:
- fulfill an order
- issue a refund by the vendor

Notes:
- ensure you are on the latest server
- @jjeffryes Could you help me test something? When I do a refund (at least for a direct, online order), the refund API succeeds and a subsequent fetch of the order shows a REFUNDED state, but the refund transaction never shows up. It should look like this:

```
    "refundAddressTransaction": {
        "txid": "9b55dd7948519cda102db349165e3b1a43585adf47065fad5366a2ecb0a80461",
        "value": 149508,
        "confirmations": 1236,
        "height": 1127249,
        "timestamp": "2017-06-07T23:02:51.892599179Z"
    }
```

It never shows up for me, but according to CP, the it shows up in the unit tests. If it also does not show up for you, could you please log a server bug for it?
