### PR TITLE
Add dispute resolution link

### DIFF
--- a/js/templates/modals/settings/moderation.html
+++ b/js/templates/modals/settings/moderation.html
@@ -147,7 +147,7 @@
             <input type="checkbox" id="acceptGuidelines" class="<% if (ob.isModerator) { print('fauxChecked') } %>">
             <label class="tx5b" for="acceptGuidelines">
               <span>
-                <%= ob.polyT('settings.moderationTab.acceptGuidelines', { acceptGuidelinesLink: `<a href="https://openbazaar.org" class="clrTEm">${ob.polyT('settings.moderationTab.acceptGuidelinesLink')}</a>` }) %>
+                <%= ob.polyT('settings.moderationTab.acceptGuidelines', { acceptGuidelinesLink: `<a href="https://www.openbazaar.org/openbazaar-dispute-resolution-guidelines/" class="clrTEm">${ob.polyT('settings.moderationTab.acceptGuidelinesLink')}</a>` }) %>
               </span>
             </label>
           </div>


### PR DESCRIPTION
Corrects the URL in the dispute resolution link in the settings/moderation tab. 

Closes #338