### PR TITLE
Fixing the issue where an invalid address was being added to the UI

### DIFF
--- a/js/views/modals/Settings/Addresses.js
+++ b/js/views/modals/Settings/Addresses.js
@@ -106,7 +106,7 @@ export default class extends baseVw {
     model.set(formData, { validate: true });
     this.settings.set({}, { validate: true });
 
-    if (!this.settings.validationError) {
+    if (!this.settings.validationError && !model.validationError) {
       const shippingAddresses = this.settings.get('shippingAddresses');
 
       shippingAddresses.push(model);
@@ -170,7 +170,7 @@ export default class extends baseVw {
     // render so errors are shown / cleared
     this.addressForm.render();
 
-    if (this.settings.validationError) {
+    if (this.settings.validationError || model.validationError) {
       const $firstFormErr = this.$('.js-formContainer .errorList:first');
 
       if ($firstFormErr.length) {


### PR DESCRIPTION
Fixes an issue where, in settings, if you attempted to add an address with errors (e.g. no name), the invalid address would be added to the UI even though the form would show the error. It would prevent you from adding a valid address until you restarted.