### PR TITLE
Misc fixes

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1004,7 +1004,7 @@
     "pay": "PAY >",
     "payNote": "Clicking pay will advance you to the final step.",
     "pending": "Pending…",
-    "pendingNote": "Plese fund the order to complete your transaction.",
+    "pendingNote": "Please fund the order to complete your transaction.",
     "close": "close",
     "closeNote": "Your payment has been sent to the vendor.",
     "moderatorNote": "*The moderator service fee is only applied if a dispute is opened.",

--- a/js/templates/modals/editListing/editListing.html
+++ b/js/templates/modals/editListing/editListing.html
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="flexExpand posR tabContent">
-    <div class="gutterVMd js-formSectionsContainer">
+    <div class="gutterVMd2 js-formSectionsContainer">
       <section class="js-scrollToSection contentBox padMd clrP clrBr clrSh3">
         <div class="flexHCent">
           <h2 class="h3 clrT js-listingHeading"><% print(ob.createMode ? ob.polyT('editListing.createListingLabel') : ob.polyT('editListing.editListingLabel')) %></h2>
@@ -224,7 +224,7 @@
         <hr class="clrBr rowMd">
         <% if (ob.errors['item.skus']) print(ob.formErrorTmpl({ errors: ob.errors['item.skus'] })) %>
         <div class="js-variantInventoryTableContainer"></div>
-      </section>      
+      </section>
 
       <section class="js-scrollToSection contentBox padMd clrP clrBr clrSh3 tx3">
         <h2 class="h4 clrT"><%= ob.polyT('editListing.sectionNames.returnPolicy') %></h2>

--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -33,7 +33,7 @@
 </div>
 
 
-<div class="listingContent flexColRow gutterVMd">
+<div class="listingContent flexColRow gutterVMd2">
   <div class="contentBox padLg clrP clrBr clrSh3">
     <div class="flex">
       <h2 class="txUnb flexExpand"><%= ob.item.title %></h2>

--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -62,7 +62,7 @@
             <% ob.item.options.forEach((item) => { %>
               <div class="flexVCent gutterHLg">
                 <div class="col4 h5 txUnl"><%= item.name %></div>
-                <div class="col8">
+                <div class="col8 txLft">
                   <select class="js-variantSelect" name="<%= item.name %>">
                     <% item.variants.forEach((variant) => { %>
                       <option value="<%= variant.name %>"><%= variant.name %></option>

--- a/js/templates/modals/orderDetail/summaryTab/accepted.html
+++ b/js/templates/modals/orderDetail/summaryTab/accepted.html
@@ -8,7 +8,7 @@
     <div class="avatarCol disc clrBr2 clrSh1 flexNoShrink" style="<%= ob.getAvatarBgImage(ob.avatarHashes) %>"></span></div>
     <div class="flexExpand tx5">
       <div class="rowTn txB"><%= ob.polyT('orderDetail.summaryTab.accepted.orderAccepted') %></div>
-      <div class="flex gutterH"><%= ob.infoText %></div>
+      <div><%= ob.infoText %></div>
     </div>
     <div class="col">
       <div class="flexVCent gutterHLg">

--- a/js/templates/modals/orderDetail/summaryTab/disputeAcceptance.html
+++ b/js/templates/modals/orderDetail/summaryTab/disputeAcceptance.html
@@ -25,7 +25,7 @@
           ob.polyT('orderDetail.summaryTab.disputeAcceptance.orderCompleteWhenBuyerReviews');
       %>
       <div class="rowTn txB"><%= introLine %></div>
-      <div class="flex gutterH"><%= subText %></div>
+      <div><%= subText %></div>
     </div>
   </div>
 </div>

--- a/js/templates/modals/orderDetail/summaryTab/disputePayout.html
+++ b/js/templates/modals/orderDetail/summaryTab/disputePayout.html
@@ -1,6 +1,6 @@
 <%
   let priceLines = {};
-  let partyHeadings = {};  
+  let partyHeadings = {};
 
   ['buyer', 'vendor', 'moderator'].forEach(type => {
     priceLines[type] = ob.convertAndFormatCurrency(ob.payout[`${type}Output`].amount,
@@ -30,21 +30,21 @@
         <div class="avatarCol disc clrBr2 clrSh1 flexNoShrink" style="<%= ob.getAvatarBgImage(ob.buyerAvatarHashes) %>"></div>
         <div class="flexExpand tx5">
           <div class="rowTn txB"><%= partyHeadings.buyer %></div>
-          <div class="flex gutterH"><%= priceLines.buyer %></div>
+          <div><%= priceLines.buyer %></div>
         </div>
       </div>
       <div class="flex gutterH clrT">
         <div class="avatarCol disc clrBr2 clrSh1 flexNoShrink" style="<%= ob.getAvatarBgImage(ob.vendorAvatarHashes) %>"></span></div>
         <div class="flexExpand tx5">
           <div class="rowTn txB"><%= partyHeadings.vendor %></div>
-          <div class="flex gutterH"><%= priceLines.vendor %></div>
+          <div><%= priceLines.vendor %></div>
         </div>
       </div>
       <div class="flex gutterH clrT">
         <div class="avatarCol disc clrBr2 clrSh1 flexNoShrink" style="<%= ob.getAvatarBgImage(ob.moderatorAvatarHashes) %>"></span></div>
         <div class="flexExpand tx5">
           <div class="rowTn txB"><%= partyHeadings.moderator %></div>
-          <div class="flex gutterH"><%= priceLines.moderator %></div>
+          <div><%= priceLines.moderator %></div>
         </div>
       </div>
     </div>
@@ -80,7 +80,7 @@
           ob.polyT('orderDetail.summaryTab.disputePayout.noteFromHeading');
       %>
       <div class="rowTn"><%= noteFromHeading %></div>
-      <div class="flex gutterH"><%= ob.resolution %></div>
+      <div><%= ob.resolution %></div>
     </div>
   </div>
 </div>

--- a/js/templates/modals/orderDetail/summaryTab/disputeStarted.html
+++ b/js/templates/modals/orderDetail/summaryTab/disputeStarted.html
@@ -13,7 +13,7 @@
           ob.polyT('orderDetail.summaryTab.disputeStarted.genericIsDisputed');
       %>
       <div class="rowTn txB"><%= introLine %></div>
-      <div class="flex gutterH"><%= ob.claim || ob.polyT('orderDetail.summaryTab.disputeStarted.noReasonProvided') %></div>
+      <div><%= ob.claim || ob.polyT('orderDetail.summaryTab.disputeStarted.noReasonProvided') %></div>
     </div>
     <div class="col">
       <% if (ob.showResolveButton) { %>
@@ -21,7 +21,7 @@
           className: `btn clrBAttGrad clrBrDec1 clrTOnEmph tx5b js-resolveDispute`,
           btnText: ob.polyT('orderDetail.summaryTab.disputeStarted.resolveBtn')
         }) %>
-      <% } %>  
+      <% } %>
     </div>
   </div>
 </div>

--- a/js/templates/modals/purchase/coupons.html
+++ b/js/templates/modals/purchase/coupons.html
@@ -6,7 +6,7 @@
   </div>
 <% } %>
 <% ob.couponCodes.forEach(code => { %>
-  <div class="txSm rowTn flex">
+  <div class="txSm rowTn flexVCent gutterH">
     <span class="clrTEm"><%= ob.polyT('purchase.code', { code }) %></span>
     <button class="btnTxtOnly js-remove" data-code="<%= code %>">
       <%= ob.polyT('purchase.removeCode') %>

--- a/js/templates/modals/settings/advanced.html
+++ b/js/templates/modals/settings/advanced.html
@@ -1,4 +1,4 @@
-<div class="gutterVMd">
+<div class="gutterVMd2">
   <div class="contentBox padMd clrP clrBr clrSh3">
     <div class="flexHCent">
       <h2 class="h3 clrT"><%= ob.polyT('settings.advancedTab.sectionName') %></h2>

--- a/js/templates/modals/settings/moderation.html
+++ b/js/templates/modals/settings/moderation.html
@@ -1,4 +1,4 @@
-<div class="gutterVMd">
+<div class="gutterVMd2">
   <div class="contentBox padMd clrP clrBr clrSh3">
     <div class="flexHCent">
       <h2 class="h3 clrT">Moderation</h2>

--- a/js/templates/modals/settings/page.html
+++ b/js/templates/modals/settings/page.html
@@ -1,4 +1,4 @@
-<div class="gutterVMd">
+<div class="gutterVMd2">
   <div class="contentBox padMd clrP clrBr clrSh3">
     <div class="flexHCent">
       <h2 class="h3 clrT"><%= ob.polyT('settings.pageTab.sectionPage') %></h2>

--- a/js/templates/modals/settings/store.html
+++ b/js/templates/modals/settings/store.html
@@ -1,4 +1,4 @@
-<div class="gutterVMd">
+<div class="gutterVMd2">
   <div class="contentBox padMd clrP clrBr clrSh3">
     <div class="flexHCent">
       <h2 class="h3 clrT"><%= ob.polyT('settings.storeTab.sectionName') %></h2>

--- a/js/templates/pageNav.html
+++ b/js/templates/pageNav.html
@@ -46,7 +46,7 @@
       <div>
         <div class="flexVCent box margLSm posR">
           <a href="#search" class="toolTipNoWrap js-discover" data-tip="<%= ob.polyT('pageNav.toolTip.discover') %>">
-            <div class="discoverButton navBtn" style="background-image: url('../imgs/obVectorIconSmall.svg')"></div>
+            <div class="discoverBtn navBtn" style="background-image: url('../imgs/obVectorIconSmall.svg')"></div>
           </a>
           <% if (ob.showDiscoverCallout) { %>
             <div class="discoverCallout js-discoverCallout arrowBoxTop confirmBox clrP clrBr">

--- a/js/templates/userPage/home.html
+++ b/js/templates/userPage/home.html
@@ -1,5 +1,5 @@
 <div class="flexRow gutterH">
-  <div class="col4 gutterVMd">
+  <div class="col4 gutterVMd2">
     <div class="userCard js-userCard">
     </div>
     <% if(ob.moderator && ob.modInfo) { %>

--- a/js/views/modals/purchase/Moderators.js
+++ b/js/views/modals/purchase/Moderators.js
@@ -59,7 +59,8 @@ export default class extends baseVw {
   getModeratorsByID(IDs = this.options.moderatorIDs) {
     const op = this.options;
     const includeString = op.include ? `&include=${op.include}` : '';
-    const urlString = `ob/${op.apiPath}?async=${op.async}${includeString}&usecache=${op.useCache}`;
+    const urlString =
+      `ob/${op.apiPath}?async=${!!op.async}${includeString}&usecache=${!!op.useCache}`;
     const url = app.getServerUrl(urlString);
 
     this.notFetchedYet = IDs;

--- a/styles/components/_layout.scss
+++ b/styles/components/_layout.scss
@@ -455,6 +455,11 @@
   margin-bottom: $padMd;
 }
 
+.gutterVMd2 > * {
+  @extend .gutterVFlush;
+  margin-bottom: $padMd2;
+}
+
 .gutterVLg > * {
   @extend .gutterVFlush;
   margin-bottom: $padLg;

--- a/styles/modules/_pageNav.scss
+++ b/styles/modules/_pageNav.scss
@@ -42,7 +42,7 @@
       }
     }
 
-    .discoverButton {
+    .discoverBtn {
       background-repeat: no-repeat;
       background-size: 100% 100%;
     }
@@ -91,9 +91,13 @@
   }
 
   &.notNavigable {
+    a,
+    button,
+    .btn,
     .iconBtn,
     .addressBar,
     .navListBtn,
+    .discoverBtn,
     .searchWrapper::after {
       @include disabled;
     }
@@ -262,7 +266,7 @@
     width: 420px;
     right: 40px;
     padding: 0 $pad $pad;
-  }  
+  }
 
   .navListWrapper {
     z-index: 2;


### PR DESCRIPTION
Adds space between coupon applied text and remove link.
Closes #669 

Make everything in the pageNav bar disabled when not navigable
Closes #663

Take unneeded flex gutterH classes off of divs that only have text in them in the order details summary, so they don't overflow their containers.
Closes #661

If usecache or async in the options is undefined, make it false
Closes #647

Add left align to variants on listing details. 
Closes #640

Change modal gutters to 12px. 
Closes #518

