### PR TITLE
unbolded tags

### DIFF
--- a/styles/modules/modals/_listingDetail.scss
+++ b/styles/modules/modals/_listingDetail.scss
@@ -49,6 +49,7 @@
           float: left;
           margin: 0 $padSm $padSm 0;
           font-size: $tx5b;
+          font-weight: 400;
           padding: 0 $pad;
         }
       }


### PR DESCRIPTION
Tags are currently unbolded in the create/edit listing screen. They're now consistent and also unbolded on the listing detail screen.