### PR TITLE
Sanitize strings in json response from search

### DIFF
--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -214,7 +214,15 @@ export default class extends baseVw {
         url: searchUrl,
         dataType: 'json',
       })
-        .done((data, status, xhr) => {
+        .done((pData, status, xhr) => {
+          let data = JSON.stringify(pData, (key, val) => {
+            // sanitize the data from any dangerous characters
+            if (typeof val === 'string') {
+              return val.replace(/["&'\/<>]/g, '');
+            }
+            return val;
+          });
+          data = JSON.parse(data);
           // make sure minimal data is present
           if (data.name && data.links) {
             // if data about the provider is recieved, update the model

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import $ from 'jquery';
 import is from 'is_js';
+import sanitizeHtml from 'sanitize-html';
 import baseVw from '../baseVw';
 import loadTemplate from '../../utils/loadTemplate';
 import app from '../../app';
@@ -218,7 +219,10 @@ export default class extends baseVw {
           let data = JSON.stringify(pData, (key, val) => {
             // sanitize the data from any dangerous characters
             if (typeof val === 'string') {
-              return val.replace(/["&'\/<>]/g, '');
+              return sanitizeHtml(val, {
+                allowedTags: [],
+                allowedAttributes: [],
+              });
             }
             return val;
           });

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "babel-register": "^6.9.0",
     "backbone": "^1.3.3",
     "backbone.localstorage": "^1.1.16",
+    "bech32": "^0.0.3",
     "bitcoin-convert": "^1.0.4",
     "bitcore-lib": "^0.14.0",
     "cropit": "^0.5.1",
@@ -81,6 +82,7 @@
     "node-polyglot": "^2.0.0",
     "open": "0.0.5",
     "qr-encode": "^0.3.0",
+    "sanitize-html": "^1.14.1",
     "sortablejs": "^1.5.0-rc1",
     "trumbowyg": "^2.4.2",
     "trunk8": "0.0.1",
@@ -88,7 +90,6 @@
     "underscore": "^1.8.3",
     "url-parse": "^1.1.7",
     "velocity-animate": "^1.2.3",
-    "yargs": "^6.6.0",
-    "bech32": "^0.0.3"
+    "yargs": "^6.6.0"
   }
 }


### PR DESCRIPTION
Strips dangerous characters from the search JSON to prevent XSS attacks from malicious search providers.

Closes #832 

This can be tested by adding a dangerous option to the data before it is sanitized.

```
pData.options = [
            {
              "test": {
                "label": "<script>alert(\"test filter header\");</script>",
                "type": "dropdown",
                "options": [
                  {
                    "label": "foo",
                    "value": "bar"
                  },
                  {
                    "label": "<script>alert(\"test label\");</script>",
                    "value": "<script>alert(\"test value\");</script>"
                  }
                ]
              }
            },
            {
              "test": {
                "label": "test",
                "type": "<script>alert(\"test filter type\");</script>",
                "options": [
                  {
                    "label": "foo",
                    "value": "bar"
                  }
                ]
              }
            }
            ];
```