### PR TITLE
Move Order Details Error check

### DIFF
--- a/js/views/modals/orderDetail/OrderDetail.js
+++ b/js/views/modals/orderDetail/OrderDetail.js
@@ -127,6 +127,7 @@ export default class extends BaseModal {
     this.stopListening(this.model, null, this.onOrderRequest);
     const featuredProfileState = { isFetching: false };
     let featuredProfileFetch;
+    console.log(this.model.toJSON())
 
     if (this.type === 'case') {
       if (this.model.get('buyerOpened')) {
@@ -181,11 +182,6 @@ export default class extends BaseModal {
   get participantIds() {
     if (!this._participantIds) {
       let contract = this.model.get('contract');
-
-      if (!contract) {
-        throw new Error('Unable to determine the participant IDs. The contract is not ' +
-          'available. The order model has likely not been synced yet.');
-      }
 
       if (this.type === 'case') {
         contract = this.model.get('buyerOpened') ?

--- a/js/views/modals/orderDetail/OrderDetail.js
+++ b/js/views/modals/orderDetail/OrderDetail.js
@@ -127,7 +127,6 @@ export default class extends BaseModal {
     this.stopListening(this.model, null, this.onOrderRequest);
     const featuredProfileState = { isFetching: false };
     let featuredProfileFetch;
-    console.log(this.model.toJSON())
 
     if (this.type === 'case') {
       if (this.model.get('buyerOpened')) {

--- a/js/views/modals/orderDetail/OrderDetail.js
+++ b/js/views/modals/orderDetail/OrderDetail.js
@@ -188,6 +188,11 @@ export default class extends BaseModal {
           this.model.get('vendorContract');
       }
 
+      if (!contract) {
+        throw new Error('Unable to determine the participant IDs. The contract is not ' +
+          'available. The order model has likely not been synced yet.');
+      }
+
       const contractJSON = contract.toJSON();
 
       this._participantIds = {


### PR DESCRIPTION
There's a check for a contract object in the orderDetails model in the orderDetails view. For a case, there will never be a contract, just a buyerContract or vendorContract, which was making it impossible for moderators to open their cases.

Edit: I put the test back, but moved it after the contract was set for cases.