### PR TITLE
Restrict Moderation if the Purchase Price is Low

### DIFF
--- a/js/collections/purchase/Moderators.js
+++ b/js/collections/purchase/Moderators.js
@@ -10,4 +10,8 @@ export default class extends Collection {
   model(attrs, options) {
     return new Profile(attrs, options);
   }
+
+  modelId(attrs) {
+    return attrs.peerID;
+  }
 }

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1088,7 +1088,7 @@
     "quantity": "Quantity",
     "useShapeShift": "Or use ShapeShift in the next step",
     "moderatedPayment": "Moderated Payment",
-    "tooLowForMods": "Based on the current estimated fee, moderated payment is not available for orders under %{minModPrice}. A direct payment will be used instead.",
+    "tooLowForMods": "Based on the current estimated fee, the moderated payment option is not available for orders under %{minModPrice}. A direct payment will be used instead.",
     "noValidModerators": "No valid moderators are available for this order.",
     "moderationDisclaimer": "Your payment will be held securly in escrow. If any issues arise, you’ll have the ability to open a dispute with a moderator. *The moderator service fee only applies if a dispute is opened.",
     "chooseModerator": "Choose This Moderator",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1143,7 +1143,8 @@
       "ownIDTitle": "You Can't Purchase Your Own Listings",
       "ownIDMsg": "You can preview the purchase process for your own listings, but you cannot purchase them.",
       "paymentFailed": "The Payment Could Not Be Completed",
-      "zeroPrice": "You cannot purchase a listing with a total price of zero."
+      "zeroPrice": "You cannot purchase a listing with a total price of zero.",
+      "feesFailed": "Transaction Fees Cannot Be Loaded"
     }
   },
   "moderators": {

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1088,7 +1088,7 @@
     "quantity": "Quantity",
     "useShapeShift": "Or use ShapeShift in the next step",
     "moderatedPayment": "Moderated Payment",
-    "tooLowForMods": "The total price is too low for this order to be moderated.",
+    "tooLowForMods": "Based on the current estimated fee, moderated payment is not available for orders under %{minModPrice}. A direct payment will be used instead.",
     "noValidModerators": "No valid moderators are available for this order.",
     "moderationDisclaimer": "Your payment will be held securly in escrow. If any issues arise, you’ll have the ability to open a dispute with a moderator. *The moderator service fee only applies if a dispute is opened.",
     "chooseModerator": "Choose This Moderator",

--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1079,6 +1079,7 @@
     "quantity": "Quantity",
     "useShapeShift": "Or use ShapeShift in the next step",
     "moderatedPayment": "Moderated Payment",
+    "tooLowForMods": "The total price is too low for this order to be moderated.",
     "noValidModerators": "No valid moderators are available for this order.",
     "moderationDisclaimer": "Your payment will be held securly in escrow. If any issues arise, you’ll have the ability to open a dispute with a moderator. *The moderator service fee only applies if a dispute is opened.",
     "chooseModerator": "Choose This Moderator",

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -180,13 +180,16 @@ const totalPrice = ob.prices[0].price + ob.prices[0].vPrice;
         <section class="contentBox pad clrP clrBr clrSh3 sidebar">
           <i class="js-close cornerTR ion-ios-close-empty iconBtn clrP clrBr clrSh3 closeBtn"></i>
           <div class="js-actionBtn"></div>
-          <div class="js-receipt"></div>
-          <% if (ob.hasModerators) { %>
-            <hr class="clrBr js-moderatorNote">
-            <div class="padSm txSm txCtr clrT2 js-moderatorNote">
-              <%= ob.polyT('purchase.moderatorNote') %>
-            </div>
-          <% } %>
+          <div class="rowLg">
+            <div class="js-receipt"></div>
+            <% if (ob.hasModerators) { %>
+              <hr class="clrBr js-moderatorNote">
+              <div class="padSm txSm txCtr clrT2 js-moderatorNote">
+                <%= ob.polyT('purchase.moderatorNote') %>
+              </div>
+            <% } %>
+          </div>
+          <div class="tx6 js-feeChangeContainer"></div>
         </section>
       </div>
     </div>

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -96,11 +96,11 @@ const totalPrice = ob.prices[0].price + ob.prices[0].vPrice;
                 <p class="clrTErr hide js-noValidModerators">
                   <%= ob.polyT('purchase.noValidModerators') %>
                 </p>
-                <p class="clrTErr tx5b hide js-modsNotAllowed">
+                <p class="tx5b hide js-modsNotAllowed">
                   <%
                   const minModPrice = ob.convertAndFormatCurrency(ob.minModPrice, 'BTC', ob.displayCurrency);
                   %>
-                  <%= ob.polyT('purchase.tooLowForMods', { minModPrice }) %>
+                  <strong><%= ob.polyT('purchase.tooLowForMods', { minModPrice }) %></strong>
                 </p>
               <% } %>
             </div>

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -5,182 +5,188 @@ const totalPrice = ob.prices[0].price + ob.prices[0].vPrice;
 
 <div class="popInMessageHolder js-popInMessages"></div>
 
-<div class="topControls gutterHSm flex">
-  <% if (ob.vendor) { %>
-  <div class="contentBox clrP clrSh3 clrBr clrT">
-    <div class="padSm gutterHSm overflowAuto margRSm flexVCent">
-      <a class="clrBr2 clrSh1 discTn flexNoShrink" style="<%= ob.getAvatarBgImage(ob.vendor.avatar) %>"></a>
-      <p class="txUnl tx3 clamp"><%= ob.vendor.name %></p>
-      <a class="link flexNoShrink tx6 js-goToListing"><% print(ob.polyT('purchase.returnToListing')) %></a>
-    </div>
-  </div>
-  <% } %>
-</div>
+<% if (!ob.isFetching) { %>
 
-<div class="flexRow gutterH">
-  <div class="col9">
-    <div class="flexColRow gutterV">
-      <% // to support multiple items in a purchase, loop this section %>
-      <section class="contentBox pad clrP clrBr clrSh3">
-        <div class="js-errors"></div>
-        <div class="js-items-quantity-errors"></div>
-        <div class="flexVCent gutterH">
-          <div class="thumb" style="<%= ob.getListingBgImage(ob.listing.item.images[0]) %>"></div>
-          <div class="flexExpand">
-            <div class="flexCol gutterVTn">
-              <div class="width100 noOverflow">
-                <b><%= ob.listing.item.title %></b>
-              </div>
-              <% ob.variants.forEach(variant => { %>
-                <div class="width100 noOverflow">
-                  <span class="clrT2"><%= variant.name %>: <%= variant.value %></span>
-                </div>
-              <% }); %>
-            </div>
-          </div>
-          <div class="showIfPay flexNoShrink">
-            <div class="flexVCent gutterHSm">
-              <label class="flexNoShrink" for="purchaseQuantity">
-                <%= ob.polyT('purchase.quantity') %>
-              </label>
-              <input
-                  class="clrBr clrP"
-                  type="text"
-                  id="purchaseQuantity"
-                  size="3"
-                  name="quantity"
-                  value="1"
-                  data-var-type="number">
-            </div>
-          </div>
-          <div class="pad flexNoShrink">
-            <b>
-              <%= ob.convertAndFormatCurrency(totalPrice, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
-            </b>
-          </div>
-        </div>
-      </section>
-      <% if (ob.listing.shippingOptions && ob.listing.shippingOptions.length) { %>
-        <section class="contentBox padMd clrP clrBr clrSh3 showIfPay js-shipping">
-          <div class="js-shipping-errors js-items-shipping-errors"></div>
-          <div class="js-shippingWrapper"></div>
-        </section>
-      <% } %>
-      <section class="contentBox padMd clrP clrBr clrSh3 showIfPay">
-        <div class="flexColRows gutterVSm">
-          <h2 class="h4 required"><%= ob.polyT('purchase.paymentTypeTitle') %></h2>
-          <div class="contentBox pad clrP clrBr flexVCent">
-            <i class="btcIcon margRSm"></i>
+  <div class="topControls gutterHSm flex">
+    <% if (ob.vendor) { %>
+    <div class="contentBox clrP clrSh3 clrBr clrT">
+      <div class="padSm gutterHSm overflowAuto margRSm flexVCent">
+        <a class="clrBr2 clrSh1 discTn flexNoShrink" style="<%= ob.getAvatarBgImage(ob.vendor.avatar) %>"></a>
+        <p class="txUnl tx3 clamp"><%= ob.vendor.name %></p>
+        <a class="link flexNoShrink tx6 js-goToListing"><% print(ob.polyT('purchase.returnToListing')) %></a>
+      </div>
+    </div>
+    <% } %>
+  </div>
+
+  <div class="flexRow gutterH">
+    <div class="col9">
+      <div class="flexColRow gutterV">
+        <% // to support multiple items in a purchase, loop this section %>
+        <section class="contentBox pad clrP clrBr clrSh3">
+          <div class="js-errors"></div>
+          <div class="js-items-quantity-errors"></div>
+          <div class="flexVCent gutterH">
+            <div class="thumb" style="<%= ob.getListingBgImage(ob.listing.item.images[0]) %>"></div>
             <div class="flexExpand">
-              <%= ob.polyT('currencies.BTC') %>
+              <div class="flexCol gutterVTn">
+                <div class="width100 noOverflow">
+                  <b><%= ob.listing.item.title %></b>
+                </div>
+                <% ob.variants.forEach(variant => { %>
+                  <div class="width100 noOverflow">
+                    <span class="clrT2"><%= variant.name %>: <%= variant.value %></span>
+                  </div>
+                <% }); %>
+              </div>
             </div>
-            <div class="tx6 clrT2 margRSm"><%= ob.polyT('purchase.useShapeShift') %></div>
-            <i class="shapeShiftIcon" style="background-image: url('../imgs/shapeShiftIcon.png');"></i>
+            <div class="showIfPay flexNoShrink">
+              <div class="flexVCent gutterHSm">
+                <label class="flexNoShrink" for="purchaseQuantity">
+                  <%= ob.polyT('purchase.quantity') %>
+                </label>
+                <input
+                    class="clrBr clrP"
+                    type="text"
+                    id="purchaseQuantity"
+                    size="3"
+                    name="quantity"
+                    value="1"
+                    data-var-type="number">
+              </div>
+            </div>
+            <div class="pad flexNoShrink">
+              <b>
+                <%= ob.convertAndFormatCurrency(totalPrice, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
+              </b>
+            </div>
           </div>
-          <% if (ob.hasModerators) { %>
-            <div class="js-moderatedOption">
-              <input
-                  type="checkbox"
-                  name="moderated"
-                  checked
-                  id="purchaseModerated">
-              <label for="purchaseModerated"><%= ob.polyT('purchase.moderatedPayment') %></label>
-              <p class="clrT2 tx6">
-                <%= ob.polyT('purchase.moderationDisclaimer') %>
-              </p>
-            </div>
-            <p class="clrTErr hide js-noValidModerators">
-              <%= ob.polyT('purchase.noValidModerators') %>
-            </p>
-          <% } %>
-        </div>
-      </section>
-      <% if (ob.hasModerators) { %>
-        <section class="contentBox padMd clrP clrBr clrSh3 showIfPay js-moderator">
-          <h2 class="h4"><%= ob.polyT('purchase.moderatorTitle') %></h2>
-          <div class="js-moderated-errors"></div>
-          <div class="js-moderatorsWrapper"></div>
         </section>
-      <% } %>
-      <section class="contentBox padMd clrP clrBr clrSh3 showIfPay">
-        <h2 class="h4">
-          <%= ob.polyT('purchase.informationTitle') %>
-          <span class="clrT2 txUnb tx5b"><%= ob.polyT('purchase.optional') %></span>
-        </h2>
-        <div class="flexRow gutterH row">
-          <div class="col6">
-            <div class="rowTn">
-              <label for="emailAddress" class="tx5">
-                <%= ob.polyT('purchase.emailAddress') %>
-              </label>
+        <% if (ob.listing.shippingOptions && ob.listing.shippingOptions.length) { %>
+          <section class="contentBox padMd clrP clrBr clrSh3 showIfPay js-shipping">
+            <div class="js-shipping-errors js-items-shipping-errors"></div>
+            <div class="js-shippingWrapper"></div>
+          </section>
+        <% } %>
+        <section class="contentBox padMd clrP clrBr clrSh3 showIfPay">
+          <div class="flexColRows gutterVSm">
+            <h2 class="h4 required"><%= ob.polyT('purchase.paymentTypeTitle') %></h2>
+            <div class="contentBox pad clrP clrBr flexVCent">
+              <i class="btcIcon margRSm"></i>
+              <div class="flexExpand">
+                <%= ob.polyT('currencies.BTC') %>
+              </div>
+              <div class="tx6 clrT2 margRSm"><%= ob.polyT('purchase.useShapeShift') %></div>
+              <i class="shapeShiftIcon" style="background-image: url('../imgs/shapeShiftIcon.png');"></i>
             </div>
-            <div>
-              <input
-                  class="btnHeight clrBr clrP js-purchaseField"
-                  type="text"
-                  id="emailAddress"
-                  name="alternateContactInfo"
-                  placeholder="<%= ob.polyT('purchase.emailPlaceholder') %>"
-                  value="<%= ob.alternateContactInfo %>">
+            <% if (ob.hasModerators) { %>
+              <div class="js-moderatedOption">
+                <input
+                    type="checkbox"
+                    name="moderated"
+                    checked
+                    id="purchaseModerated">
+                <label for="purchaseModerated"><%= ob.polyT('purchase.moderatedPayment') %></label>
+                <p class="clrT2 tx6">
+                  <%= ob.polyT('purchase.moderationDisclaimer') %>
+                </p>
+              </div>
+              <p class="clrTErr hide js-noValidModerators">
+                <%= ob.polyT('purchase.noValidModerators') %>
+              </p>
+            <% } %>
+          </div>
+        </section>
+        <% if (ob.hasModerators) { %>
+          <section class="contentBox padMd clrP clrBr clrSh3 showIfPay js-moderator">
+            <h2 class="h4"><%= ob.polyT('purchase.moderatorTitle') %></h2>
+            <div class="js-moderated-errors"></div>
+            <div class="js-moderatorsWrapper"></div>
+          </section>
+        <% } %>
+        <section class="contentBox padMd clrP clrBr clrSh3 showIfPay">
+          <h2 class="h4">
+            <%= ob.polyT('purchase.informationTitle') %>
+            <span class="clrT2 txUnb tx5b"><%= ob.polyT('purchase.optional') %></span>
+          </h2>
+          <div class="flexRow gutterH row">
+            <div class="col6">
+              <div class="rowTn">
+                <label for="emailAddress" class="tx5">
+                  <%= ob.polyT('purchase.emailAddress') %>
+                </label>
+              </div>
+              <div>
+                <input
+                    class="btnHeight clrBr clrP js-purchaseField"
+                    type="text"
+                    id="emailAddress"
+                    name="alternateContactInfo"
+                    placeholder="<%= ob.polyT('purchase.emailPlaceholder') %>"
+                    value="<%= ob.alternateContactInfo %>">
+              </div>
+              <div>
+                <span class="txSm clrT2"><%= ob.polyT('purchase.emailNote') %></span>
+              </div>
             </div>
-            <div>
-              <span class="txSm clrT2"><%= ob.polyT('purchase.emailNote') %></span>
+            <div class="col6">
+              <div class="rowTn">
+                <label for="couponCode" class="tx5">
+                  <%= ob.polyT('purchase.couponCode') %>
+                </label>
+              </div>
+              <div class="flex gutterH row">
+                <input
+                    class="btnHeight clrBr clrP"
+                    type="text"
+                    id="couponCode"
+                    name="couponCode"
+                    placeholder="<%= ob.polyT('purchase.couponCodePlaceholder') %>">
+                <button class="btn clrP clrBr clrSh2 js-applyCoupon">
+                  <%= ob.polyT('purchase.applyCode') %>
+                </button>
+              </div>
+              <div class="js-couponsWrapper">
+                <% // coupons are inserted here after they are added by the user. %>
+              </div>
             </div>
           </div>
-          <div class="col6">
-            <div class="rowTn">
-              <label for="couponCode" class="tx5">
-                <%= ob.polyT('purchase.couponCode') %>
-              </label>
-            </div>
-            <div class="flex gutterH row">
-              <input
-                  class="btnHeight clrBr clrP"
-                  type="text"
-                  id="couponCode"
-                  name="couponCode"
-                  placeholder="<%= ob.polyT('purchase.couponCodePlaceholder') %>">
-              <button class="btn clrP clrBr clrSh2 js-applyCoupon">
-                <%= ob.polyT('purchase.applyCode') %>
-              </button>
-            </div>
-            <div class="js-couponsWrapper">
-              <% // coupons are inserted here after they are added by the user. %>
-            </div>
+          <hr class="clrBr row">
+          <div class="rowTn">
+            <label for="memo" class="tx5">
+              <%= ob.polyT('purchase.memo') %>
+            </label>
           </div>
-        </div>
-        <hr class="clrBr row">
-        <div class="rowTn">
-          <label for="memo" class="tx5">
-            <%= ob.polyT('purchase.memo') %>
-          </label>
-        </div>
-        <textarea
-            class="clrBr clrP js-purchaseField"
-            id="memo"
-            name="memo"
-            maxlength="5000"
-            rows="6"
-            placeholder="<%= ob.polyT('purchase.memoPlaceholder') %>"><%= ob.memo %></textarea>
-      </section>
-      <section class="contentBox padMd clrP clrBr clrSh3 showIfPending js-pending">
-      </section>
-      <section class="contentBox padMd clrP clrBr clrSh3 showIfComplete js-complete">
+          <textarea
+              class="clrBr clrP js-purchaseField"
+              id="memo"
+              name="memo"
+              maxlength="5000"
+              rows="6"
+              placeholder="<%= ob.polyT('purchase.memoPlaceholder') %>"><%= ob.memo %></textarea>
+        </section>
+        <section class="contentBox padMd clrP clrBr clrSh3 showIfPending js-pending">
+        </section>
+        <section class="contentBox padMd clrP clrBr clrSh3 showIfComplete js-complete">
+        </section>
+      </div>
+    </div>
+    <div class="col3">
+      <section class="contentBox pad clrP clrBr clrSh3 sidebar">
+        <i class="js-close cornerTR ion-ios-close-empty iconBtn clrP clrBr clrSh3 closeBtn"></i>
+        <div class="js-actionBtn"></div>
+        <div class="js-receipt"></div>
+        <% if (ob.hasModerators) { %>
+          <hr class="clrBr js-moderatorNote">
+          <div class="padSm txSm txCtr clrT2 js-moderatorNote">
+            <%= ob.polyT('purchase.moderatorNote') %>
+          </div>
+        <% } %>
       </section>
     </div>
   </div>
-  <div class="col3">
-    <section class="contentBox pad clrP clrBr clrSh3 sidebar">
-      <i class="js-close cornerTR ion-ios-close-empty iconBtn clrP clrBr clrSh3 closeBtn"></i>
-      <div class="js-actionBtn"></div>
-      <div class="js-receipt"></div>
-      <% if (ob.hasModerators) { %>
-        <hr class="clrBr js-moderatorNote">
-        <div class="padSm txSm txCtr clrT2 js-moderatorNote">
-          <%= ob.polyT('purchase.moderatorNote') %>
-        </div>
-      <% } %>
-    </section>
-  </div>
-</div>
+
+<% } else { %>
+<div class="loadingPurchase clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
+<% } %>
 

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -96,8 +96,11 @@ const totalPrice = ob.prices[0].price + ob.prices[0].vPrice;
                 <p class="clrTErr hide js-noValidModerators">
                   <%= ob.polyT('purchase.noValidModerators') %>
                 </p>
-                <p class="clrTErr hide js-modsNotAllowed">
-                  <%= ob.polyT('purchase.tooLowForMods') %>
+                <p class="clrTErr tx5b hide js-modsNotAllowed">
+                  <%
+                  const minModPrice = ob.convertAndFormatCurrency(ob.minModPrice, 'BTC', ob.displayCurrency);
+                  %>
+                  <%= ob.polyT('purchase.tooLowForMods', { minModPrice }) %>
                 </p>
               <% } %>
             </div>

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -7,186 +7,202 @@ const totalPrice = ob.prices[0].price + ob.prices[0].vPrice;
 
 <% if (!ob.isFetching) { %>
 
-  <div class="topControls gutterHSm flex">
-    <% if (ob.vendor) { %>
-    <div class="contentBox clrP clrSh3 clrBr clrT">
-      <div class="padSm gutterHSm overflowAuto margRSm flexVCent">
-        <a class="clrBr2 clrSh1 discTn flexNoShrink" style="<%= ob.getAvatarBgImage(ob.vendor.avatar) %>"></a>
-        <p class="txUnl tx3 clamp"><%= ob.vendor.name %></p>
-        <a class="link flexNoShrink tx6 js-goToListing"><% print(ob.polyT('purchase.returnToListing')) %></a>
-      </div>
-    </div>
-    <% } %>
-  </div>
+  <% if(!ob.fetchFailed) { %>
 
-  <div class="flexRow gutterH">
-    <div class="col9">
-      <div class="flexColRow gutterV">
-        <% // to support multiple items in a purchase, loop this section %>
-        <section class="contentBox pad clrP clrBr clrSh3">
-          <div class="js-errors"></div>
-          <div class="js-items-quantity-errors"></div>
-          <div class="flexVCent gutterH">
-            <div class="thumb" style="<%= ob.getListingBgImage(ob.listing.item.images[0]) %>"></div>
-            <div class="flexExpand">
-              <div class="flexCol gutterVTn">
-                <div class="width100 noOverflow">
-                  <b><%= ob.listing.item.title %></b>
-                </div>
-                <% ob.variants.forEach(variant => { %>
-                  <div class="width100 noOverflow">
-                    <span class="clrT2"><%= variant.name %>: <%= variant.value %></span>
-                  </div>
-                <% }); %>
-              </div>
-            </div>
-            <div class="showIfPay flexNoShrink">
-              <div class="flexVCent gutterHSm">
-                <label class="flexNoShrink" for="purchaseQuantity">
-                  <%= ob.polyT('purchase.quantity') %>
-                </label>
-                <input
-                    class="clrBr clrP"
-                    type="text"
-                    id="purchaseQuantity"
-                    size="3"
-                    name="quantity"
-                    value="1"
-                    data-var-type="number">
-              </div>
-            </div>
-            <div class="pad flexNoShrink">
-              <b>
-                <%= ob.convertAndFormatCurrency(totalPrice, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
-              </b>
-            </div>
-          </div>
-        </section>
-        <% if (ob.listing.shippingOptions && ob.listing.shippingOptions.length) { %>
-          <section class="contentBox padMd clrP clrBr clrSh3 showIfPay js-shipping">
-            <div class="js-shipping-errors js-items-shipping-errors"></div>
-            <div class="js-shippingWrapper"></div>
-          </section>
-        <% } %>
-        <section class="contentBox padMd clrP clrBr clrSh3 showIfPay">
-          <div class="flexColRows gutterVSm">
-            <h2 class="h4 required"><%= ob.polyT('purchase.paymentTypeTitle') %></h2>
-            <div class="contentBox pad clrP clrBr flexVCent">
-              <i class="btcIcon margRSm"></i>
+    <div class="topControls gutterHSm flex">
+      <% if (ob.vendor) { %>
+      <div class="contentBox clrP clrSh3 clrBr clrT">
+        <div class="padSm gutterHSm overflowAuto margRSm flexVCent">
+          <a class="clrBr2 clrSh1 discTn flexNoShrink" style="<%= ob.getAvatarBgImage(ob.vendor.avatar) %>"></a>
+          <p class="txUnl tx3 clamp"><%= ob.vendor.name %></p>
+          <a class="link flexNoShrink tx6 js-goToListing"><% print(ob.polyT('purchase.returnToListing')) %></a>
+        </div>
+      </div>
+      <% } %>
+    </div>
+
+    <div class="flexRow gutterH">
+      <div class="col9">
+        <div class="flexColRow gutterV">
+          <% // to support multiple items in a purchase, loop this section %>
+          <section class="contentBox pad clrP clrBr clrSh3">
+            <div class="js-errors"></div>
+            <div class="js-items-quantity-errors"></div>
+            <div class="flexVCent gutterH">
+              <div class="thumb" style="<%= ob.getListingBgImage(ob.listing.item.images[0]) %>"></div>
               <div class="flexExpand">
-                <%= ob.polyT('currencies.BTC') %>
+                <div class="flexCol gutterVTn">
+                  <div class="width100 noOverflow">
+                    <b><%= ob.listing.item.title %></b>
+                  </div>
+                  <% ob.variants.forEach(variant => { %>
+                    <div class="width100 noOverflow">
+                      <span class="clrT2"><%= variant.name %>: <%= variant.value %></span>
+                    </div>
+                  <% }); %>
+                </div>
               </div>
-              <div class="tx6 clrT2 margRSm"><%= ob.polyT('purchase.useShapeShift') %></div>
-              <i class="shapeShiftIcon" style="background-image: url('../imgs/shapeShiftIcon.png');"></i>
+              <div class="showIfPay flexNoShrink">
+                <div class="flexVCent gutterHSm">
+                  <label class="flexNoShrink" for="purchaseQuantity">
+                    <%= ob.polyT('purchase.quantity') %>
+                  </label>
+                  <input
+                      class="clrBr clrP"
+                      type="text"
+                      id="purchaseQuantity"
+                      size="3"
+                      name="quantity"
+                      value="1"
+                      data-var-type="number">
+                </div>
+              </div>
+              <div class="pad flexNoShrink">
+                <b>
+                  <%= ob.convertAndFormatCurrency(totalPrice, ob.listing.metadata.pricingCurrency, ob.displayCurrency) %>
+                </b>
+              </div>
             </div>
-            <% if (ob.hasModerators) { %>
-              <div class="js-moderatedOption">
-                <input
-                    type="checkbox"
-                    name="moderated"
-                    checked
-                    id="purchaseModerated">
-                <label for="purchaseModerated"><%= ob.polyT('purchase.moderatedPayment') %></label>
-                <p class="clrT2 tx6">
-                  <%= ob.polyT('purchase.moderationDisclaimer') %>
-                </p>
-              </div>
-              <p class="clrTErr hide js-noValidModerators">
-                <%= ob.polyT('purchase.noValidModerators') %>
-              </p>
-            <% } %>
-          </div>
-        </section>
-        <% if (ob.hasModerators) { %>
-          <section class="contentBox padMd clrP clrBr clrSh3 showIfPay js-moderator">
-            <h2 class="h4"><%= ob.polyT('purchase.moderatorTitle') %></h2>
-            <div class="js-moderated-errors"></div>
-            <div class="js-moderatorsWrapper"></div>
           </section>
-        <% } %>
-        <section class="contentBox padMd clrP clrBr clrSh3 showIfPay">
-          <h2 class="h4">
-            <%= ob.polyT('purchase.informationTitle') %>
-            <span class="clrT2 txUnb tx5b"><%= ob.polyT('purchase.optional') %></span>
-          </h2>
-          <div class="flexRow gutterH row">
-            <div class="col6">
-              <div class="rowTn">
-                <label for="emailAddress" class="tx5">
-                  <%= ob.polyT('purchase.emailAddress') %>
-                </label>
+          <% if (ob.listing.shippingOptions && ob.listing.shippingOptions.length) { %>
+            <section class="contentBox padMd clrP clrBr clrSh3 showIfPay js-shipping">
+              <div class="js-shipping-errors js-items-shipping-errors"></div>
+              <div class="js-shippingWrapper"></div>
+            </section>
+          <% } %>
+          <section class="contentBox padMd clrP clrBr clrSh3 showIfPay">
+            <div class="flexColRows gutterVSm">
+              <h2 class="h4 required"><%= ob.polyT('purchase.paymentTypeTitle') %></h2>
+              <div class="contentBox pad clrP clrBr flexVCent">
+                <i class="btcIcon margRSm"></i>
+                <div class="flexExpand">
+                  <%= ob.polyT('currencies.BTC') %>
+                </div>
+                <div class="tx6 clrT2 margRSm"><%= ob.polyT('purchase.useShapeShift') %></div>
+                <i class="shapeShiftIcon" style="background-image: url('../imgs/shapeShiftIcon.png');"></i>
               </div>
-              <div>
-                <input
-                    class="btnHeight clrBr clrP js-purchaseField"
-                    type="text"
-                    id="emailAddress"
-                    name="alternateContactInfo"
-                    placeholder="<%= ob.polyT('purchase.emailPlaceholder') %>"
-                    value="<%= ob.alternateContactInfo %>">
+              <% if (ob.hasModerators) { %>
+                <div class="js-moderatedOption">
+                  <input
+                      type="checkbox"
+                      name="moderated"
+                      checked
+                      id="purchaseModerated">
+                  <label for="purchaseModerated"><%= ob.polyT('purchase.moderatedPayment') %></label>
+                  <p class="clrT2 tx6">
+                    <%= ob.polyT('purchase.moderationDisclaimer') %>
+                  </p>
+                </div>
+                <p class="clrTErr hide js-noValidModerators">
+                  <%= ob.polyT('purchase.noValidModerators') %>
+                </p>
+              <% } %>
+            </div>
+          </section>
+          <% if (ob.hasModerators) { %>
+            <section class="contentBox padMd clrP clrBr clrSh3 showIfPay js-moderator">
+              <h2 class="h4"><%= ob.polyT('purchase.moderatorTitle') %></h2>
+              <div class="js-moderated-errors"></div>
+              <div class="js-moderatorsWrapper"></div>
+            </section>
+          <% } %>
+          <section class="contentBox padMd clrP clrBr clrSh3 showIfPay">
+            <h2 class="h4">
+              <%= ob.polyT('purchase.informationTitle') %>
+              <span class="clrT2 txUnb tx5b"><%= ob.polyT('purchase.optional') %></span>
+            </h2>
+            <div class="flexRow gutterH row">
+              <div class="col6">
+                <div class="rowTn">
+                  <label for="emailAddress" class="tx5">
+                    <%= ob.polyT('purchase.emailAddress') %>
+                  </label>
+                </div>
+                <div>
+                  <input
+                      class="btnHeight clrBr clrP js-purchaseField"
+                      type="text"
+                      id="emailAddress"
+                      name="alternateContactInfo"
+                      placeholder="<%= ob.polyT('purchase.emailPlaceholder') %>"
+                      value="<%= ob.alternateContactInfo %>">
+                </div>
+                <div>
+                  <span class="txSm clrT2"><%= ob.polyT('purchase.emailNote') %></span>
+                </div>
               </div>
-              <div>
-                <span class="txSm clrT2"><%= ob.polyT('purchase.emailNote') %></span>
+              <div class="col6">
+                <div class="rowTn">
+                  <label for="couponCode" class="tx5">
+                    <%= ob.polyT('purchase.couponCode') %>
+                  </label>
+                </div>
+                <div class="flex gutterH row">
+                  <input
+                      class="btnHeight clrBr clrP"
+                      type="text"
+                      id="couponCode"
+                      name="couponCode"
+                      placeholder="<%= ob.polyT('purchase.couponCodePlaceholder') %>">
+                  <button class="btn clrP clrBr clrSh2 js-applyCoupon">
+                    <%= ob.polyT('purchase.applyCode') %>
+                  </button>
+                </div>
+                <div class="js-couponsWrapper">
+                  <% // coupons are inserted here after they are added by the user. %>
+                </div>
               </div>
             </div>
-            <div class="col6">
-              <div class="rowTn">
-                <label for="couponCode" class="tx5">
-                  <%= ob.polyT('purchase.couponCode') %>
-                </label>
-              </div>
-              <div class="flex gutterH row">
-                <input
-                    class="btnHeight clrBr clrP"
-                    type="text"
-                    id="couponCode"
-                    name="couponCode"
-                    placeholder="<%= ob.polyT('purchase.couponCodePlaceholder') %>">
-                <button class="btn clrP clrBr clrSh2 js-applyCoupon">
-                  <%= ob.polyT('purchase.applyCode') %>
-                </button>
-              </div>
-              <div class="js-couponsWrapper">
-                <% // coupons are inserted here after they are added by the user. %>
-              </div>
+            <hr class="clrBr row">
+            <div class="rowTn">
+              <label for="memo" class="tx5">
+                <%= ob.polyT('purchase.memo') %>
+              </label>
             </div>
-          </div>
-          <hr class="clrBr row">
-          <div class="rowTn">
-            <label for="memo" class="tx5">
-              <%= ob.polyT('purchase.memo') %>
-            </label>
-          </div>
-          <textarea
-              class="clrBr clrP js-purchaseField"
-              id="memo"
-              name="memo"
-              maxlength="5000"
-              rows="6"
-              placeholder="<%= ob.polyT('purchase.memoPlaceholder') %>"><%= ob.memo %></textarea>
-        </section>
-        <section class="contentBox padMd clrP clrBr clrSh3 showIfPending js-pending">
-        </section>
-        <section class="contentBox padMd clrP clrBr clrSh3 showIfComplete js-complete">
+            <textarea
+                class="clrBr clrP js-purchaseField"
+                id="memo"
+                name="memo"
+                maxlength="5000"
+                rows="6"
+                placeholder="<%= ob.polyT('purchase.memoPlaceholder') %>"><%= ob.memo %></textarea>
+          </section>
+          <section class="contentBox padMd clrP clrBr clrSh3 showIfPending js-pending">
+          </section>
+          <section class="contentBox padMd clrP clrBr clrSh3 showIfComplete js-complete">
+          </section>
+        </div>
+      </div>
+      <div class="col3">
+        <section class="contentBox pad clrP clrBr clrSh3 sidebar">
+          <i class="js-close cornerTR ion-ios-close-empty iconBtn clrP clrBr clrSh3 closeBtn"></i>
+          <div class="js-actionBtn"></div>
+          <div class="js-receipt"></div>
+          <% if (ob.hasModerators) { %>
+            <hr class="clrBr js-moderatorNote">
+            <div class="padSm txSm txCtr clrT2 js-moderatorNote">
+              <%= ob.polyT('purchase.moderatorNote') %>
+            </div>
+          <% } %>
         </section>
       </div>
     </div>
-    <div class="col3">
-      <section class="contentBox pad clrP clrBr clrSh3 sidebar">
-        <i class="js-close cornerTR ion-ios-close-empty iconBtn clrP clrBr clrSh3 closeBtn"></i>
-        <div class="js-actionBtn"></div>
-        <div class="js-receipt"></div>
-        <% if (ob.hasModerators) { %>
-          <hr class="clrBr js-moderatorNote">
-          <div class="padSm txSm txCtr clrT2 js-moderatorNote">
-            <%= ob.polyT('purchase.moderatorNote') %>
-          </div>
-        <% } %>
-      </section>
+  <% } else { %>
+    <div class="centerMsg">
+      <div class="contentBox padLg flexColRows flexHCent clrP clrBr">
+        <div class="rowLg">
+          <h2 class="rowLg"><%= ob.polyT('purchase.errors.feesFailed') %></h2>
+          <p><%= ob.fetchError %></p>
+        </div>
+        <div class="flexHCent gutterH">
+          <button class="btn clrP clrBr js-goToListing">Cancel</button>
+          <button class="btn clrP clrBr js-retryFee">Retry</button>
+        </div>
+      </div>
     </div>
-  </div>
+  <% } %>
 
 <% } else { %>
-<div class="loadingPurchase clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
+  <div class="loadingPurchase clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
 <% } %>
 

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -96,6 +96,9 @@ const totalPrice = ob.prices[0].price + ob.prices[0].vPrice;
                 <p class="clrTErr hide js-noValidModerators">
                   <%= ob.polyT('purchase.noValidModerators') %>
                 </p>
+                <p class="clrTErr hide js-modsNotAllowed">
+                  <%= ob.polyT('purchase.tooLowForMods') %>
+                </p>
               <% } %>
             </div>
           </section>

--- a/js/templates/modals/purchase/receipt.html
+++ b/js/templates/modals/purchase/receipt.html
@@ -4,12 +4,12 @@
   const listingCurrency = ob.listing.metadata.pricingCurrency;
   const viewingCurrency = ob.displayCurrency;
   const isBTC = viewingCurrency === 'BTC';
-  ob.items.forEach((item, i) => {
+  ob.prices.forEach((priceObj, i) => {
     // convert and truncate the prices here, to prevent rounding errors in the display
-    const basePrice = Number(ob.formatPrice(ob.convertCurrency(ob.prices[i].price, listingCurrency, viewingCurrency), isBTC));
-    const shippingPrice = Number(ob.formatPrice(ob.convertCurrency(ob.prices[i].sPrice, listingCurrency, viewingCurrency), isBTC));
-    const surcharge = Number(ob.formatPrice(ob.convertCurrency(ob.prices[i].vPrice, listingCurrency, viewingCurrency), isBTC));
-    const quantity = Number.isInteger(item.quantity) ? item.quantity : 1;
+    const basePrice = Number(ob.formatPrice(ob.convertCurrency(priceObj.price, listingCurrency, viewingCurrency), isBTC));
+    const shippingPrice = Number(ob.formatPrice(ob.convertCurrency(priceObj.sPrice, listingCurrency, viewingCurrency), isBTC));
+    const surcharge = Number(ob.formatPrice(ob.convertCurrency(priceObj.vPrice, listingCurrency, viewingCurrency), isBTC));
+const quantity = Number.isInteger(ob.items[i].quantity) ? ob.items[i].quantity : 1;
     let itemTotal = basePrice + surcharge;
     const preCouponPrice = itemTotal;
     ob.coupons.forEach((coupon) => {

--- a/js/templates/modals/purchase/receipt.html
+++ b/js/templates/modals/purchase/receipt.html
@@ -9,7 +9,7 @@
     const basePrice = Number(ob.formatPrice(ob.convertCurrency(priceObj.price, listingCurrency, viewingCurrency), isBTC));
     const shippingPrice = Number(ob.formatPrice(ob.convertCurrency(priceObj.sPrice, listingCurrency, viewingCurrency), isBTC));
     const surcharge = Number(ob.formatPrice(ob.convertCurrency(priceObj.vPrice, listingCurrency, viewingCurrency), isBTC));
-const quantity = Number.isInteger(ob.items[i].quantity) ? ob.items[i].quantity : 1;
+    const quantity = Number.isInteger(priceObj.quantity) ? priceObj.quantity : 1;
     let itemTotal = basePrice + surcharge;
     const preCouponPrice = itemTotal;
     ob.coupons.forEach((coupon) => {

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -426,6 +426,11 @@ export default class extends BaseModal {
       vendor: this.vendor,
       removeOnClose: true,
       showCloseButton: false,
+      initialState: {
+        isFetching: true,
+        fetchError: '',
+        fetchFailed: false,
+      },
     })
       .render()
       .open();

--- a/js/views/modals/purchase/Moderators.js
+++ b/js/views/modals/purchase/Moderators.js
@@ -64,14 +64,15 @@ export default class extends baseVw {
       `ob/${op.apiPath}?async=${op.async}${includeString}&usecache=${op.useCache}`;
     const url = app.getServerUrl(urlString);
 
+    if (this.fetch && this.fetch.state() === 'pending') return;
+
     this.notFetchedYet = IDs;
     this.fetchingMods = IDs;
     if (IDs.length) {
       this.$moderatorsStatus.removeClass('hide').text(app.polyglot.t('moderators.moderatorsLoading',
           { remaining: IDs.length, total: IDs.length }));
     }
-    // if somehow a new fetch is started while one is in progress, abort it.
-    if (this.fetch) this.fetch.abort();
+
     // Either a list of IDs can be posted, or any available moderators can be retrieved with GET
     if (IDs.length || this.options.method === 'GET') {
       this.$moderatorsWrapper.addClass('processing');
@@ -145,9 +146,12 @@ export default class extends baseVw {
 
   checkNotFetched() {
     const nfYet = this.notFetchedYet.length;
+    // if at least one mod has loaded, remove the spinner
+    if (nfYet < this.fetchingMods.length) {
+      this.$moderatorsWrapper.removeClass('processing');
+    }
     if (nfYet === 0) {
       // all ids have been fetced
-      this.$moderatorsWrapper.removeClass('processing');
       this.$moderatorsStatus.addClass('hide').text('');
       // check if none of the loaded moderators are valid
       if (!this.moderatorsCol.length) {

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -189,7 +189,7 @@ export default class extends BaseModal {
       .done((data, status, xhr) => {
         if (xhr.statusText === 'abort') return;
         const feePerByte = data[app.localSettings.get('defaultTransactionFee').toLowerCase()];
-        this.minModPrice = feePerByte * 350 / 100000000;
+        this.estFee = feePerByte * 184 / 100000000;
         this.setState({
           isFetching: false,
           fetchError: false,
@@ -464,7 +464,7 @@ export default class extends BaseModal {
     if (cur !== 'BTC') {
       btcTotal = convertCurrency(btcTotal, cur, 'BTC');
     }
-    const tooLow = btcTotal < this.minModPrice;
+    const tooLow = btcTotal < this.estFee * 10;
     this.toggleModeration(!tooLow);
     this.getCachedEl('.js-modsNotAllowed').toggleClass('hide', !tooLow);
   }

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -189,7 +189,8 @@ export default class extends BaseModal {
       .done((data, status, xhr) => {
         if (xhr.statusText === 'abort') return;
         const feePerByte = data[app.localSettings.get('defaultTransactionFee').toLowerCase()];
-        this.estFee = feePerByte * 184 / 100000000;
+        const estFee = feePerByte * 184 / 100000000;
+        this.minModPrice = estFee * 10;
         this.setState({
           isFetching: false,
           fetchError: false,
@@ -464,7 +465,7 @@ export default class extends BaseModal {
     if (cur !== 'BTC') {
       btcTotal = convertCurrency(btcTotal, cur, 'BTC');
     }
-    const tooLow = btcTotal < this.estFee * 10;
+    const tooLow = btcTotal < this.minModPrice;
     this.toggleModeration(!tooLow);
     this.getCachedEl('.js-modsNotAllowed').toggleClass('hide', !tooLow);
   }
@@ -523,6 +524,7 @@ export default class extends BaseModal {
         variants: this.variants,
         items: this.order.get('items').toJSON(),
         prices: this.prices,
+        minModPrice: this.minModPrice,
         displayCurrency: app.settings.get('localCurrency'),
         hasModerators: this.moderatorIDs.length,
       }));

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -5,7 +5,7 @@ import '../../../utils/velocity';
 import app from '../../../app';
 import loadTemplate from '../../../utils/loadTemplate';
 import { launchSettingsModal } from '../../../utils/modalManager';
-import { convertCurrency} from '../../../utils/currency';
+import { convertCurrency } from '../../../utils/currency';
 import { openSimpleMessage } from '../SimpleMessage';
 import BaseModal from '../BaseModal';
 import Order from '../../../models/purchase/Order';

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -4,6 +4,9 @@ import '../../../lib/select2';
 import '../../../utils/velocity';
 import app from '../../../app';
 import loadTemplate from '../../../utils/loadTemplate';
+import { launchSettingsModal } from '../../../utils/modalManager';
+import { convertCurrency} from '../../../utils/currency';
+import { openSimpleMessage } from '../SimpleMessage';
 import BaseModal from '../BaseModal';
 import Order from '../../../models/purchase/Order';
 import Item from '../../../models/purchase/Item';
@@ -17,9 +20,7 @@ import Coupons from './Coupons';
 import ActionBtn from './ActionBtn';
 import Payment from './Payment';
 import Complete from './Complete';
-import { launchSettingsModal } from '../../../utils/modalManager';
-import { openSimpleMessage } from '../SimpleMessage';
-import { convertCurrency} from "../../../utils/currency";
+import FeeChange from '../../components/FeeChange';
 
 
 export default class extends BaseModal {
@@ -557,6 +558,10 @@ export default class extends BaseModal {
 
       this.complete.delegateEvents();
       this.$('.js-complete').append(this.complete.render().el);
+
+      if (this.feeChange) this.feeChange.remove();
+      this.feeChange = this.createChild(FeeChange);
+      this.$('.js-feeChangeContainer').html(this.feeChange.render().el);
 
       this.isModAllowed();
     });

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -557,7 +557,7 @@ export default class extends BaseModal {
 
       this.moderators.delegateEvents();
       this.$('.js-moderatorsWrapper').append(this.moderators.render().el);
-      this.moderators.getModeratorsByID();
+      if (!state.isFetching) this.moderators.getModeratorsByID();
 
       if (this.shipping) {
         this.shipping.delegateEvents();

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -246,13 +246,15 @@ export default class extends BaseModal {
 
   toggleModeration(bool) {
     this.getCachedEl('.js-moderatedOption').toggleClass('disabled', !bool);
-    this.getCachedEl('.js-moderator').toggleClass('hide', !bool);
-    this.getCachedEl('.js-moderatorNote').toggleClass('hide', !bool);
+    // when the state is changed, always hide the following. They are unhidden by checking the
+    // moderated payment option
+    this.getCachedEl('.js-moderator').addClass('hide');
+    this.getCachedEl('.js-moderatorNote').addClass('hide');
     if (!bool) this.disableModerators();
   }
 
   onNoValidModerators() {
-    this.disableModerators();
+    this.toggleModeration(false);
     this.getCachedEl('.js-noValidModerators').removeClass('hide');
   }
 

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -125,9 +125,9 @@ export default class extends BaseModal {
 
     this.listenTo(app.settings, 'change:localCurrency', () => this.showDataChangedMessage());
     this.listenTo(app.localSettings, 'change:bitcoinUnit', () => this.showDataChangedMessage());
-    this.listenTo(this.order.get('items').at(0), 'change', () => this.isModAllowed());
+    this.listenTo(this.order.get('items').at(0), 'change', () => this.refreshPrices());
     this.listenTo(this.order.get('items').at(0).get('shipping'), 'change', () =>
-      this.isModAllowed());
+      this.refreshPrices());
   }
 
   className() {
@@ -247,7 +247,7 @@ export default class extends BaseModal {
 
   toggleModeration(bool) {
     this.getCachedEl('.js-moderatedOption').toggleClass('disabled', !bool);
-    // when the state is changed, always hide the following. They are unhidden by checking the
+    // when the visibility is changed, always hide the following. They are unhidden by checking the
     // moderated payment option
     this.getCachedEl('.js-moderator').addClass('hide');
     this.getCachedEl('.js-moderatorNote').addClass('hide');
@@ -307,7 +307,6 @@ export default class extends BaseModal {
     this.order.get('items').at(0).get('shipping')
       .set(opts);
     this.actionBtn.render();
-    this.receipt.updatePrices(this.prices);
   }
 
   updatePageState(state) {
@@ -468,6 +467,11 @@ export default class extends BaseModal {
     const tooLow = btcTotal < this.minModPrice;
     this.toggleModeration(!tooLow);
     this.getCachedEl('.js-modsNotAllowed').toggleClass('hide', !tooLow);
+  }
+
+  refreshPrices() {
+    this.isModAllowed();
+    this.receipt.updatePrices(this.prices);
   }
 
   get $popInMessages() {

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -125,7 +125,7 @@ export default class extends BaseModal {
 
     this.listenTo(app.settings, 'change:localCurrency', () => this.showDataChangedMessage());
     this.listenTo(app.localSettings, 'change:bitcoinUnit', () => this.showDataChangedMessage());
-    this.listenTo(this.order.get('items').at(0), 'change', () => this.refreshPrices());
+    this.listenTo(this.order.get('items').at(0), 'someChange ', () => this.refreshPrices());
     this.listenTo(this.order.get('items').at(0).get('shipping'), 'change', () =>
       this.refreshPrices());
   }
@@ -140,7 +140,7 @@ export default class extends BaseModal {
 
   events() {
     return {
-      'click .js-goToListing': 'close',
+      'click .js-goToListing': 'clickGoToListing',
       'click .js-close': 'clickClose',
       'click .js-retryFee': 'clickRetryFee',
       'click #purchaseModerated': 'clickModerated',
@@ -213,6 +213,16 @@ export default class extends BaseModal {
     this.getFees();
   }
 
+  goToListing() {
+    app.router.navigate(`${this.vendor.peerID}/store/${this.listing.get('slug')}`,
+      { trigger: true });
+    this.close();
+  }
+
+  clickGoToListing() {
+    this.goToListing();
+  }
+
   clickClose() {
     this.trigger('closeBtnPressed');
     this.close();
@@ -248,10 +258,8 @@ export default class extends BaseModal {
 
   toggleModeration(bool) {
     this.getCachedEl('.js-moderatedOption').toggleClass('disabled', !bool);
-    // when the visibility is changed, always hide the following. They are unhidden by checking the
-    // moderated payment option
-    this.getCachedEl('.js-moderator').addClass('hide');
-    this.getCachedEl('.js-moderatorNote').addClass('hide');
+    this.getCachedEl('.js-moderator').toggleClass('hide', !bool);
+    this.getCachedEl('.js-moderatorNote').toggleClass('hide', !bool);
     if (!bool) this.disableModerators();
   }
 

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -246,8 +246,7 @@ export default class extends BaseModal {
     this.order.get('items').at(0).get('shipping')
       .set(opts);
     this.actionBtn.render();
-    this.receipt.prices = this.prices;
-    this.receipt.render();
+    this.receipt.updatePrices(this.prices);
   }
 
   updatePageState(state) {

--- a/js/views/modals/purchase/Receipt.js
+++ b/js/views/modals/purchase/Receipt.js
@@ -7,8 +7,6 @@ import Listing from '../../../models/listing/Listing';
 export default class extends BaseView {
   constructor(options = {}) {
     super(options);
-    this.options = options;
-    this._coupons = [];
 
     if (!this.model || !(this.model instanceof Order)) {
       throw new Error('Please provide an order model');
@@ -22,10 +20,12 @@ export default class extends BaseView {
       throw new Error('Please provide the prices array');
     }
 
+    this.options = options;
+    this._coupons = options.couponObj || [];
+
     this.prices = options.prices;
 
     this.listenTo(this.model.get('items').at(0), 'change', () => this.render());
-    this.listenTo(this.model.get('items').at(0).get('shipping'), 'change', () => this.render());
   }
 
   className() {
@@ -36,19 +36,15 @@ export default class extends BaseView {
     return this._coupons;
   }
 
+  set coupons(coupons) {
+    this._coupons = coupons;
+  }
+
   updatePrices(prices) {
     if (prices !== this.prices) {
       this.prices = prices;
       this.render();
     }
-  }
-
-  set coupons(hashesAndCodes) {
-    // when we implement multiple items, the coupons should go into an array that mirrors the itmes
-    // if this is the user's own listing, the listing object only has the codes
-    const filteredCoupons = this.options.listing.get('coupons').filter((coupon) =>
-    hashesAndCodes.indexOf(coupon.get('hash') || coupon.get('discountCode')) !== -1);
-    this._coupons = filteredCoupons.map(coupon => coupon.toJSON());
   }
 
   render() {

--- a/js/views/modals/purchase/Receipt.js
+++ b/js/views/modals/purchase/Receipt.js
@@ -36,6 +36,13 @@ export default class extends BaseView {
     return this._coupons;
   }
 
+  updatePrices(prices) {
+    if (prices !== this.prices) {
+      this.prices = prices;
+      this.render();
+    }
+  }
+
   set coupons(hashesAndCodes) {
     // when we implement multiple items, the coupons should go into an array that mirrors the itmes
     // if this is the user's own listing, the listing object only has the codes

--- a/js/views/modals/purchase/Receipt.js
+++ b/js/views/modals/purchase/Receipt.js
@@ -24,8 +24,6 @@ export default class extends BaseView {
     this._coupons = options.couponObj || [];
 
     this.prices = options.prices;
-
-    this.listenTo(this.model.get('items').at(0), 'change', () => this.render());
   }
 
   className() {

--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -62,6 +62,7 @@ export default class extends baseView {
     if (userAddresses.length) {
       this.selectedAddress = userAddresses.at(0);
       this.shippingOptions.countryCode = this.selectedAddress.get('country');
+      this.shippingOptions.delegateEvents();
       this.$('.js-shippingOptionsWrapper').html(this.shippingOptions.render().el);
     } else {
       this.selectedAddress = null;

--- a/styles/modules/modals/_purchase.scss
+++ b/styles/modules/modals/_purchase.scss
@@ -91,7 +91,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    position: absolute;
+    position: fixed;
+    left: 0;
+    top: 0;
     width: 100%;
     height: 100%;
   }

--- a/styles/modules/modals/_purchase.scss
+++ b/styles/modules/modals/_purchase.scss
@@ -86,4 +86,17 @@
       top: -42px;
     }
   }
+
+  .loadingPurchase {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+  }
+
+
+
+
 }


### PR DESCRIPTION
This will check the total price of the current order on the purchase page, and if it's below the required total, disable the option to select a moderator.

This also fixes a bug where changing the shipping option did not update the receipt.

Closes #852 
Closes #795 
Closes #908