### PR TITLE
Fix Language Code in getTranslatedLangs

### DIFF
--- a/js/data/languages.js
+++ b/js/data/languages.js
@@ -1008,7 +1008,7 @@ export function getLangByCode(code, translate = true, lang = app && app.localSet
 }
 
 function getTranslatedLangs(lang = app && app.localSettings &&
-  app.localSettings.get('language') || 'en-US', sort = true) {
+  app.localSettings.standardizedTranslatedLang() || 'en-US', sort = true) {
   if (!lang) {
     throw new Error('Please provide the language the translated languages' +
       ' should be returned in.');


### PR DESCRIPTION
In languages, getTranslatedLangs was using localSettings.get('language", which returned the Transifex style language string.  That threw a `Invalid language tag: en_US` error.

This updates the code to use the standardized value instead.