### PR TITLE
Listing fixes

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -290,7 +290,7 @@ export default class ObRouter extends Router {
     const onWillRoute = () => {
       // The app has been routed to a new route, let's
       // clean up by aborting all fetches
-      profileFetch.abort();
+      if (profileFetch.abort) profileFetch.abort();
       if (listingFetch) listingFetch.abort();
     };
 
@@ -335,9 +335,11 @@ export default class ObRouter extends Router {
           listing,
         }).render()
       );
-    }).fail(() => {
-      if (profileFetch.statusText === 'abort' ||
-        profileFetch.statusText === 'abort') return;
+    }).fail(...failArgs => {
+      const jqXhr = failArgs[0];
+
+      if (jqXhr === profileFetch && profileFetch.statusText === 'abort') return;
+      if (jqXhr === listingFetch && listingFetch.statusText === 'abort') return;
 
       // todo: If really not found (404), route to
       // not found page, otherwise display error.

--- a/js/router.js
+++ b/js/router.js
@@ -335,7 +335,7 @@ export default class ObRouter extends Router {
           listing,
         }).render()
       );
-    }).fail(...failArgs => {
+    }).fail((...failArgs) => {
       const jqXhr = failArgs[0];
 
       if (jqXhr === profileFetch && profileFetch.statusText === 'abort') return;

--- a/js/templates/userPage/store.html
+++ b/js/templates/userPage/store.html
@@ -13,9 +13,9 @@
   </div>
 </div>
 <% if (ob.isFetching) { %>
-  <div class="txCtr padLg contentBox clrBr clrP"><h1 class="txCtr">Loading...</h1></div>
+  <div class="txCtr padHg contentBox clrBr clrP"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
 <% } else if (ob.fetchFailed) { %>
-  <div class="txCtr padLg contentBox clrBr clrP">
+  <div class="txCtr padHg contentBox clrBr clrP">
     <h3><%= ob.polyT('userPage.store.unableToFetchListings') %></h3>
     <p><%= ob.fetchFailReason %></p>
     <%= ob.processingButton({

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -159,6 +159,7 @@ export default class extends baseVw {
           app.loadingModal.close();
         })
         .fail((xhr) => {
+          if (xhr.statusText === 'abort') return;
           app.router.listingError(xhr, this.model.get('slug'), `#${this.ownerGuid}/store`);
         });
 

--- a/js/views/userPage/Store.js
+++ b/js/views/userPage/Store.js
@@ -177,6 +177,9 @@ export default class extends BaseVw {
             this.retryPressed = false;
             this.render();
           }, 250 - callTime);
+        } else {
+          this.retryPressed = false;
+          this.render();
         }
       } else {
         this.retryPressed = false;
@@ -554,7 +557,8 @@ export default class extends BaseVw {
         ...this.model.toJSON(),
         isFetching,
         fetchFailed,
-        fetchFailReason: this.fetchFailed && this.fetch.responseText || '',
+        fetchFailReason: fetchFailed && this.fetch.responseJSON
+          && this.fetch.responseJSON.reason || '',
         filter: this.filter,
         countryList: this.countryList,
         shipsToSelected: this.filter.shipsTo || 'any',
@@ -579,7 +583,6 @@ export default class extends BaseVw {
 
     this.$shipsToSelect.select2({
       dropdownParent: this.$('.js-shipsToSelectDropdownContainer'),
-      // dropdownPosition : 'below',
     });
 
     if (!this.rendered) {


### PR DESCRIPTION
- Fixes issue where if you navigate away from a listing fetch that subsequently fails, the listing error page appears merged with the page you're on.
- Swapped 'loading...' text on the store with a spinner.
- Fixed bug where if the listings fetch fails, the store always shows a spinner and never gets to the error state.