### PR TITLE
Fix Default Currency in Settings Moderation.

### DIFF
--- a/js/models/profile/FixedFee.js
+++ b/js/models/profile/FixedFee.js
@@ -6,7 +6,7 @@ import is from 'is_js';
 export default class extends BaseModel {
   defaults() {
     return {
-      currencyCode: 'BTC',
+      currencyCode: '',
       amount: 0,
     };
   }

--- a/js/templates/modals/settings/moderation.html
+++ b/js/templates/modals/settings/moderation.html
@@ -63,7 +63,7 @@
               </div>
               <div class="col2 js-feeFixedInput <% if (!ob.fee || (ob.fee && ob.fee.feeType === 'PERCENTAGE')) { print('visuallyHidden') } %>">
                 <% var amt = ob.fee && ob.fee.fixedFee ? ob.fee.fixedFee.amount : 0;
-                   var ccode = ob.fee && ob.fee.fixedFee ? ob.fee.fixedFee.currencyCode : ob.defaultCurrency;
+                   var ccode = ob.fee && ob.fee.fixedFee && ob.fee.fixedFee.currencyCode ? ob.fee.fixedFee.currencyCode : ob.defaultCurrency;
                    amt = typeof amt === 'number' ? ob.formatPrice(amt, ccode === 'BTC') : amt;
                 %>
                 <!-- use text and set max length so excess decimals can't be entered.-->

--- a/js/views/modals/Settings/Moderation.js
+++ b/js/views/modals/Settings/Moderation.js
@@ -36,7 +36,7 @@ export default class extends baseVw {
     this.listenTo(this.profile, 'sync', () => {
       app.profile.set({
         moderator: this.profile.get('moderator'),
-        modInfo: this.profile.get('moderatorInfo').toJSON(),
+        moderatorInfo: this.profile.get('moderatorInfo').toJSON(),
       });
     });
   }


### PR DESCRIPTION
- Don't default fee currency to BTC.
- Use default currency if no moderation currency has been set.
- Fix bug with setting moderation info due to wrong parameter name.
- Closes #525 