### PR TITLE
Fix clamp peek through and other issues

### DIFF
--- a/js/templates/listingCard.html
+++ b/js/templates/listingCard.html
@@ -29,9 +29,9 @@
       <% } %>
   </div>
   <div class="pad clrBr borderTop">
-    <div class="rowSm <% if(ob.vendor) print('trimWidth') %>">
+    <div class="rowSm">
       <% const tooltipClass = ob.title.length > 60 ? 'toolTip' : 'toolTipNoWrap' %>
-      <div class="<%= tooltipClass %> toolTipTop inlineBlock" data-tip="<%= ob.title %>">
+      <div class="<%= tooltipClass %> toolTipTop inlineBlock <% if(ob.vendor) print('trimWidth') %>" data-tip="<%= ob.title %>">
         <a class="clrT clamp"><%= ob.title %></a>
       </div>
     </div>

--- a/styles/components/_type.scss
+++ b/styles/components/_type.scss
@@ -149,24 +149,48 @@ a .txNoUnd:hover {
   display: -webkit-box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
+  /* set the height to slightly less than the line height to prevent the top of the next row of
+     characters from peeking through. If the line height is not default, this property must be
+     overridden.
+   */
+  max-height: 1.18em;
 }
 
 .clamp2 {
   /* adds an ellipses to the end of wrapped text after 2 lines */
   @extend .clamp;
   -webkit-line-clamp: 2;
+  max-height: 2.38em;
 }
 
 .clamp3 {
   /* adds an ellipses to the end of wrapped text after 3 lines */
   @extend .clamp;
   -webkit-line-clamp: 3;
+  max-height: 3.58em;
 }
 
 .clamp4 {
   /* adds an ellipses to the end of wrapped text after 4 lines */
   @extend .clamp;
   -webkit-line-clamp: 4;
+  max-height: 4.78em;
+}
+
+p.clamp {
+  max-height: 1.48em;
+}
+
+p.clamp2 {
+  max-height: 2.98em;
+}
+
+p.clamp3 {
+  max-height: 4.48em;
+}
+
+p.clamp4 {
+  max-height: 5.98em;
 }
 
 // two column flow

--- a/styles/modules/_notifications.scss
+++ b/styles/modules/_notifications.scss
@@ -61,7 +61,7 @@
     .notification {
       &:last-child {
         .notificationListItem {
-          border-width: 0;          
+          border-width: 0;
         }
       }
 
@@ -75,6 +75,7 @@
         .thumbCol {
           position: relative;
           width: 42px;
+          min-width: 42px; // prevent collapse when in flex parents
 
           .btcIcon {
             width: 32px;


### PR DESCRIPTION
This fixes an issue where the next line of characters could peek through the bottom of clamped text.

It also fixes a problem where very long notifications would push the thumbnail to the side in the notifications list, and a problem where very long listing titles were not being trimmed to avoid running beneath the avatar.

Closes #1033 
