### PR TITLE
adjusting the sequence of where the processing state in the payment m…

### DIFF
--- a/js/views/modals/purchase/Payment.js
+++ b/js/views/modals/purchase/Payment.js
@@ -51,6 +51,8 @@ export default class extends BaseVw {
           if (e.jsonData.notification.orderId === this.orderId) {
             const amount = integerToDecimal(e.jsonData.notification.fundingTotal, true);
             if (amount >= this.balanceRemaining) {
+              this.$confirmWalletConfirm.removeClass('processing');
+              this.$confirmWallet.addClass('hide');
               this.trigger('walletPaymentComplete', e.jsonData.notification);
             } else {
               // Ensure the resulting balance has a maximum of 8 decimal places with not
@@ -115,8 +117,6 @@ export default class extends BaseVw {
       .fail(jqXhr => {
         openSimpleMessage(app.polyglot.t('purchase.errors.paymentFailed'),
           jqXhr.responseJSON && jqXhr.responseJSON.reason || '');
-      })
-      .always(() => {
         if (this.isRemoved()) return;
         this.$confirmWalletConfirm.removeClass('processing');
         this.$confirmWallet.addClass('hide');


### PR DESCRIPTION
…odule is updated

closes #619 

@jjeffryes The only way I could think of this bug happening is that we were removing the spinner once the spend Xhr completed, but the module doesn't consider the payment to be complete (and fire off the 'walletPaymentComplete' event) until a payment socket is received with the funds. My best guess is that socket was delayed for whatever reason (maybe it's dependent on the blockchain or some blockchain related api and those are known to have latency quirks).

So... I updated it so the 'processing' state on the 'Yes, Pay' button won't clear until we have confirmed payment or the Spend call fails. 