### PR TITLE
Add support to build RPM binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ deploy:
     - "dist/osx/*.zip"
     - "dist/linux32/*.deb"
     - "dist/linux64/*.deb"
+    - "dist/linux32/*.rpm"
+    - "dist/linux64/*.rpm"
   skip_cleanup: true
   all_branches: true
   on:

--- a/build.sh
+++ b/build.sh
@@ -60,6 +60,10 @@ case "$TRAVIS_OS_NAME" in
 
     echo 'Install npm packages for Linux'
     npm install --save-dev electron-installer-debian --silent
+    npm install -g --save-dev electron-installer-redhat --silent
+
+    # Install rpmbuild
+    sudo apt-get install rpm
 
     # Ensure fakeroot is installed
     sudo apt-get install fakeroot
@@ -74,7 +78,7 @@ case "$TRAVIS_OS_NAME" in
     APPNAME="openbazaar2"
 
     echo "Packaging Electron application"
-    electron-packager . ${APPNAME} --platform=linux --arch=ia32 --=${ELECTRONVER} --overwrite --prune --out=dist
+    electron-packager . ${APPNAME} --platform=linux --arch=ia32 --version=${ELECTRONVER} --overwrite --prune --out=dist
 
     echo 'Move go server to electron app'
     mkdir dist/${APPNAME}-linux-ia32/resources/openbazaar-go/
@@ -85,12 +89,15 @@ case "$TRAVIS_OS_NAME" in
     echo 'Create debian archive'
     electron-installer-debian --config .travis/config_ia32.json
 
+    echo 'Create RPM archive'
+    electron-installer-redhat --config .travis/config_ia32.json
+
     echo 'Sign the installer'
 
     echo 'Building Linux 64-bit Installer....'
 
     echo "Packaging Electron application"
-    electron-packager . ${APPNAME} --platform=linux --arch=x64 --=${ELECTRONVER} --overwrite --prune --out=dist
+    electron-packager . ${APPNAME} --platform=linux --arch=x64 --version=${ELECTRONVER} --overwrite --prune --out=dist
 
     echo 'Move go server to electron app'
     mkdir dist/${APPNAME}-linux-x64/resources/openbazaar-go/
@@ -100,6 +107,9 @@ case "$TRAVIS_OS_NAME" in
 
     echo 'Create debian archive'
     electron-installer-debian --config .travis/config_amd64.json
+
+    echo 'Create RPM archive'
+    electron-installer-redhat --config .travis/config_amd64.json
 
     echo 'Sign the installer'
 

--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ case "$TRAVIS_OS_NAME" in
     mkdir dist/linux64
 
     echo 'Install npm packages for Linux'
-    npm install --save-dev electron-installer-debian --silent
+    npm install -g --save-dev electron-installer-debian --silent
     npm install -g --save-dev electron-installer-redhat --silent
 
     # Install rpmbuild

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "copyfiles": "^1.0.0",
     "cross-env": "^1.0.8",
     "electron": "^1.4.15",
+    "electron-installer-debian": "^0.5.2",
+    "electron-installer-redhat": "^0.5.0",
+    "electron-winstaller": "2.5.2",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-config-defaults": "^9.0.0",
@@ -56,8 +59,7 @@
     "node-sass": "^3.13.0",
     "nodemon": "^1.9.2",
     "npm-run-all": "^2.2.0",
-    "sinon": "^1.17.6",
-    "electron-winstaller": "2.5.2"
+    "sinon": "^1.17.6"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
This adds the RPMs into the Travis build script and also fixes a little bug I noticed where we don't specify version for whatever reason in the install script...not sure how it still works!

![image](https://user-images.githubusercontent.com/45482/30279275-c8da40a8-96da-11e7-90e5-eddacb4f71f0.png)
