### PR TITLE
Purchase mod patch

### DIFF
--- a/js/templates/modals/purchase/moderators.html
+++ b/js/templates/modals/purchase/moderators.html
@@ -1,4 +1,7 @@
 <div class="moderatorsWrapper boxProcessingFaded clrBr js-moderatorsWrapper">
   <%= ob.spinner() %>
 </div>
-<div class="moderatorsStatus clrT4 tx6 js-moderatorsStatus"></div>
+<div class="moderatorsStatus flexVCent flexHCent gutterHTn tx6 js-moderatorsStatus">
+  <%= ob.spinner({ className: 'spinnerTxt' }) %>
+  <span class="clrT4 js-moderatorStatusInner"></span>
+</div>

--- a/js/views/modals/purchase/Moderators.js
+++ b/js/views/modals/purchase/Moderators.js
@@ -69,7 +69,8 @@ export default class extends baseVw {
     this.notFetchedYet = IDs;
     this.fetchingMods = IDs;
     if (IDs.length) {
-      this.$moderatorsStatus.removeClass('hide').text(app.polyglot.t('moderators.moderatorsLoading',
+      this.$moderatorsStatus.removeClass('hide');
+      this.$moderatorStatusText.text(app.polyglot.t('moderators.moderatorsLoading',
           { remaining: IDs.length, total: IDs.length }));
     }
 
@@ -152,13 +153,14 @@ export default class extends baseVw {
     }
     if (nfYet === 0) {
       // all ids have been fetced
-      this.$moderatorsStatus.addClass('hide').text('');
+      this.$moderatorsStatus.addClass('hide');
+      this.$moderatorStatusText.text('');
       // check if none of the loaded moderators are valid
       if (!this.moderatorsCol.length) {
         this.trigger('noValidModerators');
       }
     } else {
-      this.$moderatorsStatus.text(app.polyglot.t('moderators.moderatorsLoading',
+      this.$moderatorStatusText.text(app.polyglot.t('moderators.moderatorsLoading',
           { remaining: nfYet, total: this.fetchingMods.length }));
     }
   }
@@ -220,6 +222,7 @@ export default class extends baseVw {
       super.render();
       this.$moderatorsWrapper = this.$('.js-moderatorsWrapper');
       this.$moderatorsStatus = this.$('.js-moderatorsStatus');
+      this.$moderatorStatusText = this.$('.js-moderatorStatusInner');
     });
 
     return this;

--- a/js/views/modals/purchase/Moderators.js
+++ b/js/views/modals/purchase/Moderators.js
@@ -92,8 +92,8 @@ export default class extends baseVw {
                   if (eventData.error) {
                     // errors don't have a message id, check to see if the peerID matches
                     if (this.options.moderatorIDs.indexOf(eventData.peerId) !== -1) {
-                      eventData.profile = { peerID: eventData.peerId };
-                      this.moderatorsCol.add(eventData.profile);
+                      // don't add errored moderators
+                      this.removeNotFetched(eventData.peerId);
                     }
                   } else if (eventData.id === socketID) {
                     // don't add profiles that are not moderators. The ID list may have peerIDs

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -234,17 +234,17 @@ export default class extends BaseModal {
     this.getCachedEl('.js-moderatorNote').toggleClass('hide', !checked);
     this.order.moderated = checked;
 
-    if (checked && this._oldMod) {
+    if (checked) {
       // re-select the previously selected moderator, if any
       for (const mod of this.moderators.modCards) {
-        if (mod.model.id === this._oldMod) {
+        if (mod.model.id === this._oldMod || this.moderators.selectedIDs[0]) {
           mod.changeSelectState('selected');
           break;
         }
       }
     } else {
       // deselect all the moderators after storing any selected moderator
-      this._oldMod = this.order.get('moderator');
+      this._oldMod = this.moderators.selectedIDs[0];
       this.moderators.deselectOthers();
       this.order.set('moderator', '');
     }

--- a/styles/components/_spinner.scss
+++ b/styles/components/_spinner.scss
@@ -4,13 +4,18 @@
     height: $spinnerLg;
   }
 
+  &.spinnerMd {
+    width: $spinnerMd;
+    height: $spinnerMd;
+  }
+
   &.spinnerSm {
     width: $spinnerSm;
     height: $spinnerSm;
   }
 
-  &.spinnerMd {
-    width: $spinnerMd;
-    height: $spinnerMd;
+  &.spinnerTxt {
+    width: 1em;
+    height: 1em;
   }
 }


### PR DESCRIPTION
Cleans up a few small issues.
- don't show moderators with errors. This will add a slightly weird issue where the total count includes them, so if 12 moderators are loading and 3 are pad, 9 will be shown but the loading text will say "Loading X out of 12 moderators."
- fix the issue with the last selected moderator not being re-selected when moderation is turned off and back on if the selected moderator was the first one and had been selected automatically.
- adds a spinner to the loading text so it's more clear it's in progress.
- adds a new spinnerTxt class for spinners that are the same size as the text they are next to.