### PR TITLE
Use full line for address in wallet

### DIFF
--- a/js/templates/modals/wallet/transaction.html
+++ b/js/templates/modals/wallet/transaction.html
@@ -30,22 +30,22 @@
 
       if (ob.value > 0) {
         infoLine = ob.polyT('wallet.transactions.transaction.incomingText', {
-          currencyPairing: `<span class="txB">${priceFrag}</span>`,
+          currencyPairing: `<span class="txB flexNoShrink margRTxt">${priceFrag}</span>`,
         });
       } else {
-        const currencyPairing = `<span class="txB">${priceFrag}</span>`;
+        const currencyPairing = `<span class="txB flexNoShrink margRTxt">${priceFrag}</span>`;
 
         if (ob.address) {
           infoLine = ob.polyT('wallet.transactions.transaction.outgoingText', {
             currencyPairing,
-            address: `<span class="toAddress noOverflow clrTEmph1">${ob.address}</span>`,
+            address: `<span class="toAddress margLTxt noOverflow clrTEmph1">${ob.address}</span>`,
           });
         } else {
           infoLine = currencyPairing;
         }
       }
     %>
-    <div class="rowTn"><%= infoLine %></div>
+    <div class="rowTn flex"><%= infoLine %></div>
     <%
       let timeAgoAndConfirmCount = ob.polyT('wallet.transactions.transaction.timeAgoAndConfirmCount', {
         timeAgo: ob.timeAgo,

--- a/styles/components/_layout.scss
+++ b/styles/components/_layout.scss
@@ -392,6 +392,14 @@
   margin-left: $pad;
 }
 
+.margLTxt {
+  margin-left: 0.333em; // equivalent to a space character
+}
+
+.margRTxt {
+  margin-right: 0.333em; // equivalent to a space character
+}
+
 #ov1 .marginTopAuto {
   margin-top: auto;
 

--- a/styles/modules/modals/_wallet.scss
+++ b/styles/modules/modals/_wallet.scss
@@ -162,7 +162,6 @@
         font-weight: bold;
         display: inline-block;
         vertical-align: bottom;
-        max-width: 100px;
       }
 
       &.confirmedTransaction {


### PR DESCRIPTION
This PR will use the entire horizontal space for addresses in the wallet, truncating the address with an ellipses when needed.

It also adds 2 new classes for injecting margins equivalent to spaces, which is useful when using a flex container with text mixed with child objects. 

Closes #1279

![image](https://user-images.githubusercontent.com/1584275/37786492-3b0a7622-2dd3-11e8-87ae-afe12cd067ab.png)
