### PR TITLE
Don't allow adding moderators without compatible coins

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -367,7 +367,9 @@
     "termsOfService": "Terms of Service",
     "addAsModeratorButton": "Add as Moderator",
     "disclaimer": "**The moderator service charge only applies when a dispute arises.",
-    "languages": "Languages"
+    "languages": "Languages",
+    "currenciesSupported": "Currencies Supported",
+    "noCoinSupport": "This moderator does not support %{coin}."
   },
   "about": {
     "linkText": "About OpenBazaar",
@@ -917,6 +919,7 @@
     "type": "Type: %{type}",
     "condition": "Condition: %{condition}",
     "tags": "Tags",
+    "paymentsAccepted": "Payments Accepted",
     "noTags": "No tags entered",
     "buyNow": "BUY NOW",
     "description": "Description",

--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -43,7 +43,7 @@
     <div class="flex gutterHLg">
       <h2 class="txUnb flexExpand"><%= ob.item.title %></h2>
       <h2 class="txUnb flexNoShrink js-price">
-        <%= 
+        <%=
           ob.currencyMod.formattedCurrency(
             ob.item.price,
             ob.metadata.pricingCurrency,
@@ -104,7 +104,7 @@
                 unpurchaseable = false;
               }
 
-              let unpurchasableMarkup = `<div class="flexHRight clrTErr">${ob.polyT('listingDetail.unableToPurchase.unpurchaseable') } &nbsp;<span class="toolTip"   data-tip="${tip}" style="text-align: left"><span class="ion-alert-circled clrTErr"></span></span></div>`;              
+              let unpurchasableMarkup = `<div class="flexHRight clrTErr">${ob.polyT('listingDetail.unableToPurchase.unpurchaseable') } &nbsp;<span class="toolTip"   data-tip="${tip}" style="text-align: left"><span class="ion-alert-circled clrTErr"></span></span></div>`;
             %>
             <button class="btnHg clrBAttGrad clrBrDec1 clrTOnEmph js-purchaseBtn <%= buyNowClass %>">
               <%= ob.polyT('listingDetail.buyNow') %>
@@ -136,7 +136,7 @@
           }); %>
           <% if(!ob.item.tags.length) { print(`<i class="clrT2">${ob.polyT('listingDetail.noTags')}</i>`) } %>
         </div>
-        <h5>Payments Accepted</h5>
+        <h5><%= ob.polyT('listingDetail.paymentsAccepted') %></h5>
         <ul class="unstyled">
           <% ob.metadata.acceptedCurrencies.forEach(cur => {
             const curData = ob.currencyMod.getCryptoCurByCode(cur);
@@ -146,7 +146,7 @@
                 <%= ob.currencyMod.cryptoIcon({ code: curData.code }) %>
                 <div class="acceptedCurName"><%= ob.polyT(`cryptoCurrencies.${curData.code}`) %></div>
               </li>
-            <% }            
+            <% }
           }) %>
         </ul>
       </div>

--- a/js/templates/modals/moderatorDetails.html
+++ b/js/templates/modals/moderatorDetails.html
@@ -44,10 +44,25 @@
       </div>
     </div>
     <div class="contentBox mDetailBox padMd clrP clrBr clrSh3 tx5">
+      <div class="rowMd">
+        <h4><%= ob.polyT('moderatorDetails.currenciesSupported') %></h4>
+        <ul class="unstyled">
+          <% ob.moderatorInfo.acceptedCurrencies.forEach(cur => {
+            const curData = ob.currencyMod.getCryptoCurByCode(cur);
+            if (curData) { %>
+              <li class="flexVCent gutterHSm clrBr">
+                <span class="ion-ios-checkmark-empty clrTEm tx2"></span>
+                <%= ob.currencyMod.cryptoIcon({ code: curData.code }) %>
+                <div class="acceptedCurName"><%= ob.polyT(`cryptoCurrencies.${curData.code}`) %></div>
+              </li>
+            <% }
+          }) %>
+        </ul>
+      </div>
       <div class="rowLg">
         <h4><%= ob.polyT('moderatorDetails.languages') %></h4>
         <% ob.modLanguages.forEach(lang => { %>
-        <div class="rowSm txSm"><%= lang %></div>
+          <div class="rowSm txSm"><%= lang %></div>
         <% }); %>
       </div>
       <div class="row">
@@ -57,13 +72,19 @@
       </div>
       <div class="flexCol flexHCent gutterV">
         <% if (ob.cardState !== 'selected' && (!ob.ownMod || ob.purchase)) { %>
-          <button class="btn clrP clrBr js-addAsModerator">
-            <% if (ob.purchase) { %>
-              <%= ob.polyT('purchase.chooseModerator') %>
-            <% } else { %>
-              <%= ob.polyT('moderatorDetails.addAsModeratorButton') %>
-            <% } %>
-          </button>
+          <% if (ob.moderatorInfo.acceptedCurrencies.indexOf(ob.currencyMod.getServerCurrency().code) !== -1) { %>
+            <button class="btn clrP clrBr js-addAsModerator">
+              <% if (ob.purchase) { %>
+                <%= ob.polyT('purchase.chooseModerator') %>
+              <% } else { %>
+                <%= ob.polyT('moderatorDetails.addAsModeratorButton') %>
+              <% } %>
+            </button>
+          <% } else { %>
+            <strong>
+              <%= ob.polyT('moderatorDetails.noCoinSupport', { coin: ob.currencyMod.getServerCurrency().code }) %>
+            </strong>
+          <% } %>
         <% } %>
         <div>
           <em class="tx6 clrT2"><%= ob.polyT('moderatorDetails.disclaimer') %></em>

--- a/js/templates/modals/moderatorDetails.html
+++ b/js/templates/modals/moderatorDetails.html
@@ -72,7 +72,11 @@
       </div>
       <div class="flexCol flexHCent gutterV">
         <% if (ob.cardState !== 'selected' && (!ob.ownMod || ob.purchase)) { %>
-          <% if (ob.moderatorInfo.acceptedCurrencies.indexOf(ob.currencyMod.getServerCurrency().code) !== -1) { %>
+          <%
+          const curSupported = ob.moderatorInfo.acceptedCurrencies.includes(
+            ob.currencyMod.getServerCurrency().isTestnet ?   ob.currencyMod.getServerCurrency().testnetCode :   ob.currencyMod.getServerCurrency().code
+          );
+          if (curSupported) { %>
             <button class="btn clrP clrBr js-addAsModerator">
               <% if (ob.purchase) { %>
                 <%= ob.polyT('purchase.chooseModerator') %>

--- a/js/templates/userCard.html
+++ b/js/templates/userCard.html
@@ -23,12 +23,16 @@
     <% if (!ob.hideControls) { %>
       <div class="userControls flexHRight gutterHSm">
         <% if (!ob.ownGuid) { %>
-          <% if (ob.moderator && ob.moderatorInfo.acceptedCurrencies.indexOf(ob.currencyMod.getServerCurrency().code) !== -1) { %>
-            <%= ob.processingButton({
-            className: `iconBtnSm clrP clrBr toolTipNoWrap toolTipTop js-mod ${ob.ownMod ? 'active' : ''}`,
-            btnText: '<i class="ion-briefcase"></i>',
-            attrs: `data-tip="${ob.getModTip(ob.ownMod)}"`,
-            }) %>
+          <%
+            const curSupported = ob.moderator && ob.moderatorInfo.acceptedCurrencies.includes(
+              ob.currencyMod.getServerCurrency().isTestnet ?   ob.currencyMod.getServerCurrency().testnetCode :   ob.currencyMod.getServerCurrency().code
+            );
+            if (curSupported) { %>
+              <%= ob.processingButton({
+              className: `iconBtnSm clrP clrBr toolTipNoWrap toolTipTop js-mod ${ob.ownMod ? 'active' : ''}`,
+              btnText: '<i class="ion-briefcase"></i>',
+              attrs: `data-tip="${ob.getModTip(ob.ownMod)}"`,
+              }) %>
           <% } %>
           <%= ob.processingButton({
             className: `iconBtnSm clrP clrBr toolTipNoWrap toolTipTop js-follow ${ob.followedByYou ? 'active' : ''}`,

--- a/js/templates/userCard.html
+++ b/js/templates/userCard.html
@@ -8,7 +8,7 @@
     <% } %>>
     <div class="blockedOverlay clrP flexCent tx5">
       <div><%= ob.polyT('userShort.blockedUserOverlayText') %></div>
-    </div>    
+    </div>
     <div class="userIconWrap">
       <a class="userIcon disc clrBr2 clrSh1"
         <% var avatarHash = ob.avatarHashes ? ob.isHiRez() ? ob.avatarHashes.small : ob.avatarHashes.tiny : ''; %>
@@ -23,7 +23,7 @@
     <% if (!ob.hideControls) { %>
       <div class="userControls flexHRight gutterHSm">
         <% if (!ob.ownGuid) { %>
-          <% if (ob.moderator) { %>
+          <% if (ob.moderator && ob.moderatorInfo.acceptedCurrencies.indexOf(ob.currencyMod.getServerCurrency().code) !== -1) { %>
             <%= ob.processingButton({
             className: `iconBtnSm clrP clrBr toolTipNoWrap toolTipTop js-mod ${ob.ownMod ? 'active' : ''}`,
             btnText: '<i class="ion-briefcase"></i>',


### PR DESCRIPTION
This adds a check to make sure users don't add moderators that don't support their current crypto coin.

The moderator button on the user card is hidden if the moderator doesn't support the user's coin.

On the moderator details modal, the moderator's supported currencies are shown, and the add button is replaced with a message stating the user's coin isn't supported by this moderator if that's the case. 

Closes #1195 
