### PR TITLE
fix deleting unloaded mods

### DIFF
--- a/js/views/modals/Settings/Store.js
+++ b/js/views/modals/Settings/Store.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import _ from 'underscore';
 import app from '../../../app';
 import loadTemplate from '../../../utils/loadTemplate';
 import '../../../lib/select2';
@@ -149,7 +150,9 @@ export default class extends baseVw {
   }
 
   getSettingsData() {
-    const selected = this.modsSelected.selectedIDs;
+    let selected = app.settings.get('storeModerators');
+    // the mods may not have loaded in the interface yet. Subtract only explicitly de-selected ones
+    selected = _.without(selected, ...this.modsSelected.unselectedIDs);
     const byID = this.modsByID.selectedIDs;
     const available = this.modsAvailable.selectedIDs;
     return { storeModerators: [...new Set([...selected, ...byID, ...available])] };

--- a/js/views/modals/Settings/Store.js
+++ b/js/views/modals/Settings/Store.js
@@ -151,7 +151,7 @@ export default class extends baseVw {
 
   getSettingsData() {
     let selected = app.settings.get('storeModerators');
-    // the mods may not have loaded in the interface yet. Subtract only explicitly de-selected ones
+    // The mods may not have loaded in the interface yet. Subtract only explicitly de-selected ones.
     selected = _.without(selected, ...this.modsSelected.unselectedIDs);
     const byID = this.modsByID.selectedIDs;
     const available = this.modsAvailable.selectedIDs;


### PR DESCRIPTION
If mods load very slowly, saving was deleting unloaded mods. This PR changes the code to only remove loaded mods that have been de-selected.