### PR TITLE
use translated language for stats

### DIFF
--- a/js/views/modals/wallet/Stats.js
+++ b/js/views/modals/wallet/Stats.js
@@ -43,7 +43,7 @@ export default class extends baseVw {
       throw new Error('Please provide a number.');
     }
 
-    return new Intl.NumberFormat(app.localSettings.get('language'), {
+    return new Intl.NumberFormat(app.localSettings.standardizedTranslatedLang(), {
       minimumFractionDigits: 0,
       maximumFractionDigits: 8,
     }).format(amount);


### PR DESCRIPTION
This fixes the wallet stats, which was still referencing the old language settings.