### PR TITLE
Fix race condition in moderation

### DIFF
--- a/js/views/modals/purchase/Complete.js
+++ b/js/views/modals/purchase/Complete.js
@@ -20,7 +20,7 @@ export default class extends BaseVw {
     this.processingTime = this.options.listing.get('item').processingTime ||
       app.polyglot.t('purchase.completeSection.noData');
     this.vendorPeerID = this.options.listing.get('vendorID').peerID;
-    this.orderID = ''; // supplied by pending.js when the order is paid for
+    this._orderID = '';
   }
 
   className() {
@@ -77,6 +77,14 @@ export default class extends BaseVw {
     e.preventDefault();
     this.sendMessageInput();
     e.preventDefault();
+  }
+
+  get orderID() {
+    return this._orderID;
+  }
+
+  set orderID(ID) {
+    if (ID !== this._orderID) this._orderID = ID;
   }
 
   get $messageInput() {

--- a/js/views/modals/purchase/Complete.js
+++ b/js/views/modals/purchase/Complete.js
@@ -83,8 +83,8 @@ export default class extends BaseVw {
     return this._orderID;
   }
 
-  set orderID(ID) {
-    if (ID !== this._orderID) this._orderID = ID;
+  set orderID(orderID) {
+    if (orderID !== this._orderID) this._orderID = orderID;
   }
 
   get $messageInput() {

--- a/js/views/modals/purchase/Moderators.js
+++ b/js/views/modals/purchase/Moderators.js
@@ -184,7 +184,7 @@ export default class extends baseVw {
       this.removeNotFetched(model.id);
       this.modCards.push(newModView);
       // if required, select the first  moderator
-      if (this.options.selectFirst && !this.firstSelected) {
+      if (this.options.selectFirst && !this.firstSelected && !this.noneSelected) {
         this.firstSelected = true;
         newModView.changeSelectState('selected');
       }
@@ -207,6 +207,14 @@ export default class extends baseVw {
         mod.changeSelectState(this.options.notSelected);
       }
     });
+  }
+
+  get noneSelected() {
+    return this._noneSelected;
+  }
+
+  set noneSelected(bool) {
+    this._noneSelected = bool;
   }
 
   remove() {

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -242,6 +242,7 @@ export default class extends BaseModal {
     } else {
       // deselect all the moderators after storing any selected moderator
       this._oldMod = this.moderators.selectedIDs[0];
+      this.moderators.noneSelected = true;
       this.moderators.deselectOthers();
       this.order.set('moderator', '');
     }
@@ -250,18 +251,20 @@ export default class extends BaseModal {
   disableModerators() {
     this.getCachedEl('#purchaseModerated').prop('checked', false);
     this.order.moderated = false;
+    this.moderators.deselectOthers();
     this.order.set('moderator', '');
   }
 
-  toggleModeration(bool) {
+  moderationOn(bool) {
     this.getCachedEl('.js-moderatedOption').toggleClass('disabled', !bool);
     this.getCachedEl('.js-moderator').toggleClass('hide', !bool);
     this.getCachedEl('.js-moderatorNote').toggleClass('hide', !bool);
     if (!bool) this.disableModerators();
+    this.moderators.noneSelected = !bool;
   }
 
   onNoValidModerators() {
-    this.toggleModeration(false);
+    this.moderationOn(false);
     this.getCachedEl('.js-noValidModerators').removeClass('hide');
   }
 
@@ -343,7 +346,9 @@ export default class extends BaseModal {
     }
 
     // set the moderator
-    this.order.set({ moderator: this.moderators.selectedIDs[0] }, { validate: true });
+    if (this.order.moderated) {
+      this.order.set({ moderator: this.moderators.selectedIDs[0] }, { validate: true });
+    }
 
     // cancel any existing order
     if (this.orderSubmit) this.orderSubmit.abort();
@@ -470,9 +475,9 @@ export default class extends BaseModal {
     if (cur !== 'BTC') {
       btcTotal = convertCurrency(btcTotal, cur, 'BTC');
     }
-    const tooLow = btcTotal < this.minModPrice;
-    this.toggleModeration(!tooLow);
-    this.getCachedEl('.js-modsNotAllowed').toggleClass('hide', !tooLow);
+    const allowModeration = btcTotal >= this.minModPrice;
+    this.moderationOn(allowModeration);
+    this.getCachedEl('.js-modsNotAllowed').toggleClass('hide', allowModeration);
   }
 
   refreshPrices() {


### PR DESCRIPTION
Fixes a bug where a race condition caused the first moderator to be invisibly selected when the order total was too low for a moderator.

Closes #948