### PR TITLE
Tweak selectize

### DIFF
--- a/js/lib/selectize.js
+++ b/js/lib/selectize.js
@@ -698,6 +698,9 @@ import { _tagsDelimiter } from '../utils/selectize';
         blur      : function() { return self.onBlur.apply(self, arguments); },
         focus     : function() { self.ignoreBlur = false; return self.onFocus.apply(self, arguments); },
         paste     : function() { return self.onPaste.apply(self, arguments); }
+        // click     : function() {
+
+        // }
       });
   
       $document.on('keydown' + eventNS, function(e) {
@@ -851,7 +854,18 @@ import { _tagsDelimiter } from '../utils/selectize';
      */
     onClick: function(e) {
       var self = this;
-  
+
+      // If the input has focus, we'll let a click of it open the menu, which
+      // might be closed. This prevents the user from having to click out of the
+      // input and then click back in, just to show the menu.
+      if (self.isFocused && !self.isDisabled) {
+        if (!self.$activeItems.length) {
+          self.showInput();
+          self.setActiveItem(null);
+          self.refreshOptions(!!self.settings.openOnFocus);
+        }
+      }
+
       // necessary for mobile webkit devices (manual focus triggering
       // is ignored unless invoked within a click event)
       if (!self.isFocused) {
@@ -2677,7 +2691,7 @@ import { _tagsDelimiter } from '../utils/selectize';
     selectOnTab: true,
     preload: false,
     allowEmptyOption: false,
-    closeAfterSelect: false,
+    closeAfterSelect: true,
   
     scrollDuration: 60,
     loadThrottle: 300,

--- a/js/lib/selectize.js
+++ b/js/lib/selectize.js
@@ -698,9 +698,6 @@ import { _tagsDelimiter } from '../utils/selectize';
         blur      : function() { return self.onBlur.apply(self, arguments); },
         focus     : function() { self.ignoreBlur = false; return self.onFocus.apply(self, arguments); },
         paste     : function() { return self.onPaste.apply(self, arguments); }
-        // click     : function() {
-
-        // }
       });
   
       $document.on('keydown' + eventNS, function(e) {

--- a/js/views/modals/Settings/Moderation.js
+++ b/js/views/modals/Settings/Moderation.js
@@ -199,7 +199,6 @@ export default class extends baseVw {
         maxItems: null,
         valueField: 'code',
         searchField: ['name', 'code'],
-        closeAfterSelect: false,
         items: moderator.get('languages'),
         options: getTranslatedLangs(),
         render: {

--- a/js/views/modals/editListing/ShippingOption.js
+++ b/js/views/modals/editListing/ShippingOption.js
@@ -234,7 +234,6 @@ export default class extends BaseView {
         maxItems: null,
         valueField: 'id',
         searchField: ['text', 'id'],
-        closeAfterSelect: false,
         items: this.model.get('regions'),
         options: this.selectCountryData,
         render: {


### PR DESCRIPTION
Reverting back selectize so the menu closes after selecting an option and fixing the issue that required you to click away and then back into the control to re-show the menu.