### PR TITLE
Center the listing image in the listing card.

### DIFF
--- a/styles/components/_listingCard.scss
+++ b/styles/components/_listingCard.scss
@@ -17,6 +17,7 @@
       height: 225px;
       position: relative;
       background-size: cover;
+      background-position: center;
     }
 
     .listingIcons {


### PR DESCRIPTION
Listing images in the listing cards are not always centered, because the image is not always square. This corrects the centering on non-square images.