### PR TITLE
Don't show the refund link if disputed

### DIFF
--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -72,11 +72,8 @@ export default class extends BaseVw {
         const acceptedState = {
           showFulfillButton: false,
           infoText: app.polyglot.t('orderDetail.summaryTab.accepted.vendorReceived'),
+          showRefundButton: false,
         };
-
-        if (state !== 'DISPUTED') {
-          acceptedState.showRefundButton = false;
-        }
 
         this.accepted.setState(acceptedState);
       }
@@ -468,7 +465,6 @@ export default class extends BaseVw {
       showRefundButton: isVendor && [
         'AWAITING_FULFILLMENT',
         'PARTIALLY_FULFILLED',
-        'DISPUTED',
       ].indexOf(orderState) > -1,
       showFulfillButton: canFulfill,
     };


### PR DESCRIPTION
Allowing the vendor to issue a refund while an order is in a disputed state isn't being handled on the server, and shouldn't be an option. 

This PR does not show the refund link when the order is in a disputed state. There will be a separate PR for the server to prevent the refund API from allowing a call when the order is disputed.