### PR TITLE
Fix view listing

### DIFF
--- a/js/utils/modalManager.js
+++ b/js/utils/modalManager.js
@@ -32,14 +32,9 @@ export function launchEditListingModal(modalOptions = {}) {
     }
   }
 
-  const editListingModal = new EditListing(modalOptions);
-  // use a timeout to prevent the editModal from being undefined when the view listing
-  // function is set due to the override of the open method
-  setTimeout(() => {
-    editListingModal.render()
-      .open();
-  });
-
+  const editListingModal = new EditListing(modalOptions)
+    .render()
+    .open();
 
   return editListingModal;
 }

--- a/js/utils/modalManager.js
+++ b/js/utils/modalManager.js
@@ -36,7 +36,8 @@ export function launchEditListingModal(modalOptions = {}) {
   // use a timeout to prevent the editModal from being undefined when the view listing
   // function is set due to the override of the open method
   setTimeout(() => {
-    editListingModal.render().open();
+    editListingModal.render()
+      .open();
   });
 
 

--- a/js/utils/modalManager.js
+++ b/js/utils/modalManager.js
@@ -32,9 +32,13 @@ export function launchEditListingModal(modalOptions = {}) {
     }
   }
 
-  const editListingModal = new EditListing(modalOptions)
-    .render()
-    .open();
+  const editListingModal = new EditListing(modalOptions);
+  // use a timeout to prevent the editModal from being undefined when the view listing
+  // function is set due to the override of the open method
+  setTimeout(() => {
+    editListingModal.render().open();
+  });
+
 
   return editListingModal;
 }

--- a/js/views/modals/editListing/EditListing.js
+++ b/js/views/modals/editListing/EditListing.js
@@ -836,7 +836,7 @@ export default class extends BaseModal {
       try {
         cur = this._origModel.unparsedResponse.listing.metadata.pricingCurrency;
       } catch (e) {
-        return;
+        return this;
       }
 
       if (getCurrencyValidity(cur) === 'UNRECOGNIZED_CURRENCY') {
@@ -854,6 +854,7 @@ export default class extends BaseModal {
         });
       }
     }
+    return this;
   }
 
   get trackInventoryBy() {


### PR DESCRIPTION
This fixes a weird bug where the override of the open method in the edit listing modal view on line 829 of EditListing.js caused this.editModal to be undefined in line 179 of Listing.js when the modal view was created.

I'm not entirely sure why that was happening, but adding a timeout to the render and open of the modal fixed it.

Removing the override of the open method also fixes it, but we can't just remove that.