### PR TITLE
various minor tweaks to the auto update status messages

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -20,7 +20,7 @@
   "langChangeRestartTitle": "Restart needed for language change",
   "langChangeRestartMessage": "In order for your language change to fully take effect, you must restart the app. If any saves or publishes are still in progress, please wait until they are done.",
   "update": {
-    "checking": "Checking for updates.",
+    "checking": "Checking for updates…",
     "error": "There was an error checking for updates. Error: %{error}",
     "available": "An update is downloading now. You can choose to install it when the download is complete.",
     "notAvailable": "No updates are available.",

--- a/js/start.js
+++ b/js/start.js
@@ -627,9 +627,9 @@ ipcRenderer.on('show-server-log', () => launchDebugLogModal());
 
 // Handle update events from main.js
 ipcRenderer.on('updateChecking', () =>
-  showUpdateStatus(app.polyglot.t('update.checking'), 'pending'));
+  showUpdateStatus(app.polyglot.t('update.checking')));
 ipcRenderer.on('updateAvailable', () =>
-  showUpdateStatus(app.polyglot.t('update.available'), 'pending'));
+  showUpdateStatus(app.polyglot.t('update.available')));
 ipcRenderer.on('updateNotAvailable', () =>
   showUpdateStatus(app.polyglot.t('update.notAvailable')));
 ipcRenderer.on('updateError', (e, msg) =>

--- a/js/templates/statusMessage.html
+++ b/js/templates/statusMessage.html
@@ -3,8 +3,6 @@
     <span class="icon ion-alert-circled"></span>
   <% } else if (ob.type === 'confirmed') { %>
     <span class="icon ion-ios-checkmark-empty"></span>
-  <% } else if (ob.type === 'pending') { %>
-  <span class="icon ion-more"></span>
   <% } %>
   <%= ob.msg %>
 </div>

--- a/js/utils/autoUpdate.js
+++ b/js/utils/autoUpdate.js
@@ -16,7 +16,10 @@ export function showUpdateStatus(status = '', type = 'message') {
       duration: 9999999999,
     });
   } else {
-    statusMsg.update(status);
+    statusMsg.update({
+      msg: status,
+      type,
+    });
   }
 
   // updates may arrive multiple times, manually remove the message when no new message


### PR DESCRIPTION
This PR:

- fixes issue where the type on update status events was not being updated unless you explicitly passed in a type (e.g. the "notAvailable" status message would show a pending status)
- eliminates the `pending` status from the status bar message since the icon looked really odd. Adjusted the auto update 'checking' status message to have a trailing ellipse, which is how we handle similar pending messages across the site (e.g. 'Saving settings...', 'Publishing to the network...', etc...)