### PR TITLE
Delete entire stats object when saving.

### DIFF
--- a/js/models/profile/Profile.js
+++ b/js/models/profile/Profile.js
@@ -164,13 +164,7 @@ export default class Profile extends BaseModel {
     if (method !== 'read') {
       delete options.attrs.lastModified;
 
-      if (options.attrs.stats) {
-        delete options.attrs.stats.followerCount;
-        delete options.attrs.stats.followingCount;
-        delete options.attrs.stats.listingCount;
-        delete options.attrs.stats.ratingCount;
-        delete options.attrs.stats.averageRating;
-      }
+      if (options.attrs.stats) delete options.attrs.stats;
 
       const images = [options.attrs.avatarHashes, options.attrs.headerHashes];
       images.forEach(imageHashes => {


### PR DESCRIPTION
When the profile was edited, it was sending 
```
stats: {
  postCount: 0,
}
```
which caused the server to return values of 0 for all the stats child objects.

Since we shouldn't be overwriting the stats object at all, this PR removes it on non-read syncs instead of removing specific children.

@rmisio do you know of a reason we wouldn't want to just remove the stats object? My assumption is the postCount attribute was added to the server and we didn't catch it, which created this bug. That attribute isn't used for anything in the client as far as I can tell.

Closes #656 

This may close this server bug https://github.com/OpenBazaar/openbazaar-go/issues/696