### PR TITLE
More tweaks

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1,8 +1,15 @@
 {
-  "unpublishedConfirmTitle": "Unpublished Content",
-  "unpublishedConfirmBody": "You have unpublished content. If you close now your latest data will not be viewable by others. Are you sure you want to close?",
-  "unpublishedConfirmYes": "Yes",
-  "unpublishedConfirmNo": "No",
+  "publish": {
+    "unpublishedConfirmTitle": "Unpublished Content",
+    "unpublishedConfirmBody": "You have unpublished content. If you close now your latest data will not be viewable by others. Are you sure you want to close?",
+    "unpublishedConfirmYes": "Yes",
+    "unpublishedConfirmNo": "No",
+    "failedRetryTitle": "There was an error retrying the publish.",
+    "statusPublishing": "Publishing updates to network…",
+    "retryLink": "Retry",
+    "statusPublishFailed": "Publishing failed. %{retryLink}",
+    "statusPublishComplete": "Publishing complete."
+  },
   "restartNow": "Restart Now",
   "restartLater": "Restart Later",
   "langChangeRestartTitle": "Restart needed for language change",

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -658,8 +658,8 @@ export default class extends BaseVw {
 
     if (this.disputeAcceptance) this.disputeAcceptance.remove();
     this.disputeAcceptance = this.createChild(DisputeAcceptance, {
-      dataObject: data,
       initialState: {
+        timestamp: data.timestamp,
         acceptedByBuyer: closer.id === this.buyer.id,
         buyerViewing: app.profile.id === this.buyer.id,
       },

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -194,8 +194,13 @@ export default class extends BaseVw {
         }
       });
 
-      this.listenTo(this.contract, 'change:disputeAcceptance',
-        () => this.renderDisputeAcceptanceView());
+      this.listenTo(this.contract, 'change:disputeAcceptance', () => {
+        this.renderDisputeAcceptanceView();
+
+        if (this.disputePayout) {
+          this.disputePayout.setState({ showAcceptButton: false });
+        }
+      });
     } else {
       this.listenTo(orderEvents, 'resolveDisputeComplete', e => {
         if (e.id === this.model.id) {
@@ -610,8 +615,6 @@ export default class extends BaseVw {
       throw new Error('Unable to create the Dispute Payout view because the resolution ' +
         'data object has not been set.');
     }
-
-    console.log(`the state is ${this.model.get('state')}`);
 
     if (this.disputePayout) this.disputePayout.remove();
     this.disputePayout = this.createChild(DisputePayout, {

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -235,6 +235,9 @@ export default class extends BaseVw {
       'disputeUpdate',
       // Notification to the vendor and buyer when a mod has made a decision on an open dispute.
       'disputeClose',
+      // Notification the other party will receive when a dispute payout is accepted (e.g. if vendor
+      // accepts, the buyer will get this and vice versa).
+      'disputeAccepted',
     ];
 
     if (serverSocket) {
@@ -607,6 +610,8 @@ export default class extends BaseVw {
       throw new Error('Unable to create the Dispute Payout view because the resolution ' +
         'data object has not been set.');
     }
+
+    console.log(`the state is ${this.model.get('state')}`);
 
     if (this.disputePayout) this.disputePayout.remove();
     this.disputePayout = this.createChild(DisputePayout, {


### PR DESCRIPTION
- The order detail overlay ties into the 'disputeAccepted' socket, so the UI could update if the other party accepts a payout.
- Incorporated the Publish api into the status message when a publish fails. Previously it had a Retry link that just kicked off a dummy alert.
- Wired in some translations to the Publishing related status messages.