### PR TITLE
Update electron to 1.7.5 [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai": "^3.5.0",
     "copyfiles": "^1.0.0",
     "cross-env": "^1.0.8",
-    "electron": "^1.4.15",
+    "electron": "^1.7.5",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-config-defaults": "^9.0.0",


### PR DESCRIPTION
Note: do not merge until this is thoroughly tested on all OSes.

- [ ] Tested on Win32
- [ ] Tested on Win64
- [ ] Tested on Mac
- [ ] Tested on Linux

This update is not considered required for beta or launch,  but it would be nice to get it in when we can.