### PR TITLE
Mod tweaks

### DIFF
--- a/js/start.js
+++ b/js/start.js
@@ -19,6 +19,7 @@ import ObRouter from './router';
 import { getChatContainer, getBody } from './utils/selectors';
 import { setFeedbackOptions, addFeedback } from './utils/feedback';
 import { showUpdateStatus, updateReady } from './utils/autoUpdate';
+import { handleLinks } from './utils/dom';
 import Chat from './views/chat/Chat.js';
 import ChatHeads from './collections/ChatHeads';
 import PageNav from './views/PageNav.js';
@@ -36,7 +37,7 @@ import { fetchExchangeRates } from './utils/currency';
 import './utils/exchangeRateSyncer';
 import { launchDebugLogModal, launchSettingsModal } from './utils/modalManager';
 import listingDeleteHandler from './startup/listingDelete';
-import { fixLinuxZoomIssue, handleLinks, handleServerShutdownRequests } from './startup';
+import { fixLinuxZoomIssue, handleServerShutdownRequests } from './startup';
 import ConnectionManagement from './views/modals/connectionManagement/ConnectionManagement';
 import Onboarding from './views/modals/onboarding/Onboarding';
 import WalletSetup from './views/modals/WalletSetup';
@@ -124,7 +125,7 @@ app.loadingModal = new LoadingModal({
   removeOnRoute: false,
 }).render().open(startupConnectMessaging);
 
-handleLinks();
+handleLinks(document);
 
 // add the feedback mechanism
 addFeedback();

--- a/js/startup/index.js
+++ b/js/startup/index.js
@@ -1,14 +1,12 @@
 // Putting start-up related one offs here that are too small for their own module and
 // aren't appropriate to be in any existing module
 
-import { screen, shell, ipcRenderer } from 'electron';
+import { screen, ipcRenderer } from 'electron';
 import { platform } from 'os';
 import $ from 'jquery';
 import { getBody } from '../utils/selectors';
 import { getCurrentConnection } from '../utils/serverConnect';
 import app from '../app';
-import Backbone from 'backbone';
-import TorExternalLinkWarning from '../views/modals/TorExternalLinkWarning';
 
 export function fixLinuxZoomIssue() {
   // fix zoom issue on Linux hiDPI
@@ -22,61 +20,6 @@ export function fixLinuxZoomIssue() {
     getBody().css('zoom', 1 / scaleFactor);
   }
 }
-
-/**
- * For most cases, this handler will be able to identify an external link because
- * it will be prefaced with an "external" protocol (e.g. http, ftp). An exception
- * to this is any user based url (e.g. www.espn.com). In that case, add a
- * 'data-open-external' attribute to the url to force it to be opened externally.
- */
-export function handleLinks() {
-  $(document).on('click', 'a:not([data-bypass])', (e) => {
-    const $a = $(e.target).closest('a');
-    const openExternally = $a.data('openExternal') !== undefined;
-    let href = $a.attr('href');
-
-    // Anchor without href is likely being handled programatically.
-    if (!href) return;
-
-    const link = document.createElement('a');
-    link.setAttribute('href', href);
-
-    if (link.protocol !== location.protocol || openExternally) {
-      if (link.protocol === 'ob:' && !openExternally) {
-        Backbone.history.navigate(href.slice(5), true);
-      } else {
-        // external link
-        const activeServer = app.serverConfigs.activeServer;
-        const localSettings = app.localSettings;
-        const warningOptedOut = app.localSettings &&
-          localSettings.get('dontShowTorExternalLinkWarning');
-
-        if (activeServer && activeServer.get('useTor') && !warningOptedOut) {
-          const warningModal = new TorExternalLinkWarning({ url: href })
-            .render()
-            .open();
-
-          warningModal.on('cancelClick', () => warningModal.close());
-          warningModal.on('confirmClick', () => {
-            shell.openExternal(link.protocol === 'file:' ? `http://${href}` : href);
-            warningModal.close();
-          });
-        } else {
-          shell.openExternal(link.protocol === 'file:' ? `http://${href}` : href);
-        }
-      }
-    } else {
-      if (!href.startsWith('#')) {
-        href = `#${href}`;
-      }
-
-      Backbone.history.navigate(href, true);
-    }
-
-    e.preventDefault();
-  });
-}
-
 
 /**
  * This function will accept requests from the main process to shutdown the OB server daemon.

--- a/js/templates/components/moderatorCard.html
+++ b/js/templates/components/moderatorCard.html
@@ -5,7 +5,7 @@
    const style = ob.verified ? 'verified clrBrAlert2 clrBAlert2Grad' : '';
 %>
 
-<div class="moderatorCardInner js-moderatorCard clrP <%= isDisabled %> <%= style %>">
+<div class="moderatorCardInner clrP <%= isDisabled %> <%= style %>">
   <div class="flexRow gutterH moderatorCardContent">
     <% if (ob.radioStyle) { %>
       <div class="flexNoShrink">

--- a/js/utils/dom.js
+++ b/js/utils/dom.js
@@ -78,8 +78,6 @@ export function stripHtml(text) {
  */
 export function handleLinks(el) {
   $(el).on('click', 'a:not([data-bypass])', (e) => {
-    console.log('can you feel the funk?');
-
     const $a = $(e.target).closest('a');
     const openExternally = $a.data('openExternal') !== undefined;
     let href = $a.attr('href');

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -193,8 +193,6 @@ export default class extends baseVw {
 
   onClick(e) {
     if (this.deleteConfirmOn) return;
-    const verifiedIDs = app.verifiedMods.matched(this.model.get('moderators') || []);
-    if (verifiedIDs.length && $.contains(this.getCachedEl('.js-verifiedMod')[0], e.target)) return;
     if (!this.ownListing ||
         (e.target !== this.$btnEdit[0] && e.target !== this.$btnDelete[0] &&
          !$.contains(this.$btnEdit[0], e.target) && !$.contains(this.$btnDelete[0], e.target))) {

--- a/js/views/baseVw.js
+++ b/js/views/baseVw.js
@@ -5,6 +5,10 @@ import { View } from 'backbone';
 
 export default class baseVw extends View {
   constructor(options = {}) {
+    // const opts = {
+    //   handle
+    // };
+
     super(options);
     this._childViews = [];
     this._unregisterFromParent = true;

--- a/js/views/baseVw.js
+++ b/js/views/baseVw.js
@@ -5,10 +5,6 @@ import { View } from 'backbone';
 
 export default class baseVw extends View {
   constructor(options = {}) {
-    // const opts = {
-    //   handle
-    // };
-
     super(options);
     this._childViews = [];
     this._unregisterFromParent = true;

--- a/js/views/components/ModeratorCard.js
+++ b/js/views/components/ModeratorCard.js
@@ -3,9 +3,9 @@ import loadTemplate from '../../utils/loadTemplate';
 import app from '../../app';
 import Profile from '../../models/profile/Profile';
 import VerifiedMod from './VerifiedMod';
+import { handleLinks } from '../../utils/dom';
 import { launchModeratorDetailsModal } from '../../utils/modalManager';
 import { getLangByCode } from '../../data/languages';
-
 
 export default class extends BaseVw {
   constructor(options = {}) {
@@ -36,6 +36,8 @@ export default class extends BaseVw {
     if (!this.model || !(this.model instanceof Profile)) {
       throw new Error('Please provide a Profile model.');
     }
+
+    handleLinks(this.el);
   }
 
   className() {
@@ -45,7 +47,7 @@ export default class extends BaseVw {
   events() {
     return {
       'click .js-viewBtn': 'clickModerator',
-      'click .js-moderatorCard': 'clickSelectBtn',
+      click: 'click',
     };
   }
 
@@ -61,7 +63,7 @@ export default class extends BaseVw {
     });
   }
 
-  clickSelectBtn(e) {
+  click(e) {
     e.stopPropagation();
     this.rotateSelectState();
   }

--- a/js/views/components/Moderators.js
+++ b/js/views/components/Moderators.js
@@ -313,7 +313,11 @@ export default class extends baseVw {
     });
     // add verified mods to the beginning
     if (app.verifiedMods.get(model.get('peerID'))) {
-      this.modCards.unshift(modCard);
+      const firstUnverifiedIndex = this.modCards.findIndex(card =>
+        !app.verifiedMods.get(card.model.get('peerID')));
+      const insertAtIndex = firstUnverifiedIndex < 0 ?
+        0 : firstUnverifiedIndex;
+      this.modCards.splice(insertAtIndex, 0, modCard);
     } else {
       this.modCards.push(modCard);
     }

--- a/js/views/components/VerifiedMod.js
+++ b/js/views/components/VerifiedMod.js
@@ -2,6 +2,7 @@ import BaseVw from '../baseVw';
 import loadTemplate from '../../utils/loadTemplate';
 import VerifiedMod from '../../models/VerifiedMod';
 import app from '../../app';
+import { handleLinks } from '../../utils/dom';
 
 export default class extends BaseVw {
   constructor(options = {}) {
@@ -17,6 +18,8 @@ export default class extends BaseVw {
     // If no model is passed in, show the non-verified state instead
     // For listings, this model might be just the first verified moderator on the listing.
     this.verified = options.model && options.model instanceof VerifiedMod;
+
+    handleLinks(this.el);
   }
 
   className() {
@@ -25,8 +28,12 @@ export default class extends BaseVw {
 
   events() {
     return {
-      'click .js-badge': 'onClickBadge',
+      click: 'onClick',
     };
+  }
+
+  onClick(e) {
+    e.stopPropagation();
   }
 
   render() {


### PR DESCRIPTION
- Slight tweak to the global link handler because it's previous incarnation would result in links not working if you stopped propagation on any element which contains links. With the tweak, anytime you have such an element you should be sure to explicitly call handleLinks and pass in that element.

@jjeffryes Not only had this been an issue on the listing card (which you fixed), I also found it to be an issue on the moderator component. Since propogation was being prevented on that, the learn more link was not working on the verified mod tip within it.

- Tweak to how verified mods are added to the moderators component. Previously they were being added to the top as they came in. The problems with that were:

a.) A few load, you want to select one of them and suddenly the one you want to select jumps down further as a new one comes in.
b.) The first one was being auto selected, but after a few more loaded, it would no longer be the first one. It looked random to just have the, for example, 5th one be selected by default.
 
To fix the two issues, verified mods will be added after the last verified mod. So, they still will collectively remain on top, it's just they won't be added to the tip-top as they come in.