### PR TITLE
No Deselecting Mod Radio Buttons

### DIFF
--- a/js/views/ModeratorCard.js
+++ b/js/views/ModeratorCard.js
@@ -45,7 +45,7 @@ export default class extends BaseVw {
   }
 
   rotateSelectState() {
-    if (this.cardState === 'selected') {
+    if (this.cardState === 'selected' && !this.options.radioStyle) {
       this.changeSelectState(this.notSelected);
     } else {
       this.changeSelectState('selected');


### PR DESCRIPTION
If a moderator card is in radio mode, this prevents the selected card from being de-selected.

Closes #770