### PR TITLE
Clean up emojis

### DIFF
--- a/js/templates/modals/moderatorDetails.html
+++ b/js/templates/modals/moderatorDetails.html
@@ -4,7 +4,9 @@
     <div class="contentBox mDetailBox padMd clrP clrBr clrSh3 tx5">
       <div class="flex gutterH row">
         <div>
-          <a class="userIcon disc clrBr2 clrSh1" style="<%= ob.getAvatarBgImage(ob.avatarHashes) %>"></a>
+          <a class="userIcon disc clrBr2 clrSh1"
+             style="<%= ob.getAvatarBgImage(ob.avatarHashes) %>"
+             href="#<%= ob.peerID %>"></a>
         </div>
         <div>
           <div class="flex snipKids gutterHSm rowSm">
@@ -31,14 +33,14 @@
     <div class="contentBox mDetailBox flexRow flexVCent gutterH padMd clrP clrBr clrSh3">
       <div class="flexExpand">
         <div class="flexCol flexCent">
-          <div>📍 <%= ob.location || ob.polyT('userPage.noLocation') %></div>
+          <div><%= ob.parseEmojis('📍') %> <%= ob.location || ob.polyT('userPage.noLocation') %></div>
           <div class="tx5b clrT2"><%= ob.polyT('moderatorDetails.location') %></div>
         </div>
       </div>
-      <div class="rowDivV clrBr"></div>
-      <div class="flexExpand">
+      <div class="rowDivV clrBr TODO"></div>
+      <div class="flexExpand TODO">
         <div class="flexCol flexCent">
-          👍 XX<% // placeholder for reputation %>
+          <%= ob.parseEmojis('👍') %> XX<% // placeholder for reputation %>
           <div class="tx5b clrT2"><%= ob.polyT('moderatorDetails.recommendations') %></div>
         </div>
       </div>

--- a/js/templates/userCard.html
+++ b/js/templates/userCard.html
@@ -50,7 +50,7 @@
       </div>
       <div class="flex gutterH contentBottom">
         <div class="flexExpand">
-          <span class="clrT2 clamp tx5b">📍 <%= ob.location || ob.polyT('userPage.noLocation') %></span>
+          <span class="clrT2 clamp tx5b"><%= ob.parseEmojis('📍') %> <%= ob.location || ob.polyT('userPage.noLocation') %></span>
         </div>
         <div class="tx6">
           <% print(`${ob.formatRating(ob.stats.averageRating, ob.stats.ratingCount)}`) %>


### PR DESCRIPTION
Cleans up a few templates, based off of #665, when that is merged this will be very small.

- emojifies some icons in the moderator detail and usercard templates
- hides the non-functional reputation in the moderator detail template
- makes the user icon link work in the moderator detail template