### PR TITLE
not forcing ssl on remote servers, but defaulting and showing a warning

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -677,7 +677,13 @@
       "torPwLabel": "Tor Password",
       "torPwPlaceholder": "The unhashed Tor control password",
       "warning": "Warning:",
-      "torServerWarning": "%{warning} In order to be anonymous, it is critical that you also start the server in Tor mode."
+      "torServerWarning": "%{warning} In order to be anonymous, it is critical that you also start the server in Tor mode.",
+      "saveConfirm": {
+        "title": "Are you sure?",
+        "body": "When connecting to a remote server, it is highly recommended you have SSL turned on.",
+        "btnCancel": "No, cancel",
+        "btnConfirm": "Yes, proceed"
+      }
     }
   },
   "torExternalLinkWarning": {

--- a/js/models/ServerConfig.js
+++ b/js/models/ServerConfig.js
@@ -1,8 +1,8 @@
 import { remote } from 'electron';
-import app from '../app';
-import BaseModel from './BaseModel';
 import LocalStorageSync from '../utils/backboneLocalStorage';
 import is from 'is_js';
+import app from '../app';
+import BaseModel from './BaseModel';
 
 export default class extends BaseModel {
   localStorage() {
@@ -66,10 +66,6 @@ export default class extends BaseModel {
 
       if (!attrs.password) {
         addError('password', app.polyglot.t('serverConfigModelErrors.provideValue'));
-      }
-
-      if (!attrs.SSL) {
-        addError('SSL', 'SSL must be turned on for remote servers.');
       }
     }
 
@@ -158,14 +154,12 @@ export default class extends BaseModel {
    * your machine. It may be the local bundled server or it may be a locally
    * run stand-alone server.
    */
-  isLocalServer() {
-    const ip = this.get('serverIp');
-
+  isLocalServer(ip = this.get('serverIp')) {
     return ip === 'localhost' || ip === '127.0.0.1';
   }
 
   isTorPwRequired() {
     return ['win', 'darwin'].indexOf(remote.process.platform) > -1 &&
-      this.isLocalServer();
+      this.isLocalServer() && remote.getGlobal('isBundledApp')();
   }
 }

--- a/js/templates/modals/connectionManagement/configurationForm.html
+++ b/js/templates/modals/connectionManagement/configurationForm.html
@@ -66,7 +66,7 @@
       </div>
       <div class="col9">
         <% if (ob.errors.ssl) print(ob.formErrorTmpl({ errors: ob.errors.ssl })) %>
-        <div class="btnStrip js-btnStripSsl <% if (ob.isRemote) print('disabled') %>">
+        <div class="btnStrip">
           <div class="btnRadio clrBr">
             <input type="radio"
                    name="SSL"
@@ -140,6 +140,17 @@
   <hr class="clrBr" />
   <div class="flexHRight flexVCent gutterHLg">
     <a class="js-cancel"><%= ob.polyT('connectionManagement.configurationForm.btnCancel') %></a>
-    <a class="btn clrP clrBr clrSh2 js-save"><%= ob.polyT('connectionManagement.configurationForm.btnSave') %></a>
+    <div class="posR">
+      <a class="btn clrP clrBr clrSh2 js-save"><%= ob.polyT('connectionManagement.configurationForm.btnSave') %></a>
+      <div class="js-saveConfirmBox confirmBox saveConfirmBox arrowBoxBottom tx5 clrBr clrP clrT hide">
+        <div class="tx3 txB rowSm"><%= ob.polyT('connectionManagement.configurationForm.saveConfirm.title') %></div>
+        <p><%= ob.polyT('connectionManagement.configurationForm.saveConfirm.body') %></p>
+        <hr class="clrBr row" />
+        <div class="flexHRight flexVCent gutterHLg buttonBar">
+          <a class="js-saveConfirmCancel"><%= ob.polyT('connectionManagement.configurationForm.saveConfirm.btnCancel') %></a>
+          <a class="btn clrBAttGrad clrBrDec1 clrTOnEmph js-saveConfirmed"><%= ob.polyT('connectionManagement.configurationForm.saveConfirm.btnConfirm') %></a>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/styles/components/_containers.scss
+++ b/styles/components/_containers.scss
@@ -299,7 +299,7 @@
   &::before {
     bottom: 1px;
     left: 50%;
-    transform: translate(-25%, 50%) rotate(-135deg);
+    transform: translate(calc(-25% - 6px), 50%) rotate(-135deg);
     -webkit-clip-path: polygon(0 0, 0 100%, 100% 0);
   }
 }

--- a/styles/modules/modals/_connectionManagement.scss
+++ b/styles/modules/modals/_connectionManagement.scss
@@ -105,5 +105,11 @@
       padding-left: 0;
       padding-right: 0;
     }
+
+    .saveConfirmBox {
+      @include center(true, false);
+      bottom: 0;
+      margin-bottom: 55px;
+    }
   }  
 }


### PR DESCRIPTION
Since apparently there are people using remote servers on a private network which are probably under protection from net sniffing (e.g. running the server on a PI inside your home wireless network) and it would be a big PIA for those people to have to set-up a certificate, with this PR, we are no longer forcing remote servers to use SSL.

We are defaulting it on for remote servers and showing a warning if you turn it off and try and save the configuration. Beyond that, it's up to the user to be smart and recognize that if you are indeed running the server on a publicly accessible server, you are being foolish to do so without SSL.