### PR TITLE
use qrCodeText from the currency instead of hard coding bitcoin

### DIFF
--- a/js/views/modals/purchase/Payment.js
+++ b/js/views/modals/purchase/Payment.js
@@ -175,7 +175,8 @@ export default class extends BaseVw {
   }
 
   get qrDataUri() {
-    const btcURL = `bitcoin:${this.paymentAddress}?amount=${this.balanceRemaining}`;
+    const address = getServerCurrency().qrCodeText(this.paymentAddress);
+    const btcURL = `${address}?amount=${this.balanceRemaining}`;
     return qr(btcURL, { type: 8, size: 5, level: 'Q' });
   }
 

--- a/js/views/modals/wallet/ReceiveMoney.js
+++ b/js/views/modals/wallet/ReceiveMoney.js
@@ -91,7 +91,7 @@ export default class extends baseVw {
       const address = this.getState().address;
 
       if (address) {
-        qrDataUri = qr(`bitcoin:${address}`,
+        qrDataUri = qr(getServerCurrency().qrCodeText(address),
           { type: 6, size: 5, level: 'Q' });
       }
 


### PR DESCRIPTION
Uses the qrCodeText function from data.cryptoCurrencies to set the address of the QR code in the wallet and purchase sections correctly.

Closes #1187 