### PR TITLE
Purchase patch

### DIFF
--- a/js/templates/modals/purchase/actionBtn.html
+++ b/js/templates/modals/purchase/actionBtn.html
@@ -6,9 +6,9 @@
       btnText: ob.polyT('purchase.pay')
     }) %>
   <% } else if (ob.phase ==='pending') { %>
-    <button class="btn width100 clrBAttGrad clrBrDec1 clrTOnEmph js-pendingBtn">
+    <div class="btn width100 clrBAttGrad clrBrDec1 clrTOnEmph pendingBtn">
       <%= ob.polyT('purchase.pending') %>
-    </button>
+    </div>
   <% } else if (ob.phase ==='complete') { %>
     <button class="btn width100 clrBAttGrad clrBrDec1 clrTOnEmph js-closeBtn">
       <%= ob.polyT('purchase.close') %>

--- a/js/templates/modals/purchase/shippingOptions.html
+++ b/js/templates/modals/purchase/shippingOptions.html
@@ -1,10 +1,6 @@
 <% if (ob.validShippingOptions.length) { %>
   <div class="flexColRows boxList border borderStacked clrP clrBr">
     <% ob.validShippingOptions.forEach((option, i) => {
-      if (option.type === 'LOCAL_PICKUP') {
-        option.services[0] = { name: ob.polyT('purchase.localPickup'), price: 0 };
-      }
-      option.services = _.sortBy(option.services, 'price');
       option.services.forEach((service, j) => { %>
         <div>
           <div class="btnRadio width100">

--- a/js/views/modals/purchase/ActionBtn.js
+++ b/js/views/modals/purchase/ActionBtn.js
@@ -27,7 +27,6 @@ export default class extends baseView {
   events() {
     return {
       'click .js-payBtn': 'clickPayBtn',
-      'click .js-pendingBtn': 'clickPendingBtn',
       'click .js-confirmPayConfirm': 'clickConfirmBtn',
       'click .js-confirmPayCancel': 'closeConfirmPay',
       'click .js-closeBtn': 'clickCloseBtn',
@@ -56,11 +55,6 @@ export default class extends baseView {
 
   closeConfirmPay() {
     this.state.phase = 'pay';
-    this.render();
-  }
-
-  clickPendingBtn() {
-    this.state.phase = 'complete';
     this.render();
   }
 

--- a/js/views/modals/purchase/Moderators.js
+++ b/js/views/modals/purchase/Moderators.js
@@ -59,7 +59,8 @@ export default class extends baseVw {
   getModeratorsByID(IDs = this.options.moderatorIDs) {
     const op = this.options;
     const includeString = op.include ? `&include=${op.include}` : '';
-    const url = app.getServerUrl(`ob/${op.apiPath}?async=${op.async}${includeString}`);
+    const urlString = `ob/${op.apiPath}?async=${op.async}${includeString}&usecache=${op.useCache}`;
+    const url = app.getServerUrl(urlString);
 
     this.notFetchedYet = IDs;
     this.fetchingMods = IDs;

--- a/js/views/modals/purchase/ShippingOptions.js
+++ b/js/views/modals/purchase/ShippingOptions.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import _ from 'underscore';
 import app from '../../../app';
 import '../../../lib/select2';
 import loadTemplate from '../../../utils/loadTemplate';
@@ -50,6 +51,14 @@ export default class extends baseView {
     option.regions.indexOf(this.countryCode) !== -1 || option.regions.indexOf('ALL') !== -1);
 
     if (validShippingOptions.length) {
+      validShippingOptions.forEach(option => {
+        if (option.type === 'LOCAL_PICKUP') {
+          // local pickup options need a name and price
+          option.services[0] = { name: app.polyglot.t('purchase.localPickup'), price: 0 };
+        }
+        option.services = _.sortBy(option.services, 'price');
+      });
+
       const sOpts = {};
       sOpts.name = validShippingOptions[0].name;
       if (validShippingOptions[0].type !== 'LOCAL_PICKUP') {

--- a/styles/modules/modals/_purchase.scss
+++ b/styles/modules/modals/_purchase.scss
@@ -70,6 +70,12 @@
     }
   }
 
+  .actionBtn {
+    .pendingBtn {
+      pointer-events: none;
+    }
+  }
+
   .sidebar {
     position: fixed;
     width: 234px;


### PR DESCRIPTION
This fixes a variety of small issues.

- adds usecache to the moderators so they load faster at the cost of their data being potentially out of date.
- disables clicking on the pending button.
- fixes a bug where shipping options were sorted by price in the template, causing the first one selected in the view to not always match the first one in the template.