### PR TITLE
offering a download latest link when updates are not supported

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -310,6 +310,7 @@
     "client": "Client",
     "server": "Server",
     "btnUpdateCheck": "Check for Update",
+    "downloadLatest": "Download Latest",
     "donationsTab": {
       "linkText": "Donations",
       "sectionHeader": "Donations",

--- a/js/models/ServerConfig.js
+++ b/js/models/ServerConfig.js
@@ -161,6 +161,6 @@ export default class extends BaseModel {
 
   isTorPwRequired() {
     return ['win', 'darwin'].indexOf(remote.process.platform) > -1 &&
-      this.isLocalServer() && remote.getGlobal('isBundledApp')();
+      this.isLocalServer() && remote.getGlobal('isBundledApp');
   }
 }

--- a/js/start.js
+++ b/js/start.js
@@ -565,7 +565,7 @@ app.connectionManagmentModal = new ConnectionManagement({
 app.serverConfigs.fetch().done(() => {
   if (!app.serverConfigs.length) {
     // no saved server configurations
-    if (remote.getGlobal('isBundledApp')()) {
+    if (remote.getGlobal('isBundledApp')) {
       // for a bundled app, we'll create a
       // "default" one and try to connect
       const defaultConfig = new ServerConfig({
@@ -604,7 +604,7 @@ app.serverConfigs.fetch().done(() => {
       activeServer = app.serverConfigs.activeServer = app.serverConfigs.at(0);
     }
 
-    if (activeServer.get('default') && !remote.getGlobal('isBundledApp')()) {
+    if (activeServer.get('default') && !remote.getGlobal('isBundledApp')) {
       // Your active server is the locally bundled server, but you're
       // not running the bundled app. You have bad data!
       activeServer.set('default', false);
@@ -775,7 +775,7 @@ ipcRenderer.on('close-attempt', (e) => {
 // initialize our listing delete handler
 listingDeleteHandler();
 
-if (remote.getGlobal('isBundledApp')()) {
+if (remote.getGlobal('isBundledApp')) {
   console.log(`%c${app.polyglot.t('consoleWarning.heading')}`,
     'color: red; font-weight: bold; font-size: 50px;');
   console.log(`%c${app.polyglot.t('consoleWarning.line1')}`, 'color: red;');

--- a/js/templates/modals/about/about.html
+++ b/js/templates/modals/about/about.html
@@ -24,9 +24,15 @@
               <% } %>
             </div>
             <% if (ob.isBundledApp) { %>
-            <a class="btn clrP clrBAttGrad clrBrDec1 clrTOnEmph js-checkForUpdate">
-              <%= ob.polyT('about.btnUpdateCheck') %>
-            </a>
+              <% if (ob.updatesSupported) { %>
+                <a class="btn clrP clrBAttGrad clrBrDec1 clrTOnEmph js-checkForUpdate">
+                  <%= ob.polyT('about.btnUpdateCheck') %>
+                </a>
+              <% } else { %>
+                <a class="btn clrP clrBAttGrad clrBrDec1 clrTOnEmph" href="https://www.openbazaar.org/download/">
+                  <%= ob.polyT('about.downloadLatest') %>
+                </a>              
+              <% } %>
             <% } %>
           </div>
         </div>

--- a/js/views/modals/about/About.js
+++ b/js/views/modals/about/About.js
@@ -29,7 +29,8 @@ export default class extends BaseModal {
     };
 
     this.currentTabName = 'Story';
-    this.isBundledApp = remote.getGlobal('isBundledApp')();
+    this.isBundledApp = remote.getGlobal('isBundledApp');
+    this.updatesSupported = remote.getGlobal('updatesSupported');
   }
 
   className() {
@@ -95,6 +96,7 @@ export default class extends BaseModal {
           ...this.options,
           version,
           isBundledApp: this.isBundledApp,
+          updatesSupported: this.updatesSupported,
         }));
         super.render();
 


### PR DESCRIPTION
closes #1028 

This only works on the bundled app. To test, fudge the following:

```
// const isBundledApp = fs.existsSync(serverPath + serverFilename);
const isBundledApp = true;
```

To masquerade as an os that doesn't support auto update:

```
// const updatesSupported = process.platform === 'win32' || process.platform === 'darwin';
const updatesSupported = false;
```