### PR TITLE
Startup tweaks

### DIFF
--- a/js/start.js
+++ b/js/start.js
@@ -130,9 +130,11 @@ const fetchConfigDeferred = $.Deferred();
 function fetchConfig() {
   $.get(app.getServerUrl('ob/config')).done((...args) => {
     fetchConfigDeferred.resolve(...args);
-  }).fail(() => {
+  }).fail(xhr => {
     const retryConfigDialog = new Dialog({
       title: app.polyglot.t('startUp.dialogs.retryConfig.title'),
+      message: xhr && xhr.responseJSON && xhr.responseJSON.reason ||
+        xhr.responseText || '',
       buttons: [
         {
           text: app.polyglot.t('startUp.dialogs.btnRetry'),

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "bitcoin-convert": "^1.0.4",
     "bitcore-lib": "^0.14.0",
     "cropit": "^0.5.1",
+    "homedir": "^0.6.0",
     "ionicons": "^2.0.1",
     "is_js": "^0.8.0",
     "jquery": "^3.0.0",


### PR DESCRIPTION
- if using the bundled app, a custom client data folder will be used to avoid collisions with users on the same machine using the stand-alone client
- the error message returned by the config api will be shown in the ui dialog if the call fails