### PR TITLE
Search suggestions

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1020,6 +1020,7 @@
     "addQueryProviderBtn": "Add search provider",
     "chooseDefaultTitle": "Select a default search provider",
     "chooseDefaultMsg": "This provider will be used as the default for future seaches until you set a new one.",
+    "suggestions": "Suggestions:",
     "errors": {
       "searchFailTitle": "The search query to %{provider} has failed. Choose another provider above.",
       "searchFailReason": "The search provider returned the following message: %{error}",

--- a/js/templates/search/Search.html
+++ b/js/templates/search/Search.html
@@ -38,13 +38,7 @@
                value="<%= ob.term %>">
         <button class="btn clrP clrBr searchBtn js-searchBtn"><%= ob.polyT('search.searchBtn') %></button>
       </div>
-      <% // TODO: if suggestions exist show below %>
-      <% /* %>
-      <div class="suggestions flex gutterH row">
-        <span class="tx5 clrT2"><%= ob.polyT('search.suggestions') %></span>
-        <% // TODO: suggestions loop %>
-      </div>
-      <% */ %>
+      <div class="js-suggestions"></div>
       <hr class="clrBr">
     </div>
     <div class="flexRow gutterHLg">

--- a/js/templates/search/Suggestions.html
+++ b/js/templates/search/Suggestions.html
@@ -1,0 +1,6 @@
+<% if (ob.suggestions && ob.suggestions.length) { %>
+  <button class="btnTxtOnly txUnb clrT2 suggestionTitle">Suggestions:</button>
+  <% ob.suggestions.forEach(suggestion => { %>
+    <button class="btnTxtOnly txUnb js-suggestion" data-suggestion="<%= suggestion %>"><%= suggestion%></button>
+  <% }); %>
+<% } %>

--- a/js/templates/search/Suggestions.html
+++ b/js/templates/search/Suggestions.html
@@ -1,5 +1,5 @@
 <% if (ob.suggestions && ob.suggestions.length) { %>
-  <span class="clrT2">Suggestions:</span>
+  <span class="clrT2"><%= ob.polyT('search.suggestions') %></span>
   <% ob.suggestions.forEach(suggestion => { %>
     <a class="clrT js-suggestion" data-suggestion="<%= suggestion %>"><%= suggestion%></a>
   <% }); %>

--- a/js/templates/search/Suggestions.html
+++ b/js/templates/search/Suggestions.html
@@ -1,5 +1,5 @@
 <% if (ob.suggestions && ob.suggestions.length) { %>
-  <span class="clrT2 suggestionTitle">Suggestions:</span>
+  <span class="clrT2">Suggestions:</span>
   <% ob.suggestions.forEach(suggestion => { %>
     <a class="clrT js-suggestion" data-suggestion="<%= suggestion %>"><%= suggestion%></a>
   <% }); %>

--- a/js/templates/search/Suggestions.html
+++ b/js/templates/search/Suggestions.html
@@ -1,6 +1,6 @@
 <% if (ob.suggestions && ob.suggestions.length) { %>
-  <button class="btnTxtOnly txUnb clrT2 suggestionTitle">Suggestions:</button>
+  <span class="clrT2 suggestionTitle">Suggestions:</span>
   <% ob.suggestions.forEach(suggestion => { %>
-    <button class="btnTxtOnly txUnb js-suggestion" data-suggestion="<%= suggestion %>"><%= suggestion%></button>
+    <a class="clrT js-suggestion" data-suggestion="<%= suggestion %>"><%= suggestion%></a>
   <% }); %>
 <% } %>

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -28,6 +28,21 @@ export default class extends baseVw {
 
     super(opts);
     this.options = opts;
+
+    this.defaultSuggestions = this.options.defaultSuggestions ||
+      [
+        'books',
+        'clothing',
+        'electronics',
+        'food',
+        'games',
+        'health',
+        'movies',
+        'music',
+        'sports',
+        'toys',
+      ];
+
     // in the future the may be more possible types
     this.urlType = this.usingTor ? 'torlistings' : 'listings';
 
@@ -468,7 +483,7 @@ export default class extends baseVw {
     if (this.suggestions) this.suggestions.remove();
     this.suggestions = this.createChild(Suggestions, {
       initialState: {
-        suggestions: data.suggestions || [],
+        suggestions: data.suggestions || this.defaultSuggestions,
       },
     });
     this.listenTo(this.suggestions, 'clickSuggestion', opts => this.onClickSuggestion(opts));

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -483,7 +483,7 @@ export default class extends baseVw {
     if (this.suggestions) this.suggestions.remove();
     this.suggestions = this.createChild(Suggestions, {
       initialState: {
-        suggestions: data.suggestions || this.defaultSuggestions,
+        suggestions: Array.isArray(data.suggestions) ? data.suggestions : this.defaultSuggestions,
       },
     });
     this.listenTo(this.suggestions, 'clickSuggestion', opts => this.onClickSuggestion(opts));

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -11,6 +11,7 @@ import Results from './Results';
 import ResultsCol from '../../collections/Results';
 import Providers from './SearchProviders';
 import ProviderMd from '../../models/search/SearchProvider';
+import Suggestions from './Suggestions';
 import defaultSearchProviders from '../../data/defaultSearchProviders';
 import { selectEmojis } from '../../utils';
 import { getCurrentConnection } from '../../utils/serverConnect';
@@ -378,6 +379,10 @@ export default class extends baseVw {
     this.processTerm(this.term);
   }
 
+  onClickSuggestion(opts) {
+    this.processTerm(opts.suggestion);
+  }
+
   scrollToTop() {
     this.$el[0].scrollIntoView();
   }
@@ -459,6 +464,15 @@ export default class extends baseVw {
     });
     this.listenTo(this.searchProviders, 'activateProvider', pOpts => this.activateProvider(pOpts));
     this.$('.js-searchProviders').append(this.searchProviders.render().el);
+
+    if (this.suggestions) this.suggestions.remove();
+    this.suggestions = this.createChild(Suggestions, {
+      initialState: {
+        suggestions: data.suggestions || [],
+      },
+    });
+    this.listenTo(this.suggestions, 'clickSuggestion', opts => this.onClickSuggestion(opts));
+    this.$('.js-suggestions').append(this.suggestions.render().el);
 
     // use the initial set of results data to create the results view
     if (data) this.createResults(data, state.searchUrl);

--- a/js/views/search/Suggestions.js
+++ b/js/views/search/Suggestions.js
@@ -1,0 +1,43 @@
+import loadTemplate from '../../utils/loadTemplate';
+import BaseView from '../baseVw';
+
+export default class extends BaseView {
+  constructor(options = {}) {
+
+    const opts = {
+      initialState: {
+        suggestions: [],
+      },
+      ...options.initialState || {},
+    };
+
+    super(opts);
+    this.options = opts;
+  }
+
+  className() {
+    return 'suggestions flex gutterH row tx5';
+  }
+
+  events() {
+    return {
+      'click .js-suggestion': 'onClickSuggestion',
+    };
+  }
+
+  onClickSuggestion(e) {
+    const suggestion = $(e.target).data('suggestion');
+    this.trigger('clickSuggestion', { suggestion });
+  }
+
+  render() {
+    super.render();
+    loadTemplate('search/Suggestions.html', t => {
+      this.$el.html(t({
+        ...this.options,
+      }));
+    });
+
+    return this;
+  }
+}

--- a/js/views/search/Suggestions.js
+++ b/js/views/search/Suggestions.js
@@ -4,7 +4,6 @@ import BaseView from '../baseVw';
 
 export default class extends BaseView {
   constructor(options = {}) {
-
     const opts = {
       initialState: {
         suggestions: [],

--- a/js/views/search/Suggestions.js
+++ b/js/views/search/Suggestions.js
@@ -36,7 +36,6 @@ export default class extends BaseView {
     const state = this.getState();
     loadTemplate('search/Suggestions.html', t => {
       this.$el.html(t({
-        ...this.options,
         ...state,
       }));
     });

--- a/js/views/search/Suggestions.js
+++ b/js/views/search/Suggestions.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import loadTemplate from '../../utils/loadTemplate';
 import BaseView from '../baseVw';
 
@@ -7,8 +8,9 @@ export default class extends BaseView {
     const opts = {
       initialState: {
         suggestions: [],
+        ...options.initialState || {},
       },
-      ...options.initialState || {},
+      ...options,
     };
 
     super(opts);
@@ -16,7 +18,7 @@ export default class extends BaseView {
   }
 
   className() {
-    return 'suggestions flex gutterH row tx5';
+    return 'suggestions flex gutterH row tx5 noOverflow';
   }
 
   events() {
@@ -32,9 +34,11 @@ export default class extends BaseView {
 
   render() {
     super.render();
+    const state = this.getState();
     loadTemplate('search/Suggestions.html', t => {
       this.$el.html(t({
         ...this.options,
+        ...state,
       }));
     });
 

--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -165,8 +165,8 @@
     }
   }
 
-  .suggestionTitle {
-    pointer-events: none; // this uses button markup to maintain alignment
+  .suggestions > * {
+    flex-shrink: 0;
   }
 
   .filterWrapper {

--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -165,6 +165,10 @@
     }
   }
 
+  .suggestionTitle {
+    pointer-events: none; // this uses button markup to maintain alignment
+  }
+
   .filterWrapper {
     padding-right: 5px;
 

--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -167,6 +167,7 @@
 
   .suggestions > * {
     flex-shrink: 0;
+    padding-bottom: 2px; // prevent descenders from being cut off
   }
 
   .filterWrapper {


### PR DESCRIPTION
This implements a row of suggestions below the search bar if any are provided.

Currently, if there are more than one row worth of suggestions they will just be trimmed to one line. Adding in logic to detect if they go over one line and add a button to show the rest will need to come in a future PR (the current library we use for this, Trunk8, didn't work for this scenario when I tried it).

If the search provider doesn't provide any suggestions, this will insert the following list:
'books',
        'clothing',
        'electronics',
        'food',
        'games',
        'health',
        'movies',
        'music',
        'sports',
        'toys',