### PR TITLE
Move Company in Purchase Address

### DIFF
--- a/js/models/purchase/Order.js
+++ b/js/models/purchase/Order.js
@@ -34,12 +34,9 @@ export default class extends BaseModel {
 
   addAddress(sAddr) {
     // this will convert and set an address from the settings
-    const shipTo = sAddr.get('name');
-    const addressArray = [];
-    if (sAddr.get('company')) addressArray.push(sAddr.get('company'));
-    if (sAddr.get('addressLineOne')) addressArray.push(sAddr.get('addressLineOne'));
-    if (sAddr.get('addressLineTwo')) addressArray.push(sAddr.get('addressLineTwo'));
-    const address = addressArray.join(', ');
+    const company = sAddr.get('company');
+    const shipTo = `${sAddr.get('name')}${company ? `, ${company}` : ''}`;
+    const address = `${sAddr.get('addressLineOne')} ${sAddr.get('addressLineTwo')}`;
     const city = sAddr.get('city');
     const state = sAddr.get('state');
     const postalCode = sAddr.get('postalCode');

--- a/js/models/purchase/Order.js
+++ b/js/models/purchase/Order.js
@@ -35,8 +35,11 @@ export default class extends BaseModel {
   addAddress(sAddr) {
     // this will convert and set an address from the settings
     const shipTo = sAddr.get('name');
-    const address =
-      `${sAddr.get('addressLineOne')} ${sAddr.get('addressLineTwo')} ${sAddr.get('company')}`;
+    const addressArray = [];
+    if (sAddr.get('company')) addressArray.push(sAddr.get('company'));
+    if (sAddr.get('addressLineOne')) addressArray.push(sAddr.get('addressLineOne'));
+    if (sAddr.get('addressLineTwo')) addressArray.push(sAddr.get('addressLineTwo'));
+    const address = addressArray.join(', ');
     const city = sAddr.get('city');
     const state = sAddr.get('state');
     const postalCode = sAddr.get('postalCode');

--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -50,7 +50,7 @@
           <% if (ob.order.shipping && ob.order.shipping.country !== 'NA') { %>
             <div><%= ob.order.shipping.shipTo %></div>
             <% if (ob.order.shipping.address) { %>
-            <div><%= ob.order.shipping.address %></div>
+            <div><%= ob.order.shipping.address.replace(/, /g, ',<br>') %></div>
             <% } %>
             <% if (addressLine3) { %>
             <div><%= addressLine3 %></div>
@@ -66,7 +66,7 @@
               if (addressLine3) clipboardAddress.push(addressLine3);
               if (addressLine4) clipboardAddress.push(addressLine4);
               clipboardAddress = clipboardAddress.join('\n');
-            %>  
+            %>
             <div class="gutterH">
               <a class="js-copyAddress clrTEm" data-address="<%= clipboardAddress %>"><%= ob.polyT('orderDetail.summaryTab.orderDetails.copyAddress') %></a>
               <a class="clrTEm" href="<%= mapUrl %>"><%= ob.polyT('orderDetail.summaryTab.orderDetails.viewOnMap') %></a>
@@ -85,7 +85,7 @@
                   <div><%= item.couponCodes.join(', ') %></div>
                 <% } else { %>
                   <div><%= ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
-                <% } %>              
+                <% } %>
               </div>
               <div class="col6">
                 <div class="txB rowTn"><%= ob.polyT('orderDetail.summaryTab.orderDetails.quantityHeading') %></div>
@@ -105,7 +105,7 @@
                 <div class="txB rowTn"><%= ob.polyT('orderDetail.summaryTab.orderDetails.totalHeading') %></div>
                 <div><%= priceText %></div>
               </div>
-            </div>            
+            </div>
           </div>
         </div>
       </div>

--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -50,7 +50,7 @@
           <% if (ob.order.shipping && ob.order.shipping.country !== 'NA') { %>
             <div><%= ob.order.shipping.shipTo %></div>
             <% if (ob.order.shipping.address) { %>
-            <div><%= ob.order.shipping.address.replace(/, /g, ',<br>') %></div>
+            <div><%= ob.order.shipping.address %></div>
             <% } %>
             <% if (addressLine3) { %>
             <div><%= addressLine3 %></div>

--- a/js/templates/modals/purchase/shipping.html
+++ b/js/templates/modals/purchase/shipping.html
@@ -9,16 +9,18 @@
   <select id="shippingAddress">
     <% ob.userAddresses.forEach((a, i) => { %>
     <option value="<%= i %>">
-      <% let part1 = `${a.name}`;
-         part1 += a.company ? `, ${a.company},` : '';
-         part1 += a.addressLineOne ? ` ${a.addressLineOne}` : '';
-         let part2 = a.addressLineTwo ? ` ${a.addressLineTwo}` : '';
-         part2 += a.city ? ` ${a.city}` : '';
-         let part3 = a.state || a.postalCode ? ',' : '';
-         part3 += a.state ? ` ${a.state}` : '';
-         part3 += a.postalCode ? ` ${a.postalCode}` : '';
+      <% const addr = [];
+         addr.push(a.name);
+         if (a.company) addr.push(a.company);
+         if (a.addressLineOne) addr.push(a.addressLineOne);
+         if (a.addressLineTwo) addr.push(a.addressLineTwo);
+         if (a.city) addr.push(a.city);
+         const state = a.state || '';
+         const code = a.postalCode || '';
+         const stateCode = `${state ? `${state} ` : ''}${code}`;
+         if (stateCode) addr.push(stateCode);
+         print(addr.join(', '));
       %>
-      <%= `${part1}${part2}${part3}` %>
     </option>
     <% }); %>
   </select>

--- a/js/templates/modals/purchase/shipping.html
+++ b/js/templates/modals/purchase/shipping.html
@@ -10,9 +10,9 @@
     <% ob.userAddresses.forEach((a, i) => { %>
     <option value="<%= i %>">
       <% let part1 = `${a.name}`;
+         part1 += a.company ? `, ${a.company},` : '';
          part1 += a.addressLineOne ? ` ${a.addressLineOne}` : '';
          let part2 = a.addressLineTwo ? ` ${a.addressLineTwo}` : '';
-         part2 += a.company ? `, ${a.company},` : '';
          part2 += a.city ? ` ${a.city}` : '';
          let part3 = a.state || a.postalCode ? ',' : '';
          part3 += a.state ? ` ${a.state}` : '';


### PR DESCRIPTION
This PR moves the company to before the address in 2 places:
1. the drop down in the purchase view
2. the order model

It also add a line break between each piece of the address in the order details template, to make the address format the expected way.