### PR TITLE
Use fee from settings

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -320,7 +320,7 @@
       "helperVisualEffects": "Transitions, Easing, Opacity",
       "helperWindowControls": "Maximize, Minimize & Close controls",
       "helperSaveMetaData": "Store additional transaction information",
-      "helperDefaultFee": "Average is recommended. High may clear faster.",
+      "helperDefaultFee": "High is recommended for the fastest transactions",
       "helperServerManagement": "Switch and manage server connections",
       "helperServerPeers": "Peers you're connected to",
       "smtp": {
@@ -1303,7 +1303,7 @@
   "orderCompletionModelErrors": {
     "provideReview": "Please provide a review.",
     "provideRating": "Please select a rating."
-  },  
+  },
   "bitcoinCurrencyUnits": {
     "BTC": "BTC",
     "MBTC": "mBTC",

--- a/js/models/wallet/Spend.js
+++ b/js/models/wallet/Spend.js
@@ -117,6 +117,7 @@ export default Spend;
 export function spend(fields) {
   const attrs = {
     currency: app && app.settings && app.settings.get('localCurrency') || 'BTC',
+    feeLevel: app && app.localSettings && app.localSettings.get('defaultTransactionFee') || 'high',
     memo: '',
     ...fields,
   };

--- a/js/views/modals/purchase/ConfirmWallet.js
+++ b/js/views/modals/purchase/ConfirmWallet.js
@@ -18,7 +18,8 @@ export default class extends BaseVw {
     this.listenTo(app.walletBalance, 'change:confirmed', () => this.render());
 
     // fetch the estimated fee and rerender when it returns
-    this.fetchEstimatedFee = $.get(app.getServerUrl('wallet/estimatefee/?feeLevel=NORMAL'))
+    const feeLevel = app.localSettings.get('defaultTransactionFee').toUpperCase();
+    this.fetchEstimatedFee = $.get(app.getServerUrl(`wallet/estimatefee/?feeLevel=${feeLevel}`))
       .done(data => {
         if (this.isRemoved()) return;
         this.fee = integerToDecimal(data, true);


### PR DESCRIPTION
This will apply the fee level from settings when the spend method is called, as well as change the language on the settings control and show the estimated fee in the confirm payment tooltip using the set fee level.

The fee level in the spend method is not tested, once funds confirm and are spendable (testnet is being sloooooow) I will test that.

Closes #540 
