### PR TITLE
Add data-open-external attribute to verified mods

### DIFF
--- a/js/templates/components/verifiedMod.html
+++ b/js/templates/components/verifiedMod.html
@@ -9,7 +9,7 @@
    const shortText = ob.polyT(`verifiedMod.${type}.label`);
    const longText = ob.polyT(`verifiedMod.${type}.title`);
    const not = `<b>${ob.polyT('verifiedMod.unverified.not')}</b>`;
-   const link = `<a class="txU noWrap" href="${ob.data.link}">${ob.polyT('verifiedMod.link')}</a>`;
+   const link = `<a class="txU noWrap" href="${ob.data.link}" data-open-external>${ob.polyT('verifiedMod.link')}</a>`;
 %>
 
 <% print(ob.verified ? badgeFrag : warnFrag) %>


### PR DESCRIPTION
Adds a data-open-external to the link in the verified moderator tooltip, to make sure it opens externally.

Closes #1266 
