### PR TITLE
Set app window size to 90% of screen size instead of fixed 1200x760

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 import {
   app, BrowserWindow, ipcMain,
   Menu, Tray, session, crashReporter,
-  autoUpdater, shell, dialog,
+  autoUpdater, shell, dialog, screen,
 } from 'electron';
 import homedir from 'homedir';
 import { argv } from 'yargs';
@@ -464,8 +464,8 @@ function createWindow() {
 
   // Create the browser window.
   mainWindow = new BrowserWindow({
-    width: 1200,
-    height: 760,
+    width: screen.getPrimaryDisplay().size.width * .9 ,
+    height: screen.getPrimaryDisplay().size.height * .9,
     minWidth: 1170,
     minHeight: 700,
     center: true,


### PR DESCRIPTION
I don't know if this bothers anybody else but the first thing I do when I open OB is resize the window! I'm running on OSX, and unlike most other OSX apps, OB doesn't "remember" if its window size was manually adjusted the last time it was run. I find the default 1200x760 too small, it cuts off the bottom of the first row of listings (see screen shot) and I personally just like every app I interact with to use as much screen real estate as possible. I find this 90% setting much more satisfying to interact with, and still leave a margin around the app to click the desktop, etc. 


![screen shot 2018-04-02 at 11 48 52 am](https://user-images.githubusercontent.com/2084648/38210308-e703d3ba-366b-11e8-924c-1dc9781d5587.png)
