### PR TITLE
Tweak emoji size and alignment

### DIFF
--- a/styles/modules/_chat.scss
+++ b/styles/modules/_chat.scss
@@ -394,8 +394,9 @@
   }
 }
 
-.chatConversation .emoji, #chatContainer .emoji {
-  width: 16px;
-  height: 16px;
+.chatConversation .emoji, #chatContainer .chatConvoMessages .emoji {
+  width: 1.3em;
+  height: 1.3em;
+  vertical-align: bottom;
 }
 


### PR DESCRIPTION
- only increase the size of emojis in the conversation, so the location icon doesn't throw off the line height
- align the emojis to the bottom so they are more centered.
- closes #1067 