### PR TITLE
Index abbr num test

### DIFF
--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -78,7 +78,7 @@ describe('our index utilities', () => {
   });
 
   describe('have a abbrNum utility that', () => {
-    it('returns abbreviated a rounded number based on (1000(n) & maximum trillion)', () => {
+    it('returns abbreviated a rounded number for (1000(n) & max trillion)', () => {
       const sourceNumberSet = [123, 1266, 125468,
                              77547959, 388475766449,
                              48242478968789, 482424789687893242];
@@ -90,9 +90,13 @@ describe('our index utilities', () => {
       }
     });
 
-    it('returns no abbreviation if a negative number or 0', () => {
-      const sourceNumberSet = [-12341235, 0];
-      const formattedNumberSet = [-12341235, 0];
+    it('returns abbreviated a rounded negative number for (1000(n) & max trillion)', () => {
+      const sourceNumberSet = [-123, -1266, -125468,
+                             -77547959, -388475766449,
+                             -48242478968789, -482424789687893242];
+      const formattedNumberSet = [-123, '-1.3k', '-125.47k',
+                                '-77.548m', '-388.476b',
+                                '-48.242t', '-482,424.79t'];
       for (let i = 0; i < sourceNumberSet.length; i++) {
         expect(abbrNum(sourceNumberSet[i], i)).to.be.equal(formattedNumberSet[i]);
       }

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { splitIntoRows } from '../../js/utils';
+import { splitIntoRows, abbrNum } from '../../js/utils';
 
 describe('our index utilities', () => {
   describe('have a splitIntoRows utility that', () => {
@@ -74,6 +74,24 @@ describe('our index utilities', () => {
       splitIntoRows([9, 8, 7, 6, 5, 4, 3], 2);
 
       expect(splitIntoRows([9, 8, 7, 6, 5, 4, 3], 2)).to.deep.equal([[9, 8], [7, 6], [5, 4], [3]]);
+    });
+  });
+
+  describe('have a abbrNum utility that', () => {
+    it('returns abbreviated a rounded number based on (1000(n) & maximum trillion)', () => {
+      var sourceNumberSet = [123,1266,125468,77547959,388475766449,48242478968789,482424789687893242,-12341235,0];
+      var formattedNumberSet = [123,'1.3k','125.47k','77.548m','388.476b','48.242t','482,424.79t',-12341235,0];
+      for (let i = 0; i < sourceNumberSet.length;i++) {
+        expect(abbrNum(sourceNumberSet[i],i)).to.be.equal(formattedNumberSet[i]);
+      }
+    });
+
+    it('returns no abbreviation if a negative number or 0', () => {
+      var sourceNumberSet = [-12341235,0];
+      var formattedNumberSet = [-12341235,0];
+      for (let i = 0; i < sourceNumberSet.length;i++) {
+        expect(abbrNum(sourceNumberSet[i],i)).to.be.equal(formattedNumberSet[i]);
+      }
     });
   });
 });

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -79,8 +79,8 @@ describe('our index utilities', () => {
 
   describe('have a abbrNum utility that', () => {
     it('returns abbreviated a rounded number based on (1000(n) & maximum trillion)', () => {
-      var sourceNumberSet = [123,1266,125468,77547959,388475766449,48242478968789,482424789687893242,-12341235,0];
-      var formattedNumberSet = [123,'1.3k','125.47k','77.548m','388.476b','48.242t','482,424.79t',-12341235,0];
+      var sourceNumberSet = [123,1266,125468,77547959,388475766449,48242478968789,482424789687893242];
+      var formattedNumberSet = [123,'1.3k','125.47k','77.548m','388.476b','48.242t','482,424.79t'];
       for (let i = 0; i < sourceNumberSet.length;i++) {
         expect(abbrNum(sourceNumberSet[i],i)).to.be.equal(formattedNumberSet[i]);
       }

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -79,18 +79,22 @@ describe('our index utilities', () => {
 
   describe('have a abbrNum utility that', () => {
     it('returns abbreviated a rounded number based on (1000(n) & maximum trillion)', () => {
-      var sourceNumberSet = [123,1266,125468,77547959,388475766449,48242478968789,482424789687893242];
-      var formattedNumberSet = [123,'1.3k','125.47k','77.548m','388.476b','48.242t','482,424.79t'];
-      for (let i = 0; i < sourceNumberSet.length;i++) {
-        expect(abbrNum(sourceNumberSet[i],i)).to.be.equal(formattedNumberSet[i]);
+      const sourceNumberSet = [123, 1266, 125468,
+                             77547959, 388475766449,
+                             48242478968789, 482424789687893242];
+      const formattedNumberSet = [123, '1.3k', '125.47k',
+                                '77.548m', '388.476b',
+                                '48.242t', '482,424.79t'];
+      for (let i = 0; i < sourceNumberSet.length; i++) {
+        expect(abbrNum(sourceNumberSet[i], i)).to.be.equal(formattedNumberSet[i]);
       }
     });
 
     it('returns no abbreviation if a negative number or 0', () => {
-      var sourceNumberSet = [-12341235,0];
-      var formattedNumberSet = [-12341235,0];
-      for (let i = 0; i < sourceNumberSet.length;i++) {
-        expect(abbrNum(sourceNumberSet[i],i)).to.be.equal(formattedNumberSet[i]);
+      const sourceNumberSet = [-12341235, 0];
+      const formattedNumberSet = [-12341235, 0];
+      for (let i = 0; i < sourceNumberSet.length; i++) {
+        expect(abbrNum(sourceNumberSet[i], i)).to.be.equal(formattedNumberSet[i]);
       }
     });
   });

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -82,10 +82,11 @@ describe('our index utilities', () => {
       const sourceNumberSet = [123, 1266, 125468,
                              77547959, 388475766449,
                              48242478968789, 482424789687893242];
-      const formattedNumberSet = [123, '1.3k', '125.47k',
+      const formattedNumberSet = ['123', '1.3k', '125.47k',
                                 '77.548m', '388.476b',
                                 '48.242t', '482,424.79t'];
       for (let i = 0; i < sourceNumberSet.length; i++) {
+        expect(abbrNum(sourceNumberSet[i], i)).to.be.a('string');
         expect(abbrNum(sourceNumberSet[i], i)).to.be.equal(formattedNumberSet[i]);
       }
     });
@@ -94,10 +95,11 @@ describe('our index utilities', () => {
       const sourceNumberSet = [-123, -1266, -125468,
                              -77547959, -388475766449,
                              -48242478968789, -482424789687893242];
-      const formattedNumberSet = [-123, '-1.3k', '-125.47k',
+      const formattedNumberSet = ['-123', '-1.3k', '-125.47k',
                                 '-77.548m', '-388.476b',
                                 '-48.242t', '-482,424.79t'];
       for (let i = 0; i < sourceNumberSet.length; i++) {
+        expect(abbrNum(sourceNumberSet[i], i)).to.be.a('string');
         expect(abbrNum(sourceNumberSet[i], i)).to.be.equal(formattedNumberSet[i]);
       }
     });


### PR DESCRIPTION
Noticed there was no test for js/utils/indexjs abbrNum() function so I added in the following test scenarios:

- Test for negative number
- Test for 0
- Test for n < 1000
- Test for n < 1000000
- Test for n < 1000000000
- Test for n < 1000000000000
- Test for n > 1000000000000
- Test for rounded numbers up to 6 decimal places

**(Please Note: This should not be merged until #1119 is merged)**