### PR TITLE
Update address validation for bech32

### DIFF
--- a/js/utils/index.js
+++ b/js/utils/index.js
@@ -7,6 +7,7 @@ import app from '../app';
 import multihashes from 'multihashes';
 import bitcoreLib from 'bitcore-lib';
 import twemoji from 'twemoji';
+import bech32 from 'bech32';
 
 export function getGuid(handle, resolver) {
   const deferred = $.Deferred();
@@ -142,7 +143,12 @@ export function isValidBitcoinAddress(address) {
     bitcoreLib.encoding.Base58Check.decode(address);
     return true;
   } catch (exc) {
-    return false;
+    try {
+        bech32.decode(address);
+        return true;
+    } catch(exc) {
+        return false;
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "underscore": "^1.8.3",
     "url-parse": "^1.1.7",
     "velocity-animate": "^1.2.3",
-    "yargs": "^6.6.0"
+    "yargs": "^6.6.0",
+    "bech32": "^0.0.3"
   }
 }


### PR DESCRIPTION
Check bech32 address encoding in addition to base58 when validating bitcoin
addresses.