### PR TITLE
Don't check for crypto in the exchange data

### DIFF
--- a/js/utils/currency.js
+++ b/js/utils/currency.js
@@ -241,11 +241,13 @@ export function convertCurrency(amount, fromCur, toCur) {
     return amount;
   }
 
-  if (!exchangeRates[fromCurCaps]) {
+  // Don't check for BTC and TBTC, they aren't in the exchange data
+  if (fromCurCaps !== 'BTC' && fromCurCaps !== 'TBTC' && !exchangeRates[fromCurCaps]) {
     throw new NoExchangeRateDataError(`We do not have exchange rate data for ${fromCurCaps}.`);
   }
 
-  if (!exchangeRates[toCurCaps]) {
+  // Don't check for BTC and TBTC, they aren't in the exchange data
+  if (toCurCaps !== 'BTC' && toCurCaps !== 'TBTC' && !exchangeRates[toCurCaps]) {
     throw new NoExchangeRateDataError(`We do not have exchange rate data for ${toCurCaps}.`);
   }
 


### PR DESCRIPTION
This prevents the convertCurrency function from throwing an error when it doesn't find BTC or TBTC in the exchangeRate data, as those currencies aren't in the data and aren't needed.

Note: while this fixes the bug being reported by multiple users in 2.0.20, this code hasn't been changed in 8 months, and I feel it's highly likely some other change caused this bug, which still needs to be investigated.

Note: the same change will need to be made with the alt coin branches to use the current crypto currency instead of being hard coded to BTC and TBTC.