### PR TITLE
External ob links

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import { ipcRenderer } from 'electron';
 import { Router } from 'backbone';
 import { getGuid, isMultihash } from './utils';
 import { getPageContainer } from './utils/selectors';
@@ -46,6 +47,9 @@ export default class ObRouter extends Router {
     $(window).on('hashchange', () => {
       this.setAddressBarText();
     });
+
+    ipcRenderer.on('external-route',
+      (e, route) => this.navigate(route, { trigger: true }));
   }
 
   get maxCachedHandles() {

--- a/js/start.js
+++ b/js/start.js
@@ -414,9 +414,14 @@ function start() {
         // set the profile data for the feedback mechanism
         setFeedbackOptions();
 
-        // When starting the app the route is set to empty. We'll change that to be the
-        // user's profile.
-        if (!location.hash) {
+        const externalRoute = remote.getGlobal('externalRoute');
+
+        if (externalRoute) {
+          // handle opening the app from an an external ob link
+          location.hash = `#${externalRoute}`;
+        } else if (!location.hash) {
+          // If for some reason the route to start on is empty, we'll change it to be
+          // the user's profile.
           const href = location.href.replace(/(javascript:|#).*$/, '');
           location.replace(`${href}#${app.profile.id}`);
         }

--- a/main.js
+++ b/main.js
@@ -520,7 +520,7 @@ function createWindow() {
   });
 
   // Set up protocol
-  app.setAsDefaultProtocolClient('ob2');
+  app.setAsDefaultProtocolClient('ob');
 
   // Check for URL hijacking in the browser
   preventWindowNavigation(mainWindow);

--- a/main.js
+++ b/main.js
@@ -7,7 +7,6 @@ import { argv } from 'yargs';
 import path from 'path';
 import fs from 'fs';
 import childProcess from 'child_process';
-import urlparse from 'url-parse';
 import _ from 'underscore';
 import { guid } from './js/utils';
 import LocalServer from './js/utils/localServer';

--- a/main.js
+++ b/main.js
@@ -125,21 +125,6 @@ crashReporter.start({
 });
 
 /**
- * Handles valid OB2 protocol URLs in the webapp.
- *
- * @param  {Object} externalURL Contains a string url
- */
-function handleDeepLinkEvent(externalURL) {
-  if (typeof externalURL !== 'string') return;
-
-  const theUrl = urlparse(externalURL);
-  if (theUrl.protocol !== 'ob:') {
-    console.warn(`Unable to handle ${externalURL} because it's not the ob: protocol.`);
-    return;
-  }
-}
-
-/**
  * Prevent window navigation
  *
  * @param  {Object} win Contains a browserwindow object
@@ -150,10 +135,6 @@ function preventWindowNavigation(win) {
     if (url === win.webContents.getURL()) return;
 
     e.preventDefault();
-
-    if (url.startsWith('ob:')) {
-      handleDeepLinkEvent(url);
-    }
   });
 }
 


### PR DESCRIPTION
This PR updates the code to handle external ob links.

Some notes:
- To test this properly will require a new build. @hoffmabc 
- Since we are using the `ob://` protocol to open links in both the v1 and v2 apps, it is not entirely known which one will take precedence (I imagine it's dependent on the OS). For me on OSX, with both installed, the link still opened in v1. I've come to know it's quite a pain to break the association on OSX, so I fixed things by just deleting the v1 app.
- The electron method we are using to associate the protocol (`setAsDefaultProtocolClient`) doesn't list Linux as being supported. So, I would guess this would not work on Linux. Not sure if v1 supported external ob links on Linux?

closes #862 