### PR TITLE
Fetch settings after it is saved in Onboarding.

### DIFF
--- a/js/views/modals/onboarding/Onboarding.js
+++ b/js/views/modals/onboarding/Onboarding.js
@@ -127,6 +127,7 @@ export default class extends BaseModal {
     }
 
     $.when(...saves).done(() => {
+      app.settings.fetch();
       this.trigger('onboarding-complete');
     }).fail((jqXhr) => {
       let title;


### PR DESCRIPTION
When onboarding completes, app.settings only has data created by the client. If the About modal is opened before some other process fetches settings, it will throw an error because settings is missing the version data.

This fetches the settings after it is saved in onboarding, so all of the settings data from the server is available.

@rmisio there may be a better way to do this, input welcome here.

Closes #726 


