### PR TITLE
Addresses need to be URL encoded before being used for map lookup

### DIFF
--- a/js/templates/modals/orderDetail/summaryTab/orderDetails.html
+++ b/js/templates/modals/orderDetail/summaryTab/orderDetails.html
@@ -16,7 +16,10 @@
           .replace('/n', '')
           .replace(/\s/g, '+');
       });
-    var mapUrl = `https://www.google.com/maps/place/${addressParts.join(',')}`;
+
+    let queryString = encodeURIComponent(addressParts.join(','));
+
+    var mapUrl = `https://www.google.com/maps/place/${queryString}`;
   }
 
   // For now we're only supporting one item per order, so we'll hard-code a reference to the


### PR DESCRIPTION
The view on map link would not work with my address. The reason for this is because my address includes a slash. The patch URL encodes the address before being used.