### PR TITLE
Remove Old Network Parameter

### DIFF
--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -77,7 +77,7 @@ export default class extends baseVw {
     this.term = options.term || params.q || '';
     this.sortBySelected = options.sortBySelected || params.sortBy || '';
     // all parameters not specified above are assumed to be filters
-    this.filters = _.omit(params, ['q', 'p', 'ps', 'sortBy', 'providerQ']);
+    this.filters = _.omit(params, ['q', 'p', 'ps', 'sortBy', 'providerQ', 'network']);
 
     this.processTerm(this.term);
   }


### PR DESCRIPTION
If the user pastes in a search url with a network parameter, or they switch from mainnet to testnet (or vice versa), the network parameter will be removed from the filters and replaced with the one appropriate to the network the user is currently using.