### PR TITLE
handling the payment finalized state in the order summary tab

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1172,7 +1172,8 @@
         "REFUNDED": "Refunded",
         "DISPUTED": "Disputed",
         "DECIDED": "Decided",
-        "RESOLVED": "Resolved"
+        "RESOLVED": "Resolved",
+        "PAYMENT_FINALIZED": "Payment Finalized"
       },
       "btnReject": "Reject",
       "btnAccept": "Accept",
@@ -1214,6 +1215,7 @@
       "orderNumber": "Order #: %{orderId}",
       "copyLink": "Copy",
       "notApplicable": "n/a",
+      "vendorFinalizedPayment": "You have manually finalized the order.",
       "payment": {
         "firstPaymentHeading": "Payment Details",
         "paymentHeading": "Payment Details #%{paymentNumber}",

--- a/js/templates/modals/orderDetail/summaryTab/summary.html
+++ b/js/templates/modals/orderDetail/summaryTab/summary.html
@@ -8,6 +8,7 @@
 </div>
 <hr class="clrBr rowLg" />
 <div class="js-statusProgressBarContainer statusProgressBarContainer"></div>
+<p class="js-paymentFinalizedMsg clrTErr hide" style="margin-top: 10px"><span class="ion-alert-circled padSm"></span><%= ob.polyT('orderDetail.summaryTab.vendorFinalizedPayment') %></p>
 <hr class="clrBr rowLg" />
 
 <div class="js-subSections"></div>

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -85,6 +85,10 @@ export default class extends BaseVw {
         this.completeOrderForm.remove();
         this.completeOrderForm = null;
       }
+
+      if (['PAYMENT_FINALIZED', 'COMPLETE'].indexOf(state) !== -1) {
+        this.renderPaymentFinalized();
+      }
     });
 
     if (!this.isCase()) {
@@ -303,7 +307,8 @@ export default class extends BaseVw {
 
     if (orderState === 'DISPUTED' || orderState === 'DECIDED' ||
       orderState === 'RESOLVED' ||
-      (orderState === 'COMPLETED' && this.model.get('dispute') !== undefined)) {
+      (orderState === 'COMPLETED' && this.contract.get('dispute') !== undefined) ||
+      (orderState === 'PAYMENT_FINALIZED' && this.contract.get('dispute') !== undefined)) {
       if (!this.isCase()) {
         state.states = [
           app.polyglot.t('orderDetail.summaryTab.orderDetails.progressBarStates.disputed'),
@@ -323,6 +328,10 @@ export default class extends BaseVw {
             break;
           case 'COMPLETE':
             state.currentState = 4;
+            state.disputeState = 0;
+            break;
+          case 'PAYMENT_FINALIZED':
+            state.currentState = 1;
             state.disputeState = 0;
             break;
           default:
@@ -367,6 +376,9 @@ export default class extends BaseVw {
           break;
         case 'COMPLETED':
           state.currentState = 4;
+          break;
+        case 'PAYMENT_FINALIZED':
+          state.currentState = 1;
           break;
         default:
           state.currentState = 0;
@@ -764,6 +776,11 @@ export default class extends BaseVw {
       });
   }
 
+  renderPaymentFinalized() {
+    this.getCachedEl('.js-paymentFinalizedMsg')
+      .toggleClass('hide', this.model.get('state') !== 'PAYMENT_FINALIZED');
+  }
+
   get $subSections() {
     return this._$subSections ||
       (this._$subSections = this.$('.js-subSections'));
@@ -789,6 +806,8 @@ export default class extends BaseVw {
         initialState: this.progressBarState,
       });
       this.$('.js-statusProgressBarContainer').html(this.stateProgressBar.render().el);
+
+      this.renderPaymentFinalized();
 
       if (this.orderDetails) this.orderDetails.remove();
       this.orderDetails = this.createChild(OrderDetails, {


### PR DESCRIPTION
To test, add the following line before the return in parse() of the Order model:
`response.state = 'PAYMENT_FINALIZED';`

If an order is in the finalized state, the following message will be added below the progress bar:

![image](https://user-images.githubusercontent.com/794517/29848479-c1a5c23a-8cd5-11e7-9789-89965c585586.png)

The message is geared towards the vendor because the server will only ever update the vendor's order with that state.

When in this state, the progress bar will default to the first position, even though it's possible the order progressed beyond that position. It would take a bit of work to determine what state they had been in before the finalized state and since we're minimally addressing the finalized state at this point, we'll defer on the progress bar being completely accurate.