### PR TITLE
move verifiedMod class to child of the root class

### DIFF
--- a/styles/modules/modals/_orderDetail.scss
+++ b/styles/modules/modals/_orderDetail.scss
@@ -343,34 +343,6 @@
         font-size: $tx6;
       }
 
-      .verifiedMod {
-
-        & > .badge {
-          position: relative;
-          top: -1px;
-          margin-right: 0.3em;
-        }
-
-        .tooltipWrapper {
-
-          .arrowBoxWrapper {
-            height: inherit;
-            width: 12px; // the same as the info icon
-            right: 0;
-
-            .arrowBox {
-              top: 11px;
-              left: 50%;
-
-              .badge {
-                top: -2px;
-                position: relative;
-              }
-            }
-          }
-        }
-      }
-
       .memo {
         white-space: pre-wrap;
       }
@@ -509,7 +481,7 @@
       .#{$field}ContractUnarrivedMsg {
         display: block;
       }
-    }    
+    }
 
     &.vendorContractUnavailable {
       @include contractUnavailable(vendor);
@@ -521,13 +493,41 @@
 
     &.vendorProcessingError {
       @include contractUnavailable(vendor);
-      
+
       .vendorProcErrContractUnarrivedMsg {
         display: block;
       }
 
       .vendorContractUnarrivedMsg {
         display: none;
+      }
+    }
+  }
+
+  .verifiedMod {
+
+    & > .badge {
+      position: relative;
+      top: -1px;
+      margin-right: 0.3em;
+    }
+
+    .tooltipWrapper {
+
+      .arrowBoxWrapper {
+        height: inherit;
+        width: 12px; // the same as the info icon
+        right: 0;
+
+        .arrowBox {
+          top: 11px;
+          left: 50%;
+
+          .badge {
+            top: -2px;
+            position: relative;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
The CSS adjustments to the verified moderator tooltip were only being applied to children of .orderDetails, and were not applied to the dispute tab. This PR fixes that by moving them to be children of .orderDetail, the root CSS class for the view.

Closes #1267