### PR TITLE
Account for no moderators in listings

### DIFF
--- a/js/collections/VerifiedMods.js
+++ b/js/collections/VerifiedMods.js
@@ -38,7 +38,7 @@ export default class extends Collection {
    * Return a list of verified moderators that match the ids passed in
    * @param IDs {array} - a list of IDs
    */
-  matched(IDs) {
+  matched(IDs = []) {
     return this.filter(mod => IDs.includes(mod.get('peerID')));
   }
 


### PR DESCRIPTION
This fixes an issue where it's possible to create a listing with no value for moderators, which would throw an error due to the matched function expecting an array.