### PR TITLE
fixing reference to non existent object in the Payment view

### DIFF
--- a/js/views/modals/purchase/Payment.js
+++ b/js/views/modals/purchase/Payment.js
@@ -67,7 +67,6 @@ export default class extends BaseVw {
   set balanceRemaining(amount) {
     if (amount !== this._balanceRemaining) {
       this._balanceRemaining = amount;
-      this.confirmWallet.render();
       this.$amountDueLine.html(this.amountDueLine);
       this.$qrCodeImg.attr('src', this.qrDataUri);
     }


### PR DESCRIPTION
Probably an oversight on a refactor, but this was causing the Payment view to throw an exception on partial payments and the remaining balance not decrement.