### PR TITLE
Update Duo's search endpoint

### DIFF
--- a/js/data/defaultSearchProviders.js
+++ b/js/data/defaultSearchProviders.js
@@ -11,12 +11,12 @@ const defaultSearchProviders = [
   },
   {
     id: 'duo',
-    name: 'Duo Search',
+    name: 'Duo',
     logo: '../imgs/duoSearchLogo.png',
-    search: 'http://demo.duosear.ch/search',
-    listings: 'http://demo.duosear.ch/search/listings',
-    torsearch: '',
-    torlistings: '',
+    search: 'https://ob2.duosear.ch/search',
+    listings: 'https://ob2.duosear.ch/search/listings',
+    torsearch: 'https://ob2.duosear.ch/search',
+    torlistings: 'https://ob2.duosear.ch/search/listings',
     locked: true,
   },
 ];


### PR DESCRIPTION
I am not 100% what the plain `/search` endpoint does (as opposed to `/search/listings`). As far as I can tell it is not used. Right now Duo does not return anything for it.