### PR TITLE
Prevent Rounding Error in Receipt

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1059,11 +1059,12 @@
     },
     "receipt": {
       "summary": "Order Summary",
-      "listing": "Listing (%{quantity})",
+      "listing": "Listing",
       "coupon": "Coupon",
       "shipping": "Shipping",
       "options": "Options",
-      "total": "Total"
+      "subtotal": "Subtotal",
+      "total": "Total (%{quantity})"
     },
     "errors": {
       "moderatorsTitle": "Moderator Data Failted to Load",

--- a/js/templates/modals/purchase/coupons.html
+++ b/js/templates/modals/purchase/coupons.html
@@ -6,7 +6,7 @@
   </div>
 <% } %>
 <% ob.couponCodes.forEach(code => { %>
-  <div class="txSm rowTn flex">
+  <div class="txSm rowTn flexVCent gutterH">
     <span class="clrTEm"><%= ob.polyT('purchase.code', { code }) %></span>
     <button class="btnTxtOnly js-remove" data-code="<%= code %>">
       <%= ob.polyT('purchase.removeCode') %>

--- a/js/templates/modals/purchase/receipt.html
+++ b/js/templates/modals/purchase/receipt.html
@@ -7,7 +7,7 @@
     const shippingPrice = ob.prices[i].sPrice;
     const surcharge = ob.prices[i].vPrice;
     const quantity = Number.isInteger(item.quantity) ? item.quantity : 1;
-    let itemTotal = basePrice;
+    let itemTotal = basePrice + surcharge;
     ob.coupons.forEach((coupon) => {
       if (coupon.percentDiscount) {
         itemTotal -= itemTotal * 0.01 * coupon.percentDiscount;
@@ -15,7 +15,7 @@
         itemTotal -= coupon.priceDiscount;
       }
     });
-    itemTotal = itemTotal + shippingPrice + surcharge;
+    itemTotal += shippingPrice;
     total += itemTotal * quantity;
     // don't allow coupons to make the total negative
     total = total > 0 ? total : 0;
@@ -28,6 +28,16 @@
       <%= ob.convertAndFormatCurrency(basePrice * quantity, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
     </b>
   </div>
+  <% if (ob.listing.item.options && ob.listing.item.options.length) { %>
+  <div class="flexRow">
+          <span class="flexExpand">
+            <%= ob.polyT('purchase.receipt.options') %>
+          </span>
+    <b class="flexNoShrink">
+      <%= ob.convertAndFormatCurrency(surcharge * quantity, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
+    </b>
+  </div>
+  <% } %>
   <% ob.coupons.forEach((coupon) => { %>
     <div class="flexRow">
       <span class="flexExpand">
@@ -42,16 +52,7 @@
       </b>
     </div>
   <% }); %>
-  <% if (ob.listing.item.options && ob.listing.item.options.length) { %>
-  <div class="flexRow">
-        <span class="flexExpand">
-          <%= ob.polyT('purchase.receipt.options') %>
-        </span>
-    <b class="flexNoShrink">
-      <%= ob.convertAndFormatCurrency(surcharge * quantity, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
-    </b>
-  </div>
-  <% } %>
+
   <% if (ob.listing.shippingOptions && ob.listing.shippingOptions.length) { %>
     <div class="flexRow">
       <span class="flexExpand">

--- a/js/templates/modals/purchase/receipt.html
+++ b/js/templates/modals/purchase/receipt.html
@@ -1,31 +1,30 @@
 <hr class="clrBr">
 <b><%= ob.polyT('purchase.receipt.summary') %></b>
 <%
-  let total = 0;
+  const listingCurrency = ob.listing.metadata.pricingCurrency;
+  const viewingCurrency = ob.displayCurrency;
   ob.items.forEach((item, i) => {
-    const basePrice = ob.prices[i].price;
-    const shippingPrice = ob.prices[i].sPrice;
-    const surcharge = ob.prices[i].vPrice;
+    // convert and truncate the prices here, to prevent rounding errors in the display
+    const basePrice = Number(ob.convertCurrency(ob.prices[i].price, listingCurrency, viewingCurrency).toFixed(2));
+    const shippingPrice = Number(ob.convertCurrency(ob.prices[i].sPrice, listingCurrency, viewingCurrency).toFixed(2));
+    const surcharge = Number(ob.convertCurrency(ob.prices[i].vPrice, listingCurrency, viewingCurrency).toFixed(2));
     const quantity = Number.isInteger(item.quantity) ? item.quantity : 1;
     let itemTotal = basePrice + surcharge;
+    const preCouponPrice = itemTotal;
     ob.coupons.forEach((coupon) => {
       if (coupon.percentDiscount) {
         itemTotal -= itemTotal * 0.01 * coupon.percentDiscount;
       } else if (coupon.priceDiscount) {
-        itemTotal -= coupon.priceDiscount;
+        itemTotal -= ob.convertCurrency(coupon.priceDiscount, listingCurrency, viewingCurrency).toFixed(2);
       }
     });
-    itemTotal += shippingPrice;
-    total += itemTotal * quantity;
-    // don't allow coupons to make the total negative
-    total = total > 0 ? total : 0;
 %>
   <div class="flexRow">
     <span class="flexExpand">
-      <%= ob.polyT('purchase.receipt.listing', { quantity }) %>
+      <%= ob.polyT('purchase.receipt.listing') %>
     </span>
     <b class="flexNoShrink">
-      <%= ob.convertAndFormatCurrency(basePrice * quantity, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
+      <%= ob.formatCurrency(basePrice, viewingCurrency) %>
     </b>
   </div>
   <% if (ob.listing.item.options && ob.listing.item.options.length) { %>
@@ -34,7 +33,7 @@
             <%= ob.polyT('purchase.receipt.options') %>
           </span>
     <b class="flexNoShrink">
-      <%= ob.convertAndFormatCurrency(surcharge * quantity, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
+      <%= ob.formatCurrency(surcharge, viewingCurrency) %>
     </b>
   </div>
   <% } %>
@@ -45,9 +44,9 @@
       </span>
       <b class="flexNoShrink">
         <% if (coupon.percentDiscount) {
-             print(`-${coupon.percentDiscount}%`);
+             print(`-${coupon.percentDiscount}% (-${preCouponPrice * 0.01 * coupon.percentDiscount})`);
         } else if (coupon.priceDiscount) {
-          print(`-${ob.convertAndFormatCurrency(Number(coupon.priceDiscount * quantity), ob.listing.metadata.pricingCurrency, ob.displayCurrency)}`);
+          print(`-${ob.convertAndFormatCurrency(Number(coupon.priceDiscount), listingCurrency, viewingCurrency)}`);
         } %>
       </b>
     </div>
@@ -59,17 +58,27 @@
         <%= ob.polyT('purchase.receipt.shipping') %>
       </span>
       <b class="flexNoShrink">
-        <%= ob.convertAndFormatCurrency(shippingPrice * quantity, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
+        <%= ob.formatCurrency(shippingPrice, viewingCurrency) %>
       </b>
     </div>
   <% } %>
+  <hr class="clrBr">
+  <% if (quantity > 1) { %>
+    <div class="flexRow">
+      <span class="flexExpand">
+        <%= ob.polyT('purchase.receipt.subtotal') %>
+      </span>
+      <b class="flexNoShrink">
+        <%= ob.formatCurrency(itemTotal, viewingCurrency) %>
+      </b>
+    </div>
+  <% } %>
+  <div class="flexRow">
+    <span class="flexExpand">
+      <%= ob.polyT('purchase.receipt.total', { quantity }) %>
+    </span>
+    <b class="flexNoShrink">
+      <%= ob.formatCurrency(total, viewingCurrency) %>
+    </b>
+  </div>
 <% }); %>
-<hr class="clrBr">
-<div class="flexRow">
-  <span class="flexExpand">
-    <%= ob.polyT('purchase.receipt.total') %>
-  </span>
-  <b class="flexNoShrink">
-    <%= ob.convertAndFormatCurrency(total, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
-  </b>
-</div>

--- a/js/templates/modals/purchase/receipt.html
+++ b/js/templates/modals/purchase/receipt.html
@@ -27,19 +27,9 @@
       <%= ob.polyT('purchase.receipt.listing') %>
     </span>
     <b class="flexNoShrink">
-      <%= ob.formatCurrency(basePrice, viewingCurrency) %>
+      <%= ob.formatCurrency(preCouponPrice, viewingCurrency) %>
     </b>
   </div>
-  <% if (ob.listing.item.options && ob.listing.item.options.length) { %>
-  <div class="flexRow">
-          <span class="flexExpand">
-            <%= ob.polyT('purchase.receipt.options') %>
-          </span>
-    <b class="flexNoShrink">
-      <%= ob.formatCurrency(surcharge, viewingCurrency) %>
-    </b>
-  </div>
-  <% } %>
   <% ob.coupons.forEach((coupon) => { %>
     <div class="flexRow">
       <span class="flexExpand">
@@ -47,7 +37,7 @@
       </span>
       <b class="flexNoShrink">
         <% if (coupon.percentDiscount) {
-             print(`-${coupon.percentDiscount}% (-${preCouponPrice * 0.01 * coupon.percentDiscount})`);
+             print(`-${coupon.percentDiscount}%`);
         } else if (coupon.priceDiscount) {
           print(`-${ob.convertAndFormatCurrency(Number(coupon.priceDiscount), listingCurrency, viewingCurrency)}`);
         } %>

--- a/js/templates/modals/purchase/receipt.html
+++ b/js/templates/modals/purchase/receipt.html
@@ -3,11 +3,12 @@
 <%
   const listingCurrency = ob.listing.metadata.pricingCurrency;
   const viewingCurrency = ob.displayCurrency;
+  const isBTC = viewingCurrency === 'BTC';
   ob.items.forEach((item, i) => {
     // convert and truncate the prices here, to prevent rounding errors in the display
-    const basePrice = Number(ob.convertCurrency(ob.prices[i].price, listingCurrency, viewingCurrency).toFixed(2));
-    const shippingPrice = Number(ob.convertCurrency(ob.prices[i].sPrice, listingCurrency, viewingCurrency).toFixed(2));
-    const surcharge = Number(ob.convertCurrency(ob.prices[i].vPrice, listingCurrency, viewingCurrency).toFixed(2));
+    const basePrice = Number(ob.formatPrice(ob.convertCurrency(ob.prices[i].price, listingCurrency, viewingCurrency), isBTC));
+    const shippingPrice = Number(ob.formatPrice(ob.convertCurrency(ob.prices[i].sPrice, listingCurrency, viewingCurrency), isBTC));
+    const surcharge = Number(ob.formatPrice(ob.convertCurrency(ob.prices[i].vPrice, listingCurrency, viewingCurrency), isBTC));
     const quantity = Number.isInteger(item.quantity) ? item.quantity : 1;
     let itemTotal = basePrice + surcharge;
     const preCouponPrice = itemTotal;
@@ -15,9 +16,11 @@
       if (coupon.percentDiscount) {
         itemTotal -= itemTotal * 0.01 * coupon.percentDiscount;
       } else if (coupon.priceDiscount) {
-        itemTotal -= ob.convertCurrency(coupon.priceDiscount, listingCurrency, viewingCurrency).toFixed(2);
+        itemTotal -= Number(ob.formatPrice(ob.convertCurrency(coupon.priceDiscount, listingCurrency, viewingCurrency), isBTC));
       }
     });
+    itemTotal = itemTotal + shippingPrice;
+    const total = itemTotal * quantity;
 %>
   <div class="flexRow">
     <span class="flexExpand">

--- a/js/utils/templateHelpers.js
+++ b/js/utils/templateHelpers.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import app from '../app';
-import { formatCurrency, convertAndFormatCurrency, convertCurrency } from './currency';
+import { formatCurrency, convertAndFormatCurrency, convertCurrency, formatPrice } from './currency';
 import {
   isHiRez, isLargeWidth, isSmallHeight, getAvatarBgImage, getListingBgImage,
 } from './responsive';
@@ -51,6 +51,7 @@ export function formatRating(average, count) {
 export const getServerUrl = app.getServerUrl.bind(app);
 
 export {
+  formatPrice,
   formatCurrency,
   convertAndFormatCurrency,
   convertCurrency,

--- a/js/utils/templateHelpers.js
+++ b/js/utils/templateHelpers.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import app from '../app';
-import { formatCurrency, convertAndFormatCurrency } from './currency';
+import { formatCurrency, convertAndFormatCurrency, convertCurrency } from './currency';
 import {
   isHiRez, isLargeWidth, isSmallHeight, getAvatarBgImage, getListingBgImage,
 } from './responsive';
@@ -53,6 +53,7 @@ export const getServerUrl = app.getServerUrl.bind(app);
 export {
   formatCurrency,
   convertAndFormatCurrency,
+  convertCurrency,
   isHiRez,
   isLargeWidth,
   isSmallHeight,

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -473,15 +473,18 @@ export default class extends BaseModal {
 
       this.moderators.delegateEvents();
       this.$('.js-moderatorsWrapper').append(this.moderators.render().el);
+      this.moderators.getModeratorsByID();
 
       if (this.shipping) {
         this.shipping.delegateEvents();
         this.$('.js-shippingWrapper').append(this.shipping.render().el);
       }
 
-      // remove old view if any on render
-      if (this.payment) this.payment.remove();
-      // pending view will be added once the purchase goes through
+      // if this is a re-render, and the payment exists, render it
+      if (this.payment) {
+        this.payment.delegateEvents();
+        this.$('.js-pending').append(this.payment.render().el);
+      }
 
       this.complete.delegateEvents();
       this.$('.js-complete').append(this.complete.render().el);

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -68,6 +68,53 @@ export default class extends BaseModal {
     // create an empty purchase model
     this.purchase = new Purchase();
 
+    this.actionBtn = this.createChild(ActionBtn, {
+      state: this.state,
+      listing: this.listing,
+    });
+    this.listenTo(this.actionBtn, 'purchase', (() => this.purchaseListing()));
+    this.listenTo(this.actionBtn, 'close', (() => this.close()));
+
+    this.receipt = this.createChild(Receipt, {
+      model: this.order,
+      listing: this.listing,
+      prices: this.prices,
+    });
+
+    this.coupons = this.createChild(Coupons, {
+      coupons: this.listing.get('coupons'),
+      listingPrice: this.listing.get('item').get('price'),
+    });
+    this.listenTo(this.coupons, 'changeCoupons',
+      (hashes, codes) => this.changeCoupons(hashes, codes));
+
+    this.moderators = this.createChild(Moderators, {
+      moderatorIDs: this.moderatorIDs,
+      fetchErrorTitle: app.polyglot.t('purchase.errors.moderatorsTitle'),
+      fetchErrorMsg: app.polyglot.t('purchase.errors.moderatorsMsg'),
+      purchase: true,
+      cardState: 'unselected',
+      notSelected: 'unselected',
+      singleSelect: true,
+      selectFirst: true,
+      radioStyle: true,
+    });
+    this.listenTo(this.moderators, 'noValidModerators', () => this.onNoValidModerators());
+
+    if (this.listing.get('shippingOptions').length) {
+      this.shipping = this.createChild(Shipping, {
+        model: this.listing,
+      });
+      this.listenTo(this.shipping, 'shippingOptionSelected', ((opts) => {
+        this.updateShippingOption(opts);
+      }));
+    }
+
+    this.complete = this.createChild(Complete, {
+      listing: this.listing,
+      vendor: this.vendor,
+    });
+
     this.listenTo(app.settings, 'change:localCurrency', () => this.showDataChangedMessage());
     this.listenTo(app.localSettings, 'change:bitcoinUnit', () => this.showDataChangedMessage());
   }
@@ -415,56 +462,20 @@ export default class extends BaseModal {
 
       this.$purchaseModerated = this.$('#purchaseModerated');
 
-      if (this.actionBtn) this.actionBtn.remove();
-      this.actionBtn = this.createChild(ActionBtn, {
-        state: this.state,
-        listing: this.listing,
-      });
-      this.listenTo(this.actionBtn, 'purchase', (() => this.purchaseListing()));
-      this.listenTo(this.actionBtn, 'close', (() => this.close()));
+      this.actionBtn.delegateEvents();
       this.$('.js-actionBtn').append(this.actionBtn.render().el);
 
-      if (this.receipt) this.receipt.remove();
-      this.receipt = this.createChild(Receipt, {
-        model: this.order,
-        listing: this.listing,
-        prices: this.prices,
-      });
+      this.receipt.delegateEvents();
       this.$('.js-receipt').append(this.receipt.render().el);
 
-      if (this.coupons) this.coupons.remove();
-      this.coupons = this.createChild(Coupons, {
-        coupons: this.listing.get('coupons'),
-        listingPrice: this.listing.get('item').get('price'),
-      });
-      this.listenTo(this.coupons, 'changeCoupons',
-        (hashes, codes) => this.changeCoupons(hashes, codes));
+      this.coupons.delegateEvents();
       this.$('.js-couponsWrapper').html(this.coupons.render().el);
 
-      if (this.moderators) this.moderators.remove();
-      this.moderators = this.createChild(Moderators, {
-        moderatorIDs: this.moderatorIDs,
-        fetchErrorTitle: app.polyglot.t('purchase.errors.moderatorsTitle'),
-        fetchErrorMsg: app.polyglot.t('purchase.errors.moderatorsMsg'),
-        purchase: true,
-        cardState: 'unselected',
-        notSelected: 'unselected',
-        singleSelect: true,
-        selectFirst: true,
-        radioStyle: true,
-      });
-      this.listenTo(this.moderators, 'noValidModerators', () => this.onNoValidModerators());
+      this.moderators.delegateEvents();
       this.$('.js-moderatorsWrapper').append(this.moderators.render().el);
-      this.moderators.getModeratorsByID();
 
-      if (this.listing.get('shippingOptions').length) {
-        if (this.shipping) this.shipping.remove();
-        this.shipping = this.createChild(Shipping, {
-          model: this.listing,
-        });
-        this.listenTo(this.shipping, 'shippingOptionSelected', ((opts) => {
-          this.updateShippingOption(opts);
-        }));
+      if (this.shipping) {
+        this.shipping.delegateEvents();
         this.$('.js-shippingWrapper').append(this.shipping.render().el);
       }
 
@@ -472,13 +483,7 @@ export default class extends BaseModal {
       if (this.payment) this.payment.remove();
       // pending view will be added once the purchase goes through
 
-      // remove old view if any on render
-      if (this.complete) this.complete.remove();
-      // add the complete view
-      this.complete = this.createChild(Complete, {
-        listing: this.listing,
-        vendor: this.vendor,
-      });
+      this.complete.delegateEvents();
       this.$('.js-complete').append(this.complete.render().el);
     });
 


### PR DESCRIPTION
When fiat prices are converted to BTC, then converted to a different fiat price, it can result in a rounding error of 0.01 in the displayed total vs. the individual prices of the listing, options, coupons and shipping. This PR fixes that with the following changes:
- show the listing price as the listing price plus the surcharge from the options chosen
- don't show the option prices
- subtract coupons before adding the shipping price
- convert and round all prices to 2 decimal places before doing any calculations
- if the quantity is more than 1, show a subtotal with the price for 1 listing after calculations
- show the total with quantity for the multiple of the subtotal by the quantity

This PR also refactors the purchases view to move the creation of child views out of the render function, so refreshes are handled correctly.

Closes #660