### PR TITLE
handle a failed profile fetch in the order detail profile box

### DIFF
--- a/js/templates/modals/orderDetail/profileBox.html
+++ b/js/templates/modals/orderDetail/profileBox.html
@@ -2,7 +2,7 @@
   <div class="center">
     <%= ob.spinner({ className: 'spinnerMd' }) %>
   </div>
-<% } else if (ob.name) { %>
+<% } else { %>
   <%
     let featuredProfileAvatarStyle = ob.getAvatarBgImage(ob.avatarHashes,
       {

--- a/js/views/modals/orderDetail/OrderDetail.js
+++ b/js/views/modals/orderDetail/OrderDetail.js
@@ -138,10 +138,7 @@ export default class extends BaseModal {
     this.featuredProfileFetch.done(profile => {
       this.featuredProfileMd = profile;
       this.featuredProfile.setModel(this.featuredProfileMd);
-      this.featuredProfile.setState({
-        isFetching: false,
-      });
-    });
+    }).always(() => this.featuredProfile.setState({ isFetching: false }));
   }
 
   onClickRetryFetch() {


### PR DESCRIPTION
Handle a failed profile fetch in the Order Detail top left box.

![image](https://user-images.githubusercontent.com/794517/30398118-128803e8-9884-11e7-9961-02eeeb78e88c.png)

Previously the spinner would remain forever. Now on the failure it will show the default avatar.