### PR TITLE
Fix using options instead of this for excluded ids

### DIFF
--- a/js/views/components/Moderators.js
+++ b/js/views/components/Moderators.js
@@ -179,7 +179,7 @@ export default class extends baseVw {
     }
 
     // don't get any that have already been added or excluded, or the user's own id.
-    const excluded = [...this.allIDs, ...op.excludeIDs, app.profile.id];
+    const excluded = [...this.allIDs, ...this.excludeIDs, app.profile.id];
     const IDs = _.without(op.moderatorIDs, excluded);
     const includeString = op.include ? `&include=${op.include}` : '';
     const urlString =


### PR DESCRIPTION
The GetModeratorsByID function should use this.excludedIDs so it has the most recent value instead of options.excludedIDs.