### PR TITLE
Fix fee levels

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -261,8 +261,7 @@
       "statusSaveFailed": "Unable to save general settings.",
       "saveErrorAlertTitle": "Unable to save general settings",
       "searchProvider": "Search Provider",
-      "restoreDefaultProvider": "Restore default",
-      "searchProviderError": "This is not a valid url for a search provider"
+      "restoreDefaultProvider": "Restore default"
     },
     "pageTab": {
       "helperAbout": "Displays on your Home page",
@@ -320,7 +319,7 @@
       "helperVisualEffects": "Transitions, Easing, Opacity",
       "helperWindowControls": "Maximize, Minimize & Close controls",
       "helperSaveMetaData": "Store additional transaction information",
-      "helperDefaultFee": "High is recommended for the fastest transactions",
+      "helperDefaultFee": "Priority is recommended for the fastest transactions",
       "helperServerManagement": "Switch and manage server connections",
       "helperServerPeers": "Peers you're connected to",
       "smtp": {
@@ -358,9 +357,9 @@
         "sectionName": "Transactions",
         "saveMetadata": "Save Metadata",
         "defaultFee": "Bitcoin Fee",
-        "low": "Low",
-        "medium": "Average",
-        "high": "High"
+        "low": "Economic",
+        "medium": "Normal",
+        "high": "Priority"
       },
       "appearance": {
         "sectionName": "Appearance",
@@ -1303,6 +1302,10 @@
   "orderCompletionModelErrors": {
     "provideReview": "Please provide a review.",
     "provideRating": "Please select a rating."
+  },
+  "localStorageModelErrors": {
+    "searchProvider": "This is not a valid url for a search provider",
+    "transactionFee": "You must choose one of %{levels}."
   },
   "bitcoinCurrencyUnits": {
     "BTC": "BTC",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1362,7 +1362,7 @@
     "provideReview": "Please provide a review.",
     "provideRating": "Please select a rating."
   },
-  "localStorageModelErrors": {
+  "localSettingsModelErrors": {
     "searchProvider": "This is not a valid url for a search provider",
     "transactionFee": "You must choose one of %{levels}."
   },

--- a/js/models/LocalSettings.js
+++ b/js/models/LocalSettings.js
@@ -18,7 +18,7 @@ export default class extends Model {
       windowControlStyle: remote.process.platform === 'darwin' ? 'mac' : 'win',
       showAdvancedVisualEffects: true,
       saveTransactionMetadata: true,
-      defaultTransactionFee: 'high',
+      defaultTransactionFee: 'PRIORITY',
       language: 'en-US',
       listingsGridViewType: 'grid',
       bitcoinUnit: 'BTC',
@@ -35,7 +35,11 @@ export default class extends Model {
   }
 
   get feeLevels() {
-    return ['low', 'medium', 'high'];
+    return [
+      'PRIORITY',
+      'NORMAL',
+      'ECONOMIC',
+    ];
   }
 
   get bitcoinUnits() {
@@ -58,8 +62,9 @@ export default class extends Model {
     }
 
     if (!this.feeLevels.includes(attrs.defaultTransactionFee)) {
-      addError('defaultTransactionFee',
-        `Default transaction fee needs to be one of ${this.feeLevels}.`);
+      const levels = this.feeLevels.join(', ').toLowerCase();
+      addError('defaultTransactionFee', app.polyglot.t('localStorageModelErrors.transactionFee',
+        { levels }));
     }
 
     if (!this.bitcoinUnits.includes(attrs.bitcoinUnit)) {
@@ -67,7 +72,7 @@ export default class extends Model {
     }
 
     if (is.not.url(attrs.searchProvider)) {
-      addError('searchProvider', app.polyglot.t('settings.generalTab.searchProviderError'));
+      addError('searchProvider', app.polyglot.t('localStorageModelErrors.searchProvider'));
     }
 
     if (Object.keys(errObj).length && errObj) return errObj;

--- a/js/models/LocalSettings.js
+++ b/js/models/LocalSettings.js
@@ -63,7 +63,7 @@ export default class extends Model {
 
     if (!this.feeLevels.includes(attrs.defaultTransactionFee)) {
       const levels = this.feeLevels.join(', ').toLowerCase();
-      addError('defaultTransactionFee', app.polyglot.t('localStorageModelErrors.transactionFee',
+      addError('defaultTransactionFee', app.polyglot.t('localSettingsModelErrors.transactionFee',
         { levels }));
     }
 
@@ -72,7 +72,7 @@ export default class extends Model {
     }
 
     if (is.not.url(attrs.searchProvider)) {
-      addError('searchProvider', app.polyglot.t('localStorageModelErrors.searchProvider'));
+      addError('searchProvider', app.polyglot.t('localSettingsModelErrors.searchProvider'));
     }
 
     if (Object.keys(errObj).length && errObj) return errObj;

--- a/js/models/wallet/Spend.js
+++ b/js/models/wallet/Spend.js
@@ -117,7 +117,8 @@ export default Spend;
 export function spend(fields) {
   const attrs = {
     currency: app && app.settings && app.settings.get('localCurrency') || 'BTC',
-    feeLevel: app && app.localSettings && app.localSettings.get('defaultTransactionFee') || 'high',
+    feeLevel: app &&
+    app.localSettings && app.localSettings.get('defaultTransactionFee') || 'PRIORITY',
     memo: '',
     ...fields,
   };

--- a/js/templates/modals/settings/advanced.html
+++ b/js/templates/modals/settings/advanced.html
@@ -111,34 +111,35 @@
               <div class="clrT2 txSm"><%= ob.polyT('settings.advancedTab.helperDefaultFee') %></div>
             </div>
             <div class="col9">
+              <% if (ob.errors['defaultTransactionFee']) print(ob.formErrorTmpl({ errors: ob.errors['defaultTransactionFee'] })) %>
               <div class="btnRadio clrBr">
                 <input type="radio"
                        data-persistence-location="local"
                        name="defaultTransactionFee"
-                       value="low"
+                       value="ECONOMIC"
                        id="defaultTransactionFeeLow"
                        data-var-type="string"
-                <% if(ob.defaultTransactionFee == "low") { %>checked<% } %>>
+                <% if(ob.defaultTransactionFee == "ECONOMIC") { %>checked<% } %>>
                 <label for="defaultTransactionFeeLow"><%= ob.polyT('settings.advancedTab.transaction.low') %></label>
               </div>
               <div class="btnRadio clrBr">
                 <input type="radio"
                        data-persistence-location="local"
                        name="defaultTransactionFee"
-                       value="medium"
+                       value="NORMAL"
                        id="defaultTransactionFeeMedium"
                        data-var-type="string"
-                <% if(ob.defaultTransactionFee == "medium") { %>checked<% } %>>
+                <% if(ob.defaultTransactionFee == "NORMAL") { %>checked<% } %>>
                 <label for="defaultTransactionFeeMedium"><%= ob.polyT('settings.advancedTab.transaction.medium') %></label>
               </div>
               <div class="btnRadio clrBr">
                 <input type="radio"
                        data-persistence-location="local"
                        name="defaultTransactionFee"
-                       value="high"
+                       value="PRIORITY"
                        id="defaultTransactionFeeHigh"
                        data-var-type="string"
-                <% if(ob.defaultTransactionFee == "high") { %>checked<% } %>>
+                <% if(ob.defaultTransactionFee == "PRIORITY") { %>checked<% } %>>
                 <label for="defaultTransactionFeeHigh"><%= ob.polyT('settings.advancedTab.transaction.high') %></label>
               </div>
             </div>

--- a/js/views/modals/Settings/Advanced.js
+++ b/js/views/modals/Settings/Advanced.js
@@ -48,7 +48,8 @@ export default class extends baseVw {
   }
 
   save() {
-    this.localSettings.set(this.getFormData(this.$localFields), { validate: true });
+    this.localSettings.set(this.getFormData(this.$localFields));
+    this.localSettings.set({}, { validate: true });
 
     const serverFormData = this.getFormData();
     this.settings.set(serverFormData, { validate: true });
@@ -116,7 +117,10 @@ export default class extends baseVw {
   render() {
     loadTemplate('modals/settings/advanced.html', (t) => {
       this.$el.html(t({
-        errors: this.settings.validationError || {},
+        errors: {
+          ...(this.settings.validationError || {}),
+          ...(this.localSettings.validationError || {}),
+        },
         ...this.settings.toJSON(),
         ...this.localSettings.toJSON(),
       }));


### PR DESCRIPTION
This will fix the fee levels to always use PRIORITY, NORMAL, and ECONOMIC, instead of low, medium and high.

It will also correct the advanced tab to show errors with the fee levels on save, and homogenizes the language used so it always matches the server to avoid confusion.