### PR TITLE
Search if more than 10 select options

### DIFF
--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -437,8 +437,7 @@ export default class extends baseVw {
     });
     const filterWrapper = this.$('.js-filterWrapper');
     filterWrapper.find('select').select2({
-      // disables the search box
-      minimumResultsForSearch: Infinity,
+      minimumResultsForSearch: 10,
       templateResult: selectEmojis,
       templateSelection: selectEmojis,
     });


### PR DESCRIPTION
Changes the parameter to show the select list search input if there are more than 10 options.

Currently none of the filters have more than 10 options, Tyler is adding more to the shipping filter.