### PR TITLE
Remove link to out of date docs page

### DIFF
--- a/main.js
+++ b/main.js
@@ -176,11 +176,20 @@ function createWindow() {
 
   let helpSubmenu = [
     {
+      label: 'Website',
+      click() {
+        shell.openExternal('https://openbazaar.org');
+      },
+    },
+    // until the documentation page is updated, don't show it
+    /*
+    {
       label: 'Documentation',
       click() {
         shell.openExternal('https://docs.openbazaar.org');
       },
     },
+    */
     {
       label: 'Support',
       click() {


### PR DESCRIPTION
- comments out the menu option to open the out of date docs page
- adds a link to the main website, which is useful and it's nice for the
help sub-menu not to be just one link if it's not a bundled app