### PR TITLE
Remove unneeded smartCount

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -297,7 +297,7 @@
   },
   "reputation": {
     "averageRating": "overall rating",
-    "totalReviews": "%{smart_count} review |||| %{smart_count} reviews",
+    "totalReviews": "review |||| reviews",
     "noTitle": "Listing title not found"
 
   },
@@ -1814,7 +1814,7 @@
   "cryptoCurrencyFormat": {
     "curSymbolAmount": "%{symbol}%{amount}",
     "curCodeAmount": "%{amount} %{code}"
-  },  
+  },
   "countries": {
     "AFGHANISTAN": "Afghanistan",
     "ALAND_ISLANDS": "Aland Islands",


### PR DESCRIPTION
Removes an unneeded smart_count that was left in by accident when the design changed.

Closes #1169 