### PR TITLE
Change the buttons in the rich editor.

### DIFF
--- a/js/utils/trumbowyg.js
+++ b/js/utils/trumbowyg.js
@@ -9,14 +9,17 @@ export const editorOptions = {
     ['bold', 'italic'],
     ['link'],
     ['insertImage'],
-    'btnGrp-justify',
     'btnGrp-lists',
+    ['horizontalRule'],
   ],
 };
 
 export function installRichEditor(attachPoint, options = {}) {
   const opts = {
-    editorOptions,
+    editorOptions: {
+      ...editorOptions,
+      ...options.editorOptions || {},
+    },
     ...options,
   };
 

--- a/js/views/modals/editListing/EditListing.js
+++ b/js/views/modals/editListing/EditListing.js
@@ -7,7 +7,7 @@ import path from 'path';
 import '../../../utils/velocityUiPack.js';
 import Backbone from 'backbone';
 import { isScrolledIntoView } from '../../../utils/dom';
-import '../../../utils/trumbowyg';
+import { installRichEditor } from '../../../utils/trumbowyg';
 import { getCurrenciesSortedByCode } from '../../../data/currencies';
 import { formatPrice } from '../../../utils/currency';
 import SimpleMessage, { openSimpleMessage } from '../SimpleMessage';
@@ -1201,16 +1201,8 @@ export default class extends BaseModal {
       this.$tabControls = this.$('.tabControls');
       this.$titleInput = this.$('#editListingTitle');
 
-      this.$('#editListingDescription').trumbowyg({
+      installRichEditor(this.$('#editListingDescription'), {
         topLevelClass: 'clrBr',
-        btns: [
-          ['formatting'],
-          ['bold', 'italic'],
-          ['link'],
-          ['insertImage'],
-          'btnGrp-lists',
-          ['horizontalRule'],
-        ],
       });
 
       if (this.sortablePhotos) this.sortablePhotos.destroy();

--- a/js/views/modals/editListing/EditListing.js
+++ b/js/views/modals/editListing/EditListing.js
@@ -7,7 +7,7 @@ import path from 'path';
 import '../../../utils/velocityUiPack.js';
 import Backbone from 'backbone';
 import { isScrolledIntoView } from '../../../utils/dom';
-import { installRichEditor } from '../../../utils/trumbowyg';
+import '../../../utils/trumbowyg';
 import { getCurrenciesSortedByCode } from '../../../data/currencies';
 import { formatPrice } from '../../../utils/currency';
 import SimpleMessage, { openSimpleMessage } from '../SimpleMessage';
@@ -1201,8 +1201,17 @@ export default class extends BaseModal {
       this.$tabControls = this.$('.tabControls');
       this.$titleInput = this.$('#editListingTitle');
 
-      installRichEditor(this.$('#editListingDescription'), {
+      this.$('#editListingDescription').trumbowyg({
         topLevelClass: 'clrBr',
+        btns: [
+          ['formatting'],
+          ['bold', 'italic'],
+          ['link'],
+          ['insertImage'],
+          'btnGrp-lists',
+          ['horizontalRule'],
+          ['viewHTML'],
+        ],
       });
 
       if (this.sortablePhotos) this.sortablePhotos.destroy();

--- a/js/views/modals/editListing/EditListing.js
+++ b/js/views/modals/editListing/EditListing.js
@@ -1210,7 +1210,6 @@ export default class extends BaseModal {
           ['insertImage'],
           'btnGrp-lists',
           ['horizontalRule'],
-          ['viewHTML'],
         ],
       });
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "open": "0.0.5",
     "qr-encode": "^0.3.0",
     "sortablejs": "^1.5.0-rc1",
-    "trumbowyg": "^2.4.2",
+    "trumbowyg": "^2.7.2",
     "trunk8": "0.0.1",
     "twemoji": "^2.2.5",
     "underscore": "^1.8.3",

--- a/styles/components/_misc.scss
+++ b/styles/components/_misc.scss
@@ -24,6 +24,7 @@
 
 .trumbowyg .trumbowyg-editor {
   height: auto !important;
+  padding: 10px;
   /* gross hack to stop trumbowyg from setting inline height to huge numbers when external
   images are added */
 }


### PR DESCRIPTION
This removes the alignment buttons in the rich text editor, since they style attributes they set are stripped from the data by the server.

- also adds the HR button, because it looked nice in a test description.
- fixes the top padding.
- updates Trumbowyg to 2.7.2, to incorporate various bug fixes.

Closes #820