### PR TITLE
Show Moderator Languages

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -271,7 +271,8 @@
     "PERCENTAGE": "%{percentage}%**",
     "FIXED_PLUS_PERCENTAGE": "%{amount} (+%{percentage}%)**",
     "failed": "The information for this moderator failed to load.",
-    "invalid": "This user is not currently a moderator."
+    "invalid": "This user is not currently a moderator.",
+    "languages": "%{lang}, and %{smart_count} other language. |||| %{lang}, and %{smart_count} other languages."
   },
   "moderatorDetails": {
     "messageButton": "Message",
@@ -285,7 +286,8 @@
     "FIXED_PLUS_PERCENTAGE": "%{amount} (+%{percentage})**",
     "termsOfService": "Terms of Service",
     "addAsModeratorButton": "Add as Moderator",
-    "disclaimer": "**The moderator service charge only applies when a dispute arises."
+    "disclaimer": "**The moderator service charge only applies when a dispute arises.",
+    "languages": "Languages"
   },
   "about": {
     "linkText": "About OpenBazaar",

--- a/js/models/profile/Moderator.js
+++ b/js/models/profile/Moderator.js
@@ -8,7 +8,7 @@ export default class extends BaseModel {
       fee: new Fee(),
       description: '',
       termsAndConditions: '',
-      languages: app.settings ? [app.settings.get('language')] : [],
+      languages: [],
     };
   }
 

--- a/js/templates/modals/moderatorDetails.html
+++ b/js/templates/modals/moderatorDetails.html
@@ -45,7 +45,7 @@
     </div>
     <div class="contentBox mDetailBox padMd clrP clrBr clrSh3 tx5">
       <div class="rowLg">
-        <h4>Languages</h4>
+        <h4><%= ob.polyT('moderatorDetails.languages') %></h4>
         <% ob.modLanguages.forEach(lang => { %>
         <div class="rowSm txSm"><%= lang %></div>
         <% }); %>

--- a/js/templates/modals/moderatorDetails.html
+++ b/js/templates/modals/moderatorDetails.html
@@ -44,6 +44,12 @@
       </div>
     </div>
     <div class="contentBox mDetailBox padMd clrP clrBr clrSh3 tx5">
+      <div class="rowLg">
+        <h4>Languages</h4>
+        <% ob.modLanguages.forEach(lang => { %>
+        <div class="rowSm txSm"><%= lang %></div>
+        <% }); %>
+      </div>
       <div class="row">
         <h4><%= ob.polyT('moderatorDetails.termsOfService') %></h4>
         <p><%= ob.moderatorInfo.termsAndConditions %></p>

--- a/js/templates/moderatorCard.html
+++ b/js/templates/moderatorCard.html
@@ -24,7 +24,8 @@
         <span class="clrT2"><%= ob.handle ? `@${ob.handle}` : '' %></span>
       </div>
       <div class="row clrT2">
-        <p class="clamp2"><%=ob.moderatorInfo.description %></p>
+        <div class="rowSm clamp2"><%=ob.moderatorInfo.description %></div>
+        <div class="txSm"><%= ob.modLanguages.join(', ') %></div>
       </div>
       <div class="flex snipKids gutterH tx5">
         <div class="flexNoShrink TODO">
@@ -51,7 +52,7 @@
   </div>
   <div class="flexNoShrink">
     <% if (ob.valid) { %>
-      <div class="flexColRows gutterV">
+      <div class="flexCol gutterV">
         <button class="btn clrP clrBr clrSh2 selectBtn js-viewBtn">
           <%= ob.polyT('moderatorCard.view') %>
         </button>

--- a/js/templates/moderatorCard.html
+++ b/js/templates/moderatorCard.html
@@ -25,12 +25,15 @@
       </div>
       <div class="row clrT2">
         <div class="rowSm clamp2"><%=ob.moderatorInfo.description %></div>
-        <div class="txSm">
-          <%= ob.modLanguages[0] %>
-          <% if (ob.modLanguages.length > 1) { %>
-            , and <%= ob.modLanguages.length -1 %> more.
-          <% } %>
-        </div>
+        <% if (ob.modLanguages && ob.modLanguages.length) { %>
+          <div class="txSm">
+            <% if (ob.modLanguages.length > 1) {
+                 print(ob.polyT('moderatorCard.languages', { lang: ob.modLanguages[0], smart_count: ob.modLanguages.length -1 }));
+               } else { %>
+              <%= ob.modLanguages[0] %>
+            <% } %>
+          </div>
+        <% } %>
       </div>
       <div class="flex snipKids gutterH tx5">
         <div class="flexNoShrink TODO">

--- a/js/templates/moderatorCard.html
+++ b/js/templates/moderatorCard.html
@@ -25,7 +25,12 @@
       </div>
       <div class="row clrT2">
         <div class="rowSm clamp2"><%=ob.moderatorInfo.description %></div>
-        <div class="txSm"><%= ob.modLanguages.join(', ') %></div>
+        <div class="txSm">
+          <%= ob.modLanguages[0] %>
+          <% if (ob.modLanguages.length > 1) { %>
+            , and <%= ob.modLanguages.length -1 %> more.
+          <% } %>
+        </div>
       </div>
       <div class="flex snipKids gutterH tx5">
         <div class="flexNoShrink TODO">

--- a/js/views/ModeratorCard.js
+++ b/js/views/ModeratorCard.js
@@ -1,8 +1,10 @@
+import _ from 'underscore';
 import BaseVw from './baseVw';
 import loadTemplate from '../utils/loadTemplate';
 import app from '../app';
 import Profile from '../models/profile/Profile';
 import { launchModeratorDetailsModal } from '../utils/modalManager';
+import languages from '../data/languages';
 
 
 export default class extends BaseVw {
@@ -65,12 +67,20 @@ export default class extends BaseVw {
   }
 
   render() {
+    const modLanguages = [];
+
+    this.model.get('moderatorInfo').get('languages').forEach(lang => {
+      const langName = _.findWhere(languages, { code: lang }).name;
+      modLanguages.push(langName);
+    });
+
     loadTemplate('moderatorCard.html', (t) => {
       this.$el.html(t({
         cardState: this.cardState,
         displayCurrency: app.settings.get('localCurrency'),
         valid: this.model.isModerator,
         radioStyle: this.options.radioStyle || false,
+        modLanguages,
         ...this.model.toJSON(),
       }));
 

--- a/js/views/modals/Settings/Moderation.js
+++ b/js/views/modals/Settings/Moderation.js
@@ -30,7 +30,7 @@ export default class extends baseVw {
     if (this.profile.get('moderatorInfo')) {
       this.moderator = this.profile.get('moderatorInfo');
     } else {
-      this.moderator = new Moderator();
+      this.moderator = new Moderator({ languages: [app.settings.get('language')] });
       this.profile.set('moderatorInfo', this.moderator);
     }
 

--- a/js/views/modals/Settings/Store.js
+++ b/js/views/modals/Settings/Store.js
@@ -178,7 +178,7 @@ export default class extends baseVw {
       }
       // if the view already exists and is in the DOM, this will move it
       docFrag.append(newModView.render().$el);
-      target.prepend(docFrag);
+      target.append(docFrag);
       this.modViewCache.push(newModView);
     }
   }

--- a/js/views/modals/moderatorDetails.js
+++ b/js/views/modals/moderatorDetails.js
@@ -1,8 +1,10 @@
+import _ from 'underscore';
 import loadTemplate from '../../utils/loadTemplate';
 import app from '../../app';
 import Profile from '../../models/profile/Profile';
 import SocialBtns from '../components/SocialBtns';
 import BaseModal from './BaseModal';
+import languages from '../../data/languages';
 
 export default class extends BaseModal {
   constructor(options = {}) {
@@ -36,6 +38,13 @@ export default class extends BaseModal {
   }
 
   render() {
+    const modLanguages = [];
+
+    this.model.get('moderatorInfo').get('languages').forEach(lang => {
+      const langName = _.findWhere(languages, { code: lang }).name;
+      modLanguages.push(langName);
+    });
+
     loadTemplate('modals/moderatorDetails.html', (t) => {
       this.$el.html(t({
         followedByYou: this.followedByYou,
@@ -43,6 +52,7 @@ export default class extends BaseModal {
         ownMod: app.settings.get('storeModerators').indexOf(this.model.id) !== -1,
         purchase: this.options.purchase,
         cardState: this.options.cardState,
+        modLanguages,
         ...this.model.toJSON(),
       }));
       super.render();


### PR DESCRIPTION
This will show the languages a moderator understands.

In the moderator card, the first language is shown. If they understand more than one, a message is shown with the number of additional languages, since the space is limited.

On the moderator details modal, a list of languages is shown.

@morebrownies I moved the list to the next box. The name of a given language can be pretty long, and didn't fit well between the location and fee.

![image](https://user-images.githubusercontent.com/1584275/31406297-e0b1f35a-adce-11e7-8107-03010f92ebf1.png)

![image](https://user-images.githubusercontent.com/1584275/31406303-ea4964ca-adce-11e7-94b4-654452a12d47.png)

![image](https://user-images.githubusercontent.com/1584275/31406334-019d3d40-adcf-11e7-910c-052d4150d560.png)


