### PR TITLE
Always have right index for removed mod

### DIFF
--- a/js/views/components/Moderators.js
+++ b/js/views/components/Moderators.js
@@ -110,8 +110,9 @@ export default class extends baseVw {
       }
       this.render();
     });
-    this.listenTo(this.moderatorsCol, 'remove', (md, cl, rOpts) => {
-      this.modCards.splice(rOpts.index, 1)[0].remove();
+    this.listenTo(this.moderatorsCol, 'remove', (md) => {
+      const removeIndex = this.modCards.findIndex(card => card.model === md);
+      this.modCards.splice(removeIndex, 1)[0].remove();
       this.render();
     });
     this.modCards = [];

--- a/js/views/components/Moderators.js
+++ b/js/views/components/Moderators.js
@@ -113,7 +113,6 @@ export default class extends baseVw {
     this.listenTo(this.moderatorsCol, 'remove', (md) => {
       const removeIndex = this.modCards.findIndex(card => card.model === md);
       this.modCards.splice(removeIndex, 1)[0].remove();
-      this.render();
     });
     this.modCards = [];
 


### PR DESCRIPTION
When I updated the code to always order verified mods first in the array, it broke the method of finding the index of the cached card view to remove when de-selecting mods in settings/store.

This changes to a more reliable method that doesn't assume the order never changes.