### PR TITLE
Patch wallet note

### DIFF
--- a/js/templates/modals/wallet/transaction.html
+++ b/js/templates/modals/wallet/transaction.html
@@ -67,7 +67,10 @@
           <div class="noOverflow"><a class="clrT2 js-txidLink"><%= ob.txid %></a></div>
         </div>
       </div>
-      <div class="clrT2 tx6" style="vertical-align: text-top;"><%= ob.translatedMemo || ob.memo %></div>
+      <%
+        const memo = ob.translatedMemo || ob.memo.length > 300 ? `${ob.memo.slice(0, 300)}…` : ob.memo;
+      %>
+      <div class="clrT2 tx6" style="vertical-align: text-top;"><%= memo %></div>
     </div>
   </div>
   <div class="col">

--- a/js/templates/modals/wallet/transaction.html
+++ b/js/templates/modals/wallet/transaction.html
@@ -60,19 +60,15 @@
         smart_count: ob.confirmations,
       });
     %>
-    <div class="flex gutterH clrT2 tx6">
-      <div class="" style="flex-shrink: 0"><%= timeAgoAndConfirmCount %></div>
-      <div class="" style="flex-shrink: 0;max-width: 80px">
-        <div class="noOverflow"><a class="clrT2 js-txidLink"><%= ob.txid %></a></div>
+    <div>
+      <div class="flexInline gutterH margR clrT2 tx6 floL">
+        <div class="flexNoShrink"><%= timeAgoAndConfirmCount %></div>
+        <div class="flexNoShrink" style="max-width: 80px">
+          <div class="noOverflow"><a class="clrT2 js-txidLink"><%= ob.txid %></a></div>
+        </div>
       </div>
-      <%
-        const memo = ob.translatedMemo || ob.memo.length > 300 ? `${ob.memo.slice(0, 300)}…` : ob.memo;
-      %>
-      <div class="toolTip toolTipTop toolTipCenter memoTip" data-tip="<%= memo %>">
-        <div class="noOverflow"><%= memo %></div>
-      </div>
+      <div class="clrT2 tx6" style="vertical-align: text-top;"><%= ob.translatedMemo || ob.memo %></div>
     </div>
-    
   </div>
   <div class="col">
     <div class="flexHRight">
@@ -93,10 +89,10 @@
   <% if (ob.retryConfirmOn) {
       // if we're fetching we'll just hard code some fee and show the text invisibly
       // so the spacing is still right (i.e. no jump when spinner goes away)
-      let estimatedFee = ob.fetchingEstimatedFee ? .0004 : ob.estimatedFee; 
+      let estimatedFee = ob.fetchingEstimatedFee ? .0004 : ob.estimatedFee;
       let estimatedFeeCombo = ob.convertAndFormatCurrency(estimatedFee, 'BTC',
         ob.userCurrency, { useBtcSymbol: false });
-        
+
       if (ob.userCurrency !== 'BTC') {
         estimatedFeeCombo = ob.polyT('fiatBtcPairing', {
           fiatAmount: estimatedFeeCombo,
@@ -117,13 +113,13 @@
         <p class="clrT2 bodyText"><%= ob.polyT('wallet.transactions.transaction.retryPaymentConfirmBox.insufficientFundsBody', {
           fiatBtcPairing: estimatedFeeCombo,
           asterisk: '<span>*</span>',
-        }) %></p>      
+        }) %></p>
       <% } %>
       <p class="clrT2 tx6"><%= ob.polyT('wallet.transactions.transaction.retryPaymentConfirmBox.subText', {
         asterisk: '<span>*</span>',
       }) %></p>
     </div>
-    
+
     <% if (ob.fetchingEstimatedFee) { %>
       <%= ob.spinner({ className: 'center spinnerMd' }) %>
     <% } %>

--- a/styles/components/_containers.scss
+++ b/styles/components/_containers.scss
@@ -374,12 +374,6 @@
       -webkit-clip-path: polygon(0 0, 0 100%, 100% 0);
     }
   }
-
-  &.toolTipCenter {
-    &::before {
-      text-align: center;
-    }
-  }
 }
 
 // Use for single line variable width tooltips. Factor in translations and

--- a/styles/components/_layout.scss
+++ b/styles/components/_layout.scss
@@ -39,6 +39,13 @@
   align-items: stretch; //this stretches the items to 100% height
 }
 
+.flexInline {
+  @extend .flex;
+  // use for inline flex elements
+  display: inline-flex;
+  width: auto;
+}
+
 .snip,
 .snipKids > * {
   //truncate the text in the child elements

--- a/styles/modules/modals/_wallet.scss
+++ b/styles/modules/modals/_wallet.scss
@@ -11,7 +11,7 @@
   .btcTickerContainer {
     margin-left: auto;
     margin-right: 40px;
-    
+
     .btcTicker {
       height: 100%;
     }
@@ -128,7 +128,7 @@
       font-size: $tx5;
 
       .btn {
-        font-size: $tx6;        
+        font-size: $tx6;
       }
 
       .statusIconCol {
@@ -182,12 +182,6 @@
         bottom: 3px;
         left: 5px;
       }
-
-      .memoTip {
-        &::before {
-          width: 200px;
-        }
-      }
     }
 
     .fetchErrorWrap {
@@ -218,5 +212,5 @@
         height: auto;
       }
     }
-  }  
+  }
 }


### PR DESCRIPTION
This is proposing an alternate way to handle the memo in the wallet transactions, it will wrap the memo if it is too long.

While that can make some memos larger than others, I think that is more visually appealing than having tooltips on all of them. 

I'm not sure about truncating, maybe we should still truncate the text above a certain character length? Or just limit the memo length on the client and server.

![image](https://user-images.githubusercontent.com/1584275/30122855-ebbcf948-92fd-11e7-8fad-b2fdf2f53be5.png)
