### PR TITLE
Add z-index to avatar in listing card

### DIFF
--- a/styles/components/_listingCard.scss
+++ b/styles/components/_listingCard.scss
@@ -28,6 +28,7 @@
 
     .userIconWrapper {
       position: absolute;
+      z-index: 1;
       top: 201px;
       right: 8px;
     }


### PR DESCRIPTION
Makes the tooltip hover work on the top half of the avatar, rather than having it blocked.

Closes #1070