### PR TITLE
remove extra asterisk, center text, no shrink on verified

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -395,7 +395,7 @@
     "FIXED_PLUS_PERCENTAGE": "%{amount} (+%{percentage})**",
     "termsOfService": "Terms of Service",
     "addAsModeratorButton": "Add as Moderator",
-    "disclaimer": "**The moderator service charge only applies when a dispute arises.",
+    "disclaimer": "*The moderator service charge only applies when a dispute arises.",
     "languages": "Languages",
     "currenciesSupported": "Currencies Supported",
     "noCoinSupport": "This moderator does not support %{coin}."

--- a/js/templates/modals/moderatorDetails.html
+++ b/js/templates/modals/moderatorDetails.html
@@ -25,23 +25,23 @@
     <div class="contentBox mDetailBox flexRow flexVCent gutterH padMd2 clrP clrBr clrSh3">
       <div class="flexExpand">
         <div class="flexCol flexCent">
-          <div class="txCtr"><%= ob.parseEmojis('📍') %> <%= ob.location || ob.polyT('userPage.noLocation') %></div>
-          <div class="txCtr tx5b clrT2"><%= ob.polyT('moderatorDetails.location') %></div>
+          <div><%= ob.parseEmojis('📍') %> <%= ob.location || ob.polyT('userPage.noLocation') %></div>
+          <div class="tx5b clrT2"><%= ob.polyT('moderatorDetails.location') %></div>
         </div>
       </div>
       <div class="rowDivV clrBrBk TODO"></div>
       <div class="flexExpand TODO">
         <div class="flexCol flexCent">
           <%= ob.parseEmojis('👍') %> XX<% // placeholder for reputation %>
-          <div class="txCtr tx5b clrT2"><%= ob.polyT('moderatorDetails.recommendations') %></div>
+          <div class="tx5b clrT2"><%= ob.polyT('moderatorDetails.recommendations') %></div>
         </div>
       </div>
       <div class="rowDivV clrBrBk"></div>
       <div class="flexExpand">
         <div class="flexCol flexCent">
           <% var amount = ob.currencyMod.convertAndFormatCurrency(ob.moderatorInfo.fee.fixedFee.amount, ob.moderatorInfo.fee.fixedFee.currencyCode, ob.displayCurrency) %>
-          <div class="txCtr"><%= ob.polyT(`moderatorCard.${ob.moderatorInfo.fee.feeType}`, { amount: amount, percentage: ob.moderatorInfo.fee.percentage }) %></div>
-          <div class="txCtr tx5b clrT2"><%= ob.polyT('moderatorDetails.serviceCharge') %></div>
+          <div><%= ob.polyT(`moderatorCard.${ob.moderatorInfo.fee.feeType}`, { amount: amount, percentage: ob.moderatorInfo.fee.percentage }) %></div>
+          <div class="tx5b clrT2"><%= ob.polyT('moderatorDetails.serviceCharge') %></div>
         </div>
       </div>
       <div class="rowDivV clrBrBk"></div>

--- a/js/templates/modals/moderatorDetails.html
+++ b/js/templates/modals/moderatorDetails.html
@@ -3,7 +3,7 @@
 <div class="topControls flex js-closeClickTarget"></div>
 <div class="js-closeClickTarget">
   <div class="flexColRows gutterV">
-    <div class="contentBox mDetailBox padMd2 clrP clrBr clrSh3 tx5">
+    <div class="contentBox mDetailWrapper padMd2 clrP clrBr clrSh3 tx5">
       <div class="flex gutterH row">
         <div class="flexNoShrink">
           <a class="userIcon disc clrBr2 clrSh1"
@@ -22,22 +22,22 @@
       </div>
       <div class="js-socialBtns"></div>
     </div>
-    <div class="contentBox mDetailBox flexRow flexVCent gutterH padMd2 clrP clrBr clrSh3">
-      <div class="flexExpand">
+    <div class="contentBox mDetailWrapper flexRow flexVCent gutterH padMd2 clrP clrBr clrSh3">
+      <div class="mDetail">
         <div class="flexCol flexCent">
           <div class="txCtr"><%= ob.parseEmojis('📍') %> <%= ob.location || ob.polyT('userPage.noLocation') %></div>
           <div class="txCtr tx5b clrT2"><%= ob.polyT('moderatorDetails.location') %></div>
         </div>
       </div>
       <div class="rowDivV clrBrBk TODO"></div>
-      <div class="flexExpand TODO">
+      <div class="mDetail TODO">
         <div class="flexCol flexCent">
           <%= ob.parseEmojis('👍') %> XX<% // placeholder for reputation %>
           <div class="txCtr tx5b clrT2"><%= ob.polyT('moderatorDetails.recommendations') %></div>
         </div>
       </div>
       <div class="rowDivV clrBrBk"></div>
-      <div class="flexExpand">
+      <div class="mDetail">
         <div class="flexCol flexCent">
           <% var amount = ob.currencyMod.convertAndFormatCurrency(ob.moderatorInfo.fee.fixedFee.amount, ob.moderatorInfo.fee.fixedFee.currencyCode, ob.displayCurrency) %>
           <div class="txCtr"><%= ob.polyT(`moderatorCard.${ob.moderatorInfo.fee.feeType}`, { amount: amount, percentage: ob.moderatorInfo.fee.percentage }) %></div>
@@ -45,9 +45,9 @@
         </div>
       </div>
       <div class="rowDivV clrBrBk"></div>
-      <div class="box verifiedWrapper <%= modBorder %> js-verifiedMod"></div>
+      <div class="box mDetail verifiedWrapper <%= modBorder %> js-verifiedMod"></div>
     </div>
-    <div class="contentBox mDetailBox padMd2 clrP clrBr clrSh3 tx5">
+    <div class="contentBox mDetailWrapper padMd2 clrP clrBr clrSh3 tx5">
       <div class="rowMd">
         <h4><%= ob.polyT('moderatorDetails.currenciesSupported') %></h4>
         <ul class="unstyled">

--- a/js/templates/modals/moderatorDetails.html
+++ b/js/templates/modals/moderatorDetails.html
@@ -25,23 +25,23 @@
     <div class="contentBox mDetailBox flexRow flexVCent gutterH padMd2 clrP clrBr clrSh3">
       <div class="flexExpand">
         <div class="flexCol flexCent">
-          <div><%= ob.parseEmojis('📍') %> <%= ob.location || ob.polyT('userPage.noLocation') %></div>
-          <div class="tx5b clrT2"><%= ob.polyT('moderatorDetails.location') %></div>
+          <div class="txCtr"><%= ob.parseEmojis('📍') %> <%= ob.location || ob.polyT('userPage.noLocation') %></div>
+          <div class="txCtr tx5b clrT2"><%= ob.polyT('moderatorDetails.location') %></div>
         </div>
       </div>
       <div class="rowDivV clrBrBk TODO"></div>
       <div class="flexExpand TODO">
         <div class="flexCol flexCent">
           <%= ob.parseEmojis('👍') %> XX<% // placeholder for reputation %>
-          <div class="tx5b clrT2"><%= ob.polyT('moderatorDetails.recommendations') %></div>
+          <div class="txCtr tx5b clrT2"><%= ob.polyT('moderatorDetails.recommendations') %></div>
         </div>
       </div>
       <div class="rowDivV clrBrBk"></div>
       <div class="flexExpand">
         <div class="flexCol flexCent">
           <% var amount = ob.currencyMod.convertAndFormatCurrency(ob.moderatorInfo.fee.fixedFee.amount, ob.moderatorInfo.fee.fixedFee.currencyCode, ob.displayCurrency) %>
-          <div><%= ob.polyT(`moderatorCard.${ob.moderatorInfo.fee.feeType}`, { amount: amount, percentage: ob.moderatorInfo.fee.percentage }) %></div>
-          <div class="tx5b clrT2"><%= ob.polyT('moderatorDetails.serviceCharge') %></div>
+          <div class="txCtr"><%= ob.polyT(`moderatorCard.${ob.moderatorInfo.fee.feeType}`, { amount: amount, percentage: ob.moderatorInfo.fee.percentage }) %></div>
+          <div class="txCtr tx5b clrT2"><%= ob.polyT('moderatorDetails.serviceCharge') %></div>
         </div>
       </div>
       <div class="rowDivV clrBrBk"></div>

--- a/styles/modules/modals/_moderatorDetails.scss
+++ b/styles/modules/modals/_moderatorDetails.scss
@@ -6,6 +6,7 @@
       display: flex;
       align-self: stretch;
       flex-grow: 1;
+      flex-shrink: 0;
       flex-direction: column;
       justify-content: center;
       text-align: center;

--- a/styles/modules/modals/_moderatorDetails.scss
+++ b/styles/modules/modals/_moderatorDetails.scss
@@ -6,11 +6,8 @@
     & > .verifiedWrapper {
       min-width: 20%;
       flex-grow: 1;
-    }
-
-    & > .mDetail > * {
-      max-width: 100%;
-      overflow: hidden;
+      max-width: 50%;
+      word-break: break-word;
     }
 
     .verifiedWrapper {

--- a/styles/modules/modals/_moderatorDetails.scss
+++ b/styles/modules/modals/_moderatorDetails.scss
@@ -1,17 +1,28 @@
 .moderatorDetails {
-  .contentBox.mDetailBox {
+  .contentBox.mDetailWrapper {
     min-height: 90px;
+
+    & > .mDetail,
+    & > .verifiedWrapper {
+      min-width: 20%;
+      flex-grow: 1;
+    }
+
+    & > .mDetail > * {
+      max-width: 100%;
+      overflow: hidden;
+    }
 
     .verifiedWrapper {
       display: flex;
       align-self: stretch;
-      flex-grow: 1;
       flex-shrink: 0;
       flex-direction: column;
       justify-content: center;
       text-align: center;
       border-width: 1px;
       border-style: solid;
+      padding: $pad;
 
       .verifiedMod {
         display: block;


### PR DESCRIPTION
This makes the layout in the moderator details card a little nicer when the fee amount is very large, and removes an extra asterisk.

**Before:**
![image](https://user-images.githubusercontent.com/1584275/37230138-57c9ae14-23b4-11e8-93c8-04991e26afe7.png)

**After:**
![image](https://user-images.githubusercontent.com/1584275/37230077-31a19c4c-23b4-11e8-8f6a-2cd2b0a752c7.png)
