### PR TITLE
Keep Parameters Between Search Providers

### DIFF
--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -170,11 +170,6 @@ export default class extends baseVw {
     let filters = $.param({ ...this.filterParams, ...formData });
     filters = !filters || reset ? '' : `&${filters}`;
     const newURL = new URL(`${this.providerUrl}?${query}${network}${sortBy}${page}${filters}`);
-    const newParams = newURL.searchParams;
-    // if there is no nsfw filter on the page, still send the default value to the provider
-    if (!newParams.has('nsfw')) {
-      newParams.append('nsfw', app.settings.get('showNsfw'));
-    }
     this.callSearchProvider(newURL);
   }
 

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -185,6 +185,8 @@ export default class extends baseVw {
     if (app.searchProviders.indexOf(md) === -1) {
       throw new Error('The provider must be in the collection.');
     }
+    // capture old filters before changing to the new provider
+    this.filterParams = { ...this.filterParams, ...this.getFormData(this.$filters) };
     this.sProvider = md;
     this.queryProvider = false;
     this.serverPage = 0;

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -165,8 +165,9 @@ export default class extends baseVw {
     const page = `&p=${this.serverPage}&ps=${this.pageSize}`;
     const sortBy = this.sortBySelected ? `&sortBy=${encodeURIComponent(this.sortBySelected)}` : '';
     const network = `&network=${!!app.serverConfig.testnet ? 'testnet' : 'mainnet'}`;
-    // if the DOM is ready, use the form values. Otherwise use the values set in the constructor.
-    let filters = this.$filters ? this.$filters.serialize() : $.param(this.filterParams);
+    const formData = this.getFormData(this.$filters);
+    // keep any parameters that aren't present in the form on the page
+    let filters = $.param({ ...this.filterParams, ...formData });
     filters = !filters || reset ? '' : `&${filters}`;
     const newURL = new URL(`${this.providerUrl}?${query}${network}${sortBy}${page}${filters}`);
     const newParams = newURL.searchParams;
@@ -196,7 +197,7 @@ export default class extends baseVw {
       this.mustSelectDefault = false;
       this.makeDefaultProvider();
     }
-    this.processTerm(this.term, true);
+    this.processTerm(this.term);
   }
 
   deleteProvider(md = this.sProvider) {


### PR DESCRIPTION
This PR will clear the parameters and re-apply the defaults (nsfw from the user's settings, and acceptedCurrency from their server) when switching providers.

This will make switching between providers the same as clicking the discover button, or, if a search term is in use, searching for that term with no other parameters in the address bar.