### PR TITLE
Small fixes

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1053,7 +1053,8 @@
     "codeErrors": {
       "invalid": "\"%{code}\" is not a valid code",
       "duplicate": "You can only add \"%{code}\" once",
-      "excessive": "You cannot apply discounts that total 100% or more."
+      "excessive": "You cannot apply discounts that total 100% or more.",
+      "blank": "You must enter a code."
     },
     "removeCode": "remove",
     "memo": "Memo",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -34,6 +34,7 @@
   "addressBarPlaceholder": "Type a @handle, OpenBazaar ID or search term",
   "testnet": "Test Mode",
   "testnetTooltip": "Test Mode uses testnet coins, which are intended for testing purposes only.",
+  "betaTooltip": "OpenBazaar is currently in beta. Make sure to backup your wallet, and be careful if spending large amounts of bitcoin.",
   "tabMenuHeading": "MENU",
   "fiatBtcPairing": "%{fiatAmount} (%{btcAmount})",
   "copiedToClipboard": "Copied to clipboard",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1047,6 +1047,7 @@
     "emailPlaceholder": "name@email.com",
     "emailNote": "An alternate way to reach you.",
     "couponCode": "Coupon Code",
+    "couponCodePlaceholder": "Enter code",
     "applyCode": "Apply",
     "code": "\"%{code}\" applied to order",
     "codeErrors": {

--- a/js/templates/modals/purchase/coupons.html
+++ b/js/templates/modals/purchase/coupons.html
@@ -1,7 +1,11 @@
 <% if (ob.codeResult && ob.codeResult.type && ob.codeResult.type !== 'valid') { %>
   <div class="txSm rowTn flex">
     <span class="clrTErr">
-      <%= ob.polyT(`purchase.codeErrors.${ob.codeResult.type}`, { code: ob.codeResult.code }) %>
+      <% if (ob.codeResult.code) { %>
+        <%= ob.polyT(`purchase.codeErrors.${ob.codeResult.type}`, { code: ob.codeResult.code }) %>
+      <% } else { %>
+        <%= ob.polyT('purchase.codeErrors.blank') %>
+      <% } %>
     </span>
   </div>
 <% } %>

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -131,7 +131,6 @@ const totalPrice = ob.prices[0].price + ob.prices[0].vPrice;
             <div class="rowTn">
               <label for="couponCode" class="tx5">
                 <%= ob.polyT('purchase.couponCode') %>
-                <i class="ion-ios-information-outline js-couponInfo"></i>
               </label>
             </div>
             <div class="flex gutterH row">
@@ -139,7 +138,8 @@ const totalPrice = ob.prices[0].price + ob.prices[0].vPrice;
                   class="btnHeight clrBr clrP"
                   type="text"
                   id="couponCode"
-                  name="couponCode">
+                  name="couponCode"
+                  placeholder="<%= ob.polyT('purchase.couponCodePlaceholder') %>">
               <button class="btn clrP clrBr clrSh2 js-applyCoupon">
                 <%= ob.polyT('purchase.applyCode') %>
               </button>

--- a/js/templates/pageNav.html
+++ b/js/templates/pageNav.html
@@ -37,9 +37,10 @@
           </div>
 
           <div id="testnetFlag" class="btn barBtn normalBtn clrP clrBr" >
-            <span>Beta</span>
             <% if (ob.testnet) { %>
-              <span class="toolTip" data-tip="<%= ob.polyT('testnetTooltip') %>">&nbsp;<%= ob.polyT('testnet') %></span>
+              <span class="toolTip" data-tip="<%= ob.polyT('testnetTooltip') %>">Beta <%= ob.polyT('testnet') %></span>
+            <% } else { %>
+            <span class="toolTip" data-tip="<%= ob.polyT('betaTooltip') %>">Beta</span>
             <% } %>
           </div>
 

--- a/js/templates/userPage/userPage.html
+++ b/js/templates/userPage/userPage.html
@@ -39,8 +39,10 @@
             className: `btn clrP clrBr js-followBtn`,
             btnText: ob.followed ? ob.polyT('userPage.unfollow') : ob.polyT('userPage.follow'),
           }) %>
-          <a class="btn clrP clrBr hide js-moreableBtn TODO"><%= ob.polyT('userPage.block') %></a>
+        <!--
+          <a class="btn clrP clrBr hide js-moreableBtn"><%= ob.polyT('userPage.block') %></a>
           <a class="iconBtn clrP clrBr js-moreBtn"><i class="ion-android-more-vertical"></i> </a>
+        -->
         <% } %>
       </div>
       <% if (ob.showStoreWelcomeCallout) { %>

--- a/styles/modules/_pageNav.scss
+++ b/styles/modules/_pageNav.scss
@@ -10,7 +10,6 @@
     .iconBtn {
       &:not(.normalBtn) {
         height: 20px;
-        margin-top: 7px;
       }
 
       &.navWalletBtn {
@@ -36,6 +35,8 @@
     .navBtn {
       height: 34px;
       width: 34px;
+      display: flex;
+      align-items: center;
 
       &:hover {
         text-decoration: none;
@@ -155,7 +156,20 @@
         color: #000;
         text-align: center;
         margin-right: 8px;
+        width: 13px;
+        height: 13px;
         box-sizing: border-box;
+        position: relative;
+
+        i {
+          visibility: hidden;
+          font-size: 15px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 100%;
+          height: 100%;
+        }
 
         &.navClose {
           background-color: #FF6058;
@@ -171,11 +185,32 @@
           background-color: #29CB41;
           border: solid 1px #13AD29;
           margin-right: 0;
-        }
 
-        i {
-          visibility: hidden;
-          font-size: 10px;
+          i {
+            display: block;
+            position: absolute;
+            top: 22%;
+            left: 22%;
+            width: 56%;
+            height: 56%;
+            border-radius: 1px;
+            background-color: #003200;
+          }
+
+          i:before {
+            content: '';
+            display: block;
+            position: absolute;
+            background-color: #29CB41;
+            height: 12px;
+            width: 2px;
+            left: 0;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            margin: auto;
+            transform: rotate(45deg);
+          }
         }
       }
 

--- a/styles/modules/_pageNav.scss
+++ b/styles/modules/_pageNav.scss
@@ -161,6 +161,10 @@
         box-sizing: border-box;
         position: relative;
 
+        &:hover {
+          text-decoration: none;
+        }
+
         i {
           visibility: hidden;
           font-size: 15px;
@@ -169,6 +173,7 @@
           justify-content: center;
           width: 100%;
           height: 100%;
+          pointer-events: none;
         }
 
         &.navClose {


### PR DESCRIPTION
This PR addresses a variety of small visual issues. 

- the beta label has a tooltip if the user is not in testnet mode.
- the superfluous info icon next to the coupon label in purchase was removed
- a placeholder was added for the coupon input in purchase
- the coupon input being blank is now handled separately from an invalid code
- the ... button on the user page was removed
- the windows controls were updated to look more like Mac controls and be centered properly
- other nav bar icons that were off center vertically were fixed

Closes #789, 790, 791, 788, and 786