### PR TITLE
Apply the same changes to the connected peers page.

### DIFF
--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -5,7 +5,9 @@
       <div class="tx4 border clrBr clrP pad"><%= ob.polyT('connectedPeersPage.totalPeers', { totalPeers: ob.peers.length }) %></div>
     </div>
   </div>
-  <div class="userPageFollow flexRow js-peerWrapper"></div>
+  <div class="userPageFollow">
+    <div class="userCardsContainer flexRow js-peerWrapper"></div>
+  </div>
 
   <div class="js-morePeers hide">
     <hr class="clrBr">


### PR DESCRIPTION
Just a tweak so the connected peers page gets the same changes as the follow tabs. Otherwise the layout breaks.