### PR TITLE
Refactor Notifications

### DIFF
--- a/js/start.js
+++ b/js/start.js
@@ -763,10 +763,10 @@ serverConnectEvents.on('connected', (connectedEvent) => {
   connectedEvent.socket.on('message', (e) => {
     if (e.jsonData) {
       if (e.jsonData.notification) {
-        if (e.jsonData.notification.follow) {
-          app.ownFollowers.unshift({ guid: e.jsonData.notification.follow });
-        } else if (e.jsonData.notification.unfollow) {
-          app.ownFollowers.remove(e.jsonData.notification.unfollow); // remove by id
+        if (e.jsonData.notification.type === 'follow') {
+          app.ownFollowers.unshift({ guid: e.jsonData.notification.peerId });
+        } else if (e.jsonData.notification.type === 'unfollow') {
+          app.ownFollowers.remove(e.jsonData.notification.peerId); // remove by id
         }
       }
     }

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -234,7 +234,7 @@ export default class extends BaseVw {
       // Sent to the moderator when the other party sends their copy of the contract
       'disputeUpdate',
       // Notification to the vendor and buyer when a mod has made a decision on an open dispute.
-      'disputeClose'
+      'disputeClose',
     ];
 
     if (serverSocket) {

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -209,50 +209,38 @@ export default class extends BaseVw {
     }
 
     const serverSocket = getSocket();
+    const notificationTypes = [
+      // A notification for the buyer that a payment has come in for the order. Let's refetch
+      // our model so we have the data for the new transaction and can show it in the UI.
+      // As of now, the buyer only gets these notifications and this is the only way to be
+      // aware of partial payments in realtime.
+      'payment',
+      // A notification the vendor will get when an offline order has been canceled
+      'cancel',
+      // A notification the vendor will get when an order has been fully funded
+      'order',
+      // A notification the buyer will get when the vendor has rejected an offline order.
+      'declined',
+      // A notification the buyer will get when the vendor has accepted an offline order.
+      'orderConfirmation',
+      // A notification the buyer will get when the vendor has refunded their order.
+      'refund',
+      // A notification the buyer will get when the vendor has fulfilled their order.
+      'fulfillment',
+      // A notification the vendor will get when the buyer has completed an order.
+      'orderComplete',
+      // When a party opens a dispute the mod and the other party will get this notification
+      'disputeOpen',
+      // Sent to the moderator when the other party sends their copy of the contract
+      'disputeUpdate',
+      // Notification to the vendor and buyer when a mod has made a decision on an open dispute.
+      'disputeClose'
+    ];
 
     if (serverSocket) {
       serverSocket.on('message', e => {
-        if (e.jsonData.notification) {
-          if (e.jsonData.notification.payment &&
-            e.jsonData.notification.payment.orderId === this.model.id) {
-            // A notification for the buyer that a payment has come in for the order. Let's refetch
-            // our model so we have the data for the new transaction and can show it in the UI.
-            // As of now, the buyer only gets these notifications and this is the only way to be
-            // aware of partial payments in realtime.
-            this.model.fetch();
-          } else if (e.jsonData.notification.order &&
-            e.jsonData.notification.order.orderId === this.model.id) {
-            // A notification the vendor will get when an order has been fully funded
-            this.model.fetch();
-          } else if (e.jsonData.notification.orderCancel &&
-            e.jsonData.notification.orderCancel.orderId === this.model.id) {
-            // A notification the buyer will get when the vendor has rejected an offline order.
-            this.model.fetch();
-          } else if (e.jsonData.notification.orderConfirmation &&
-            e.jsonData.notification.orderConfirmation.orderId === this.model.id) {
-            // A notification the buyer will get when the vendor has accepted an offline order.
-            this.model.fetch();
-          } else if (e.jsonData.notification.refund &&
-            e.jsonData.notification.refund.orderId === this.model.id) {
-            // A notification the buyer will get when the vendor has refunded their order.
-            this.model.fetch();
-          } else if (e.jsonData.notification.orderFulfillment &&
-            e.jsonData.notification.orderFulfillment.orderId === this.model.id) {
-            // A notification the buyer will get when the vendor has fulfilled their order.
-            this.model.fetch();
-          } else if (e.jsonData.notification.orderCompletion &&
-            e.jsonData.notification.orderCompletion.orderId === this.model.id) {
-            // A notification the vendor will get when the buyer has completed an order.
-            this.model.fetch();
-          } else if (e.jsonData.notification.disputeOpen &&
-            e.jsonData.notification.disputeOpen.orderId === this.model.id) {
-            // When a party opens a dispute the mod and the other party will get this
-            // notification
-            this.model.fetch();
-          } else if (e.jsonData.notification.disputeClose &&
-            e.jsonData.notification.disputeClose.orderId === this.model.id) {
-            // Notification to the vendor and buyer when a mod has made a decision
-            // on an open dispute.
+        if (e.jsonData.notification && e.jsonData.notification.orderId === this.model.id) {
+          if (notificationTypes.indexOf(e.jsonData.notification.type) > -1) {
             this.model.fetch();
           }
         }

--- a/js/views/modals/purchase/Payment.js
+++ b/js/views/modals/purchase/Payment.js
@@ -47,12 +47,11 @@ export default class extends BaseVw {
     if (serverSocket) {
       this.listenTo(serverSocket, 'message', e => {
         // listen for a payment socket message, to react to payments from all sources
-        if (e.jsonData.notification && e.jsonData.notification.payment) {
-          const payment = e.jsonData.notification.payment;
-          if (payment.orderId === this.orderId) {
-            const amount = integerToDecimal(payment.fundingTotal, true);
+        if (e.jsonData.notification && e.jsonData.notification.type === 'payment') {
+          if (e.jsonData.notification.orderId === this.orderId) {
+            const amount = integerToDecimal(e.jsonData.notification.fundingTotal, true);
             if (amount >= this.balanceRemaining) {
-              this.trigger('walletPaymentComplete', payment);
+              this.trigger('walletPaymentComplete', e.jsonData.notification);
             } else {
               // Ensure the resulting balance has a maximum of 8 decimal places with not
               // trailing zeros.


### PR DESCRIPTION
This updates the treatment of notifications to expect a type, and to have other data inside the notification instead of inside an inner object. 

I've tested all of the possible notifications except disputeUpdate, I wasn't able to get the timing right to catch when the notification arrived. 

Closes #500 

This must be used with the server notification PR. They should be merged together.

https://github.com/OpenBazaar/openbazaar-go/pull/536