### PR TITLE
Fix non boolean boolean

### DIFF
--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -477,7 +477,7 @@ export default class extends BaseModal {
     if (cur !== 'BTC') {
       btcTotal = convertCurrency(btcTotal, cur, 'BTC');
     }
-    const allowModeration = btcTotal >= this.minModPrice && this.moderatorIDs.length;
+    const allowModeration = (btcTotal >= this.minModPrice) && !!this.moderatorIDs.length;
     this.moderationOn(allowModeration);
     this.getCachedEl('.js-modsNotAllowed').toggleClass('hide', allowModeration);
   }


### PR DESCRIPTION
A value that needed to be boolean was being passed in as a number, which was causing part of the logic to be reversed for when to hide the moderation warning in purchases.

Fixes #1012