### PR TITLE
Update node sass for latest node

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "electron-winstaller": "2.5.2",
     "jsdom": "9.4.1",
     "mocha": "^2.5.3",
-    "node-sass": "^3.13.0",
+    "node-sass": "^4.7.2",
     "nodemon": "^1.9.2",
     "npm-run-all": "^2.2.0",
     "sinon": "^1.17.6"


### PR DESCRIPTION
This updates node-sass to the latest version (4.72), v3.13.0 isn’t compatible with node 8.