### PR TITLE
Set Max Width for Images in Home Tab

### DIFF
--- a/js/templates/userPage/home.html
+++ b/js/templates/userPage/home.html
@@ -69,7 +69,7 @@
   </div>
   <div class="col8">
     <div class="box">
-      <div class="contentBox padMd clrBr clrP clrSh2">
+      <div class="aboutBox contentBox padMd clrBr clrP clrSh2">
         <div class="informationHeader row">
           <strong><%= ob.polyT('userPage.about') %></strong>
         </div>

--- a/styles/modules/_userPage.scss
+++ b/styles/modules/_userPage.scss
@@ -83,6 +83,10 @@
       }
     }
 
+    .userPageHome .aboutBox img {
+      max-width: 100%;
+    }
+
     .userPageFollow {
       .userCardsContainer {
         flex-wrap: wrap;


### PR DESCRIPTION
This adds a max-width of 100% to images the user adds to their home tab.

There is an option in the editor to allow for user-defined widths when adding an image URL, but the attributes are stripped from the image when the code is returned from the server. We could change that if we felt it was a good idea to let the user set their own image widths.

Closes #1243