### PR TITLE
Fix purchase no mods

### DIFF
--- a/js/languages/en-US.json
+++ b/js/languages/en-US.json
@@ -1642,7 +1642,8 @@
     "noItems": "You must make at least one purchase.",
     "missingAddress": "Please choose a valid shipping address.",
     "missingShippingOption": "Please choose a valid shipping option.",
-    "needsModerator": "You must select a moderator to make a Moderated Payment."
+    "needsModerator": "You must select a moderator to make a Moderated Payment.",
+    "removeModerator": "An unmoderated purchase cannot have a moderator."
   },
   "orderFulfillmentModelErrors": {
     "provideShipper": "Please provide a shipping carrier.",

--- a/js/models/purchase/Order.js
+++ b/js/models/purchase/Order.js
@@ -64,6 +64,11 @@ export default class extends BaseModel {
       addError('moderated', app.polyglot.t('orderModelErrors.needsModerator'));
     }
 
+    if (!this.moderated && attrs.moderator) {
+      // this should only happen if there is a developer error
+      addError('moderated', app.polyglot.t('orderModelErrors.removeModerator'));
+    }
+
     if (Object.keys(errObj).length) return errObj;
 
     return undefined;

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -86,7 +86,6 @@ const totalPrice = ob.prices[0].price + ob.prices[0].vPrice;
                   <input
                       type="checkbox"
                       name="moderated"
-                      checked
                       id="purchaseModerated">
                   <label for="purchaseModerated"><%= ob.polyT('purchase.moderatedPayment') %></label>
                   <p class="clrT2 tx6">

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -348,7 +348,8 @@ export default class extends BaseModal {
 
     // set the moderator
     const moderator = this.order.moderated ? this.moderators.selectedIDs[0] : '';
-    this.order.set({ moderator }, { validate: true });
+    this.order.set({ moderator });
+    this.order.set({}, { validate: true });
 
 
     // cancel any existing order
@@ -476,7 +477,7 @@ export default class extends BaseModal {
     if (cur !== 'BTC') {
       btcTotal = convertCurrency(btcTotal, cur, 'BTC');
     }
-    const allowModeration = btcTotal >= this.minModPrice && this.moderatorIDs.length > 0;
+    const allowModeration = btcTotal >= this.minModPrice && this.moderatorIDs.length;
     this.moderationOn(allowModeration);
     this.getCachedEl('.js-modsNotAllowed').toggleClass('hide', allowModeration);
   }
@@ -537,7 +538,7 @@ export default class extends BaseModal {
         prices: this.prices,
         minModPrice: this.minModPrice,
         displayCurrency: app.settings.get('localCurrency'),
-        hasModerators: this.moderatorIDs.length > 0,
+        hasModerators: !!this.moderatorIDs.length,
       }));
 
       super.render();

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -260,6 +260,7 @@ export default class extends BaseModal {
     this.getCachedEl('.js-moderatorNote').toggleClass('hide', !bool);
     if (!bool) this.disableModerators();
     this.order.moderated = bool;
+    this.getCachedEl('#purchaseModerated').prop('checked', bool);
     this.moderators.noneSelected = !bool;
   }
 
@@ -346,9 +347,9 @@ export default class extends BaseModal {
     }
 
     // set the moderator
-    if (this.order.moderated) {
-      this.order.set({ moderator: this.moderators.selectedIDs[0] }, { validate: true });
-    }
+    const moderator = this.order.moderated ? this.moderators.selectedIDs[0] : '';
+    this.order.set({ moderator }, { validate: true });
+
 
     // cancel any existing order
     if (this.orderSubmit) this.orderSubmit.abort();
@@ -475,7 +476,7 @@ export default class extends BaseModal {
     if (cur !== 'BTC') {
       btcTotal = convertCurrency(btcTotal, cur, 'BTC');
     }
-    const allowModeration = btcTotal >= this.minModPrice;
+    const allowModeration = btcTotal >= this.minModPrice && this.moderatorIDs.length > 0;
     this.moderationOn(allowModeration);
     this.getCachedEl('.js-modsNotAllowed').toggleClass('hide', allowModeration);
   }
@@ -536,7 +537,7 @@ export default class extends BaseModal {
         prices: this.prices,
         minModPrice: this.minModPrice,
         displayCurrency: app.settings.get('localCurrency'),
-        hasModerators: this.moderatorIDs.length,
+        hasModerators: this.moderatorIDs.length > 0,
       }));
 
       super.render();


### PR DESCRIPTION
This fixes some issues with the moderation logic:
- the checked by default state of the moderation checkbox is driven by the moderation allowed code, so it's always in sync with the internal moderation value.
- the moderation allowed code checks if no moderators are available, and is false if they are not
- the model is always validated, not just if moderation is on, to clear old validation errors if the user turns moderation on, doesn't choose a moderator, gets an error, then turns moderation off and tries to purchase again.