### PR TITLE
Layout fixes

### DIFF
--- a/js/templates/chat/convoProfileHeader.html
+++ b/js/templates/chat/convoProfileHeader.html
@@ -1,5 +1,5 @@
 <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" href="<%= ob.guid %>" style="<%= ob.getAvatarBgImage(ob.avatarHashes || {}) %>"></a>
 <div class="tx6">
   <a class="rowTn handle noOverflow clrT" href="<%= ob.guid %>"><%= ob.handle ? `@${ob.handle}` : ob.guid %></a>
-  <div class="clamp2"><%= ob.location ? `📍${ob.location}` : '' %></div>
+  <div class="clamp"><%= ob.location ? `📍${ob.location}` : '' %></div>
 </div>

--- a/js/templates/chat/convoProfileHeader.html
+++ b/js/templates/chat/convoProfileHeader.html
@@ -1,5 +1,5 @@
 <a class="chatIcon disc clrBr2 clrSh1 flexNoShrink" href="<%= ob.guid %>" style="<%= ob.getAvatarBgImage(ob.avatarHashes || {}) %>"></a>
 <div class="tx6">
   <a class="rowTn handle noOverflow clrT" href="<%= ob.guid %>"><%= ob.handle ? `@${ob.handle}` : ob.guid %></a>
-  <div class="clamp"><%= ob.location ? `📍${ob.location}` : '' %></div>
+  <div class="clamp"><%= ob.location ? `${ob.parseEmojis('📍')}${ob.location}` : '' %></div>
 </div>

--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -35,9 +35,9 @@
 
 <div class="listingContent flexColRow gutterVMd2">
   <div class="contentBox padLg clrP clrBr clrSh3">
-    <div class="flex">
+    <div class="flex gutterHLg">
       <h2 class="txUnb flexExpand"><%= ob.item.title %></h2>
-      <h2 class="txUnb js-price">
+      <h2 class="txUnb flexNoShrink js-price">
         <%= ob.convertAndFormatCurrency(ob.item.price, ob.metadata.pricingCurrency, ob.displayCurrency) %>
       </h2>
     </div>

--- a/js/templates/userCard.html
+++ b/js/templates/userCard.html
@@ -52,7 +52,7 @@
         <div class="flexExpand">
           <span class="clrT2 clamp tx5b"><%= ob.parseEmojis('📍') %> <%= ob.location || ob.polyT('userPage.noLocation') %></span>
         </div>
-        <div class="tx6">
+        <div class="tx6 flexNoShrink">
           <% print(`${ob.formatRating(ob.stats.averageRating, ob.stats.ratingCount)}`) %>
         </div>
       </div>


### PR DESCRIPTION
Some small layout fixes.

- prevent long titles on the listing details from collapsing the price.
- reduce the location clamp in the chat to 1 line. Closes #879 
- prevent long locations in the user card from collapsing the rating. Closes #809 