### PR TITLE
Don't show moderators that have the wrong currency

### DIFF
--- a/js/collections/Moderators.js
+++ b/js/collections/Moderators.js
@@ -61,8 +61,11 @@ export default class extends Collection {
         // don't add excluded ids or your own id
         const notExcluded = excludeList.indexOf(mod.id) === -1 && mod.id !== app.profile.id;
         // don't add if not a mod or the mod data is missing
+        // don't add if the currency doesn't match the network
+        const cur = !!app.serverConfig.testnet ? 'tBTC' : 'BTC';
+        const validCur = mod.get('moderatorInfo').get('acceptedCurrencies').indexOf(cur) > -1;
         if (!mod.isModerator) this.trigger('invalidMod', { id: mod.id });
-        return mod.isModerator && notExcluded;
+        return mod.isModerator && notExcluded && validCur;
       });
     }
     return super.add(filteredModels, options);

--- a/js/collections/Moderators.js
+++ b/js/collections/Moderators.js
@@ -62,7 +62,7 @@ export default class extends Collection {
         const notExcluded = excludeList.indexOf(mod.id) === -1 && mod.id !== app.profile.id;
         // don't add if not a mod or the mod data is missing
         // don't add if the currency doesn't match the network
-        const cur = !!app.serverConfig.testnet ? 'tBTC' : 'BTC';
+        const cur = app.serverConfig.cryptoCurrency;
         const validCur = mod.get('moderatorInfo').get('acceptedCurrencies').indexOf(cur) > -1;
         if (!mod.isModerator) this.trigger('invalidMod', { id: mod.id });
         return mod.isModerator && notExcluded && validCur;

--- a/js/views/modals/purchase/Moderators.js
+++ b/js/views/modals/purchase/Moderators.js
@@ -98,7 +98,16 @@ export default class extends baseVw {
                     // don't add profiles that are not moderators. The ID list may have peerIDs
                     // that are out of date, and are no longer moderators.
                     if (eventData.profile.moderator && eventData.profile.moderatorInfo) {
-                      this.moderatorsCol.add(eventData.profile);
+                      // if the moderator has an invalid currency, remove them from the list
+                      const buyerCur = !!app.serverConfig.testnet ? 'tBTC' : 'BTC';
+                      const modCurs = eventData.profile.moderatorInfo.acceptedCurrencies;
+                      const validCur = modCurs.indexOf(buyerCur) > -1;
+                      if (validCur) {
+                        this.moderatorsCol.add(eventData.profile);
+                      } else {
+                        // remove the invalid moderator from the notFetched list
+                        this.removeNotFetched(eventData.peerId);
+                      }
                     } else {
                       // remove the invalid moderator from the notFetched list
                       this.removeNotFetched(eventData.peerId);

--- a/js/views/modals/purchase/Moderators.js
+++ b/js/views/modals/purchase/Moderators.js
@@ -99,7 +99,7 @@ export default class extends baseVw {
                     // that are out of date, and are no longer moderators.
                     if (eventData.profile.moderator && eventData.profile.moderatorInfo) {
                       // if the moderator has an invalid currency, remove them from the list
-                      const buyerCur = !!app.serverConfig.testnet ? 'tBTC' : 'BTC';
+                      const buyerCur = app.serverConfig.cryptoCurrency;
                       const modCurs = eventData.profile.moderatorInfo.acceptedCurrencies;
                       const validCur = modCurs.indexOf(buyerCur) > -1;
                       if (validCur) {


### PR DESCRIPTION
This will check the currency accepted by a mod, and not show moderators that use the wrong currency (BTC vs. tBTC) for the network (mainnet vs. testnet).