### PR TITLE
Refactor search.

### DIFF
--- a/js/templates/search/Search.html
+++ b/js/templates/search/Search.html
@@ -36,7 +36,12 @@
             <% if (val.type ==='dropdown') { %>
               <select name="<%= key %>" class="select2Small">
               <% _.each(val.options, function(option) {
-                var selected = option.checked ? 'selected' : '';
+                let selected = '';
+                if (ob.filterVals[key]) {
+                  selected = option.value === ob.filterVals[key] ? 'selected' : '';
+                } else {
+                  selected = option.checked ? 'selected' : '';
+                }
                 print(`<option ${selected} value="${option.value}">${option.label}</option>`);
               }); %>
               </select>
@@ -45,7 +50,12 @@
               <% _.each(val.options, function(option, ind) { %>
                 <div class="btnRadio clrBr">
                    <%
-                    var checked = option.checked ? 'checked' : '';
+                    let checked = '';
+                    if (ob.filterVals[key]) {
+                      checked = option.value === ob.filterVals[key] ? 'checked' : '';
+                    } else {
+                      checked = option.checked ? 'checked' : '';
+                    }
                     var parsedLabel = ob.parseEmojis(option.label);
                     print(`<input type="radio" name="${key}" id="${key + ind}" ${checked} value="${option.value}">`);
                     print(`<label for="${key + ind}">${parsedLabel}</label>`);
@@ -56,7 +66,12 @@
             <% } else if (val.type ==='checkbox') { %>
               <div class="flexCol">
               <% _.each(val.options, function(option, index) {
-                var checked = option.checked ? 'checked' : '';
+                let checked = '';
+                if (ob.filterVals[key]) {
+                  checked = option.value === ob.filterVals[key] ? 'checked' : '';
+                } else {
+                  checked = option.checked ? 'checked' : '';
+                }
                 var parsedLabel = ob.parseEmojis(option.label);
                 print(`<input type="checkbox" ${checked} value="${option.value}" id="${key + index}" name="${key}">`);
                 print(`<label for="${key + index}">${parsedLabel}</label>`);

--- a/js/templates/search/Search.html
+++ b/js/templates/search/Search.html
@@ -37,10 +37,10 @@
               <select name="<%= key %>" class="select2Small">
               <% _.each(val.options, function(option) {
                 let selected = '';
-                if (ob.filterVals[key]) {
+                if (ob.filterVals.hasOwnProperty(key)) {
                   selected = option.value === ob.filterVals[key] ? 'selected' : '';
                 } else {
-                  selected = option.checked ? 'selected' : '';
+                  selected = option.default ? 'selected' : '';
                 }
                 print(`<option ${selected} value="${option.value}">${option.label}</option>`);
               }); %>
@@ -51,10 +51,10 @@
                 <div class="btnRadio clrBr">
                    <%
                     let checked = '';
-                    if (ob.filterVals[key]) {
+                    if (ob.filterVals.hasOwnProperty(key)) {
                       checked = option.value === ob.filterVals[key] ? 'checked' : '';
                     } else {
-                      checked = option.checked ? 'checked' : '';
+                      checked = option.default ? 'checked' : '';
                     }
                     var parsedLabel = ob.parseEmojis(option.label);
                     print(`<input type="radio" name="${key}" id="${key + ind}" ${checked} value="${option.value}">`);
@@ -67,10 +67,10 @@
               <div class="flexCol">
               <% _.each(val.options, function(option, index) {
                 let checked = '';
-                if (ob.filterVals[key]) {
+                if (ob.filterVals.hasOwnProperty(key)) {
                   checked = option.value === ob.filterVals[key] ? 'checked' : '';
                 } else {
-                  checked = option.checked ? 'checked' : '';
+                  checked = option.default ? 'checked' : '';
                 }
                 var parsedLabel = ob.parseEmojis(option.label);
                 print(`<input type="checkbox" ${checked} value="${option.value}" id="${key + index}" name="${key}">`);

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -1,7 +1,9 @@
+import _ from 'underscore';
 import baseVw from '../baseVw';
 import loadTemplate from '../../utils/loadTemplate';
 import app from '../../app';
 import $ from 'jquery';
+import is from 'is_js';
 import Dialog from '../modals/Dialog';
 import Results from './Results';
 import ResultsCol from '../../collections/Results';
@@ -13,28 +15,34 @@ export default class extends baseVw {
     super(options);
     this.options = options;
 
-    const queryParams = (new URL(`http://blah-blah?${options.query || ''}`)).searchParams;
-    const providerQuery = queryParams.get('providerQ');
+    this.sProvider = options.sProvider || app.localSettings.get('searchProvider');
 
-    if (providerQuery) {
-      // A query for a specific provider was provided.
-      const searchURL = new URL(providerQuery);
-      const params = searchURL.searchParams;
-      this.sProvider = `${searchURL.origin}${searchURL.pathname}`;
-      this.serverPage = params.get('p') || 0;
-      this.pageSize = params.get('ps') || 12;
-      this.term = params.get('q') || '';
-      this.sortBySelected = params.get('sortBy') || '';
-      this.callSearchProvider(searchURL);
-    } else {
-      this.sProvider = app.localSettings.get('searchProvider');
-      this.serverPage = options.serverPage || 0;
-      this.pageSize = options.pageSize || 12;
-      // if the term was not a url, process the term before calling the search provider
-      this.processTerm(queryParams.get('q') || '');
+    // the search provider is used here as a placeholder to get the parameters from the created url
+    const searchURL = new URL(`${this.sProvider}?${options.query || ''}`);
+    let queryParams = searchURL.searchParams;
+
+    // if a url with parameters was in the query in, use the parameters in it instead.
+    if (queryParams.get('providerQ')) {
+      const subURL = new URL(queryParams.get('providerQ'));
+      queryParams = subURL.searchParams;
+      this.sProvider = `${subURL.origin}${subURL.pathname}`;
     }
 
-    this.usingDefault = this.sProvider === app.localSettings.get('searchProvider');
+    const params = {};
+
+    for (const param of queryParams.entries()) {
+      params[param[0]] = param[1];
+    }
+
+    // use the parameters from the query unless they were overridden in the options
+    this.serverPage = options.serverPage || params.p || 0;
+    this.pageSize = options.pageSize || params.ps || 12;
+    this.term = options.term || params.q || '';
+    this.sortBySelected = options.sortBySelected || params.sortBy || '';
+    // all parameters not specified above are assumed to be filters
+    this.filters = _.omit(params, ['q', 'p', 'ps', 'sortBy', 'providerQ']);
+
+    this.processTerm(this.term);
 
     // if not using a passed in URL, update the default provider if it changes
     this.listenTo(app.localSettings, 'change:searchProvider', (model, provider) => {
@@ -59,20 +67,25 @@ export default class extends baseVw {
     };
   }
 
-  get filterQuery() {
-    // return all currently active filters in the form of a query string
-    return this.$filters && this.$filters.length ? `&${this.$filters.serialize()}` : '';
+  get usingDefault() {
+    return this.sProvider === app.localSettings.get('searchProvider');
   }
 
+  /**
+   * This will create a url with the term and other query parameters
+   * @param {string} term
+   */
   processTerm(term) {
     this.term = term || '';
     // if term is false, search for *
     const query = `q=${encodeURIComponent(term || '*')}`;
     const page = `&p=${this.serverPage}&ps=${this.pageSize}`;
     const sortBy = this.sortBySelected ? `&sortBy=${encodeURIComponent(this.sortBySelected)}` : '';
-    const searchURL = `${this.sProvider}?${query}${sortBy}${this.filterQuery}${page}`;
+    let filters = $.param(this.filters);
+    filters = filters ? `&${filters}` : '';
+    const newURL = `${this.sProvider}?${query}${sortBy}${page}${filters}`;
 
-    this.callSearchProvider(searchURL);
+    this.callSearchProvider(newURL);
   }
 
   callSearchProvider(searchURL) {
@@ -174,7 +187,9 @@ export default class extends baseVw {
     this.processTerm(this.term);
   }
 
-  changeFilter() {
+  changeFilter(e) {
+    const targ = $(e.target);
+    this.filters[targ.prop('name')] = targ.val();
     this.processTerm(this.term);
   }
 
@@ -183,7 +198,6 @@ export default class extends baseVw {
   }
 
   useDefault() {
-    this.usingDefault = true;
     this.sProvider = app.localSettings.get('searchProvider');
     this.processTerm(this.term);
   }
@@ -214,6 +228,7 @@ export default class extends baseVw {
         provider: this.sProvider,
         defaultProvider: app.localSettings.get('searchProvider'),
         sortBySelected: this.sortBySelected,
+        filterVals: this.filters,
         emptyData,
         loading,
         ...data,

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -3,7 +3,6 @@ import baseVw from '../baseVw';
 import loadTemplate from '../../utils/loadTemplate';
 import app from '../../app';
 import $ from 'jquery';
-import is from 'is_js';
 import Dialog from '../modals/Dialog';
 import Results from './Results';
 import ResultsCol from '../../collections/Results';


### PR DESCRIPTION
- clean up initialization code
- apply the filters from the query
- set the filters on render from the query filters and/or user actions, so bad data from the server can't override it. If no filter value is present, the value in the results is used.

This closes #573 