### PR TITLE
Enable fullscreen for Mac

### DIFF
--- a/js/views/PageNav.js
+++ b/js/views/PageNav.js
@@ -225,19 +225,7 @@ export default class extends BaseVw {
   }
 
   navMaxClick() {
-    if (remote.process.platform === 'darwin') {
-      if (remote.getCurrentWindow().isFullScreen()) {
-        remote.getCurrentWindow().setFullScreen(false);
-      } else {
-        remote.getCurrentWindow().setFullScreen(true);
-      }
-    } else {
-      if (remote.getCurrentWindow().isMaximized()) {
-        remote.getCurrentWindow().unmaximize();
-      } else {
-        remote.getCurrentWindow().maximize();
-      }
-    }
+    remote.getCurrentWindow().setFullScreen(!remote.getCurrentWindow().isFullScreen());
   }
 
   onRouteSearch() {

--- a/js/views/PageNav.js
+++ b/js/views/PageNav.js
@@ -223,7 +223,7 @@ export default class extends BaseVw {
   navMinClick() {
     remote.getCurrentWindow().minimize();
   }
-  
+
   navMaxClick() {
     if (remote.process.platform === 'darwin') {
       if (remote.getCurrentWindow().isFullScreen()) {

--- a/js/views/PageNav.js
+++ b/js/views/PageNav.js
@@ -223,12 +223,20 @@ export default class extends BaseVw {
   navMinClick() {
     remote.getCurrentWindow().minimize();
   }
-
+  
   navMaxClick() {
-    if (remote.getCurrentWindow().isMaximized()) {
-      remote.getCurrentWindow().unmaximize();
+    if (remote.process.platform === 'darwin') {
+      if (remote.getCurrentWindow().isFullScreen()) {
+        remote.getCurrentWindow().setFullScreen(false);
+      } else {
+        remote.getCurrentWindow().setFullScreen(true);
+      }
     } else {
-      remote.getCurrentWindow().maximize();
+      if (remote.getCurrentWindow().isMaximized()) {
+        remote.getCurrentWindow().unmaximize();
+      } else {
+        remote.getCurrentWindow().maximize();
+      }
     }
   }
 


### PR DESCRIPTION
The green maximise button in macOS makes native apps go fullscreen. Previously a generic maximise function was being used, which works for Linux, Mac, and Windows, which worked but it was weird for Mac users.

This commit uses the fullscreen function if the OS is a Mac.