### PR TITLE
Added packages required to build on OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "open": "0.0.5",
     "qr-encode": "^0.3.0",
     "sortablejs": "^1.5.0-rc1",
+    "source-map": "^0.5.6",
+    "through2": "^2.0.3",
     "trumbowyg": "^2.4.2",
     "trunk8": "0.0.1",
     "twemoji": "^2.2.5",


### PR DESCRIPTION
These packages were needed when trying to build on OSX 10.12.6.
```
$ node --version && npm --version
v6.11.0
5.3.0
```