### PR TITLE
Check if number is higher than -1, not higher than zero.

### DIFF
--- a/js/models/listing/Item.js
+++ b/js/models/listing/Item.js
@@ -77,7 +77,7 @@ export default class extends BaseModel {
     } else {
       // If you don't have any options and have the top level as a non-negative
       // value (i.e. not infiniteInventory), we'll consider you to be tracking inventory
-      isInventoryTracked = this.get('quantity') > 0;
+      isInventoryTracked = this.get('quantity') >= 0;
     }
 
     return isInventoryTracked;


### PR DESCRIPTION
When the inventory dropped to zero, the model was counting that as not being tracked. This fixes the bug by changing > 0 to >=0 (not tracked is -1).