### PR TITLE
Fix Black Bar on Mobile Image Upload

### DIFF
--- a/js/views/modals/editListing/EditListing.js
+++ b/js/views/modals/editListing/EditListing.js
@@ -362,6 +362,11 @@ export default class extends BaseModal {
         canvas.height = imgH;
 
         this.getOrientation(photoFile, (orientation) => {
+          if (orientation > 4) {
+            canvas.width = imgH;
+            canvas.height = imgW;
+          }
+
           switch (orientation) {
             case 2:
               ctx.translate(imgW, 0);


### PR DESCRIPTION
This fixes an issue when mobile photos were rotated right and a black bar was added, due to the canvas height and width not being switched first.