### PR TITLE
Order patch

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1362,7 +1362,7 @@
         "copyAddress": "Copy",
         "viewOnMap": "View on map",
         "memo": "Memo",
-        "addressNotes": "Notes:",
+        "addressNotes": "Delivery Notes",
         "alternateContact": "Additional Contact Information"
       }
     },

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1360,7 +1360,8 @@
         "totalHeading": "Total",
         "moderatorHeading": "Moderator",
         "copyAddress": "Copy",
-        "viewOnMap": "View on map"
+        "viewOnMap": "View on map",
+        "alternateContact": "Additional Contact Information"
       }
     },
     "fulfillOrderTab": {

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1038,7 +1038,7 @@
     "noAddresses": "You don't have any saved addresses.",
     "noShippableAddresses": "This listing does not ship to your selected address.",
     "informationTitle": "Additional Information",
-    "emailAddress": "Email Address",
+    "emailAddress": "Email Address or Phone Number",
     "emailPlaceholder": "name@email.com",
     "emailNote": "An alternate way to reach you.",
     "couponCode": "Coupon Code",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -598,7 +598,7 @@
       "state": "State/Province/Region",
       "country": "Country",
       "postalCode": "Postal Code",
-      "notes": "Address Notes"
+      "notes": "Delivery Notes"
     },
     "statusSaving": "Saving settings…",
     "statusSaveFailed": "Settings failed to save.",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1362,6 +1362,7 @@
         "copyAddress": "Copy",
         "viewOnMap": "View on map",
         "memo": "Memo",
+        "addressNotes": "Notes:",
         "alternateContact": "Additional Contact Information"
       }
     },

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1361,6 +1361,7 @@
         "moderatorHeading": "Moderator",
         "copyAddress": "Copy",
         "viewOnMap": "View on map",
+        "memo": "Memo",
         "alternateContact": "Additional Contact Information"
       }
     },

--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -74,7 +74,7 @@
                   <b><%= ob.polyT('orderDetail.summaryTab.orderDetails.addressNotes') %></b>
                 </div>
                 <div>
-                  <i><%= ob.order.shipping.addressNotes %></i>
+                  <%= ob.order.shipping.addressNotes %>
                 </div>
               </div>
             <% } %>

--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -113,7 +113,7 @@
       <div class="flexRow gutterH">
         <div class="col6">
           <div class="gutterVTn">
-            <div class="txB">Memo</div>
+            <div class="txB"><%= ob.polyT('orderDetail.summaryTab.orderDetails.memo') %></div>
             <div><%= item.memo ? ob.parseEmojis(item.memo) : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
           </div>
         </div>
@@ -121,7 +121,7 @@
           <div>
             <div class="gutterVTn">
               <div class="txB"><%= ob.polyT('orderDetail.summaryTab.orderDetails.alternateContact') %></div>
-              <div><%= ob.order.alternateContactInfo %></div>
+              <div><%= ob.order.alternateContactInfo ? ob.order.alternateContactInfo : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
             </div>
           </div>
         </div>

--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -50,14 +50,17 @@
           <% if (ob.order.shipping && ob.order.shipping.country !== 'NA') { %>
             <div><%= ob.order.shipping.shipTo %></div>
             <% if (ob.order.shipping.address) { %>
-            <div><%= ob.order.shipping.address %></div>
+              <div><%= ob.order.shipping.address %></div>
             <% } %>
             <% if (addressLine3) { %>
-            <div><%= addressLine3 %></div>
+              <div><%= addressLine3 %></div>
             <% } %>
-            <div><%= addressLine4 %></div>
+              <div><%= addressLine4 %></div>
             <% if (ob.order.shipping.addressNotes) { %>
-            <div><%= ob.order.shipping.addressNotes %></div>
+              <div><%= ob.order.shipping.addressNotes %></div>
+            <% } %>
+            <% if (ob.order.alternateContactInfo) { %>
+              <div><%= ob.order.alternateContactInfo %></div>
             <% } %>
             <%
               let clipboardAddress = [ob.order.shipping.shipTo];
@@ -65,6 +68,7 @@
               if (ob.order.shipping.address) clipboardAddress.push(ob.order.shipping.address);
               if (addressLine3) clipboardAddress.push(addressLine3);
               if (addressLine4) clipboardAddress.push(addressLine4);
+              if (ob.order.alternateContactInfo) clipboardAddress.push(ob.order.alternateContactInfo);
               clipboardAddress = clipboardAddress.join('\n');
             %>
             <div class="gutterH">

--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -59,16 +59,12 @@
             <% if (ob.order.shipping.addressNotes) { %>
               <div><%= ob.order.shipping.addressNotes %></div>
             <% } %>
-            <% if (ob.order.alternateContactInfo) { %>
-              <div><%= ob.order.alternateContactInfo %></div>
-            <% } %>
             <%
               let clipboardAddress = [ob.order.shipping.shipTo];
 
               if (ob.order.shipping.address) clipboardAddress.push(ob.order.shipping.address);
               if (addressLine3) clipboardAddress.push(addressLine3);
               if (addressLine4) clipboardAddress.push(addressLine4);
-              if (ob.order.alternateContactInfo) clipboardAddress.push(ob.order.alternateContactInfo);
               clipboardAddress = clipboardAddress.join('\n');
             %>
             <div class="gutterH">
@@ -114,10 +110,23 @@
         </div>
       </div>
       <hr class="clrBr" />
-      <div class="gutterVTn">
-        <div class="txB">Memo</div>
-        <div><%= item.memo ? ob.parseEmojis(item.memo) : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
+      <div class="flexRow gutterH">
+        <div class="col6">
+          <div class="gutterVTn">
+            <div class="txB">Memo</div>
+            <div><%= item.memo ? ob.parseEmojis(item.memo) : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>
+          </div>
+        </div>
+        <div class="col6">
+          <div>
+            <div class="gutterVTn">
+              <div class="txB"><%= ob.polyT('orderDetail.summaryTab.orderDetails.alternateContact') %></div>
+              <div><%= ob.order.alternateContactInfo %></div>
+            </div>
+          </div>
+        </div>
       </div>
+
     </div>
   </div>
 </div>

--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -56,9 +56,6 @@
               <div><%= addressLine3 %></div>
             <% } %>
               <div><%= addressLine4 %></div>
-            <% if (ob.order.shipping.addressNotes) { %>
-              <div><%= ob.order.shipping.addressNotes %></div>
-            <% } %>
             <%
               let clipboardAddress = [ob.order.shipping.shipTo];
 
@@ -71,10 +68,20 @@
               <a class="js-copyAddress clrTEm" data-address="<%= clipboardAddress %>"><%= ob.polyT('orderDetail.summaryTab.orderDetails.copyAddress') %></a>
               <a class="clrTEm" href="<%= mapUrl %>"><%= ob.polyT('orderDetail.summaryTab.orderDetails.viewOnMap') %></a>
             </div>
-            <% } else { %>
-              <%= ob.polyT('orderDetail.summaryTab.notApplicable') %>
+            <% if (ob.order.shipping.addressNotes) { %>
+              <div class="addressNotes gutterVTn">
+                <div>
+                  <b><%= ob.polyT('orderDetail.summaryTab.orderDetails.addressNotes') %></b>
+                </div>
+                <div>
+                  <i><%= ob.order.shipping.addressNotes %></i>
+                </div>
+              </div>
             <% } %>
-            <span class="clrT2 hide orderDetailsCopiedToClipboard js-orderDetailsCopiedToClipboard"><%= ob.polyT('copiedToClipboard') %></span>
+          <% } else { %>
+            <%= ob.polyT('orderDetail.summaryTab.notApplicable') %>
+          <% } %>
+          <span class="clrT2 hide orderDetailsCopiedToClipboard js-orderDetailsCopiedToClipboard"><%= ob.polyT('copiedToClipboard') %></span>
         </div>
         <div class="col8">
           <div class="row">

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -231,8 +231,7 @@ export default class extends BaseModal {
   }
 
   blurMemo(e) {
-    //this.order.set('memo', $(e.target).val());
-    this.order.get('items')[0].set('memo', $(e.target).val());
+    this.order.get('items').at(0).set('memo', $(e.target).val());
   }
 
   changeCoupons(hashes, codes) {

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -231,7 +231,8 @@ export default class extends BaseModal {
   }
 
   blurMemo(e) {
-    this.order.set('memo', $(e.target).val());
+    //this.order.set('memo', $(e.target).val());
+    this.order.get('items')[0].set('memo', $(e.target).val());
   }
 
   changeCoupons(hashes, codes) {

--- a/styles/modules/modals/_orderDetail.scss
+++ b/styles/modules/modals/_orderDetail.scss
@@ -247,6 +247,10 @@
       }
     }
 
+    .addressNotes {
+      margin-top: $pad;
+    }
+
     .statusIconCol {
       text-align: center;
       flex-shrink: 0;


### PR DESCRIPTION
This fixes some issues with order data.
- the memo is correctly saved when purchasing an item.
- the alternate contact data is shown in the order details.
- the Email field in the purchase is updated to "Email Address or Phone Number", since this is not an email field, the field is for any alternate contact method.

Closes #728 
Closes #659 
Closes #658 

![image](https://user-images.githubusercontent.com/1584275/29998536-9f1182e4-8ffb-11e7-9c74-f6879fcad153.png)

![image](https://user-images.githubusercontent.com/1584275/30004866-8be205be-90a4-11e7-9ad3-026c928e17a5.png)

