### PR TITLE
Lazy Load Verified Mods

### DIFF
--- a/js/start.js
+++ b/js/start.js
@@ -358,7 +358,7 @@ function fetchStartupData() {
       if (failed.length) {
         const firstFailedXhr = failed[0];
         let title = '';
-        let msg = firstFailedXhr.responseJSON && firstFailedXhr.responseJSON.reason ||
+        const message = firstFailedXhr.responseJSON && firstFailedXhr.responseJSON.reason ||
           firstFailedXhr.status || '';
         let btnText = app.polyglot.t('startUp.dialogs.btnManageConnections');
         let btnFrag = 'manageConnections';
@@ -375,7 +375,7 @@ function fetchStartupData() {
 
         const retryFetchStartupDataDialog = new Dialog({
           title,
-          message: msg,
+          message,
           buttons: [
             {
               text: app.polyglot.t('startUp.dialogs.btnRetry'),

--- a/js/start.js
+++ b/js/start.js
@@ -316,7 +316,6 @@ let ownFollowingFetch;
 let exchangeRatesFetch;
 let walletBalanceFetch;
 let searchProvidersFetch;
-let verifiedModsFetch;
 
 function fetchStartupData() {
   ownFollowingFetch = !ownFollowingFetch || ownFollowingFetch.state() === 'rejected' ?
@@ -327,15 +326,12 @@ function fetchStartupData() {
     app.walletBalance.fetch() : walletBalanceFetch;
   searchProvidersFetch = !searchProvidersFetch || searchProvidersFetch.state() === 'rejected' ?
     app.searchProviders.fetch() : searchProvidersFetch;
-  verifiedModsFetch = !verifiedModsFetch || verifiedModsFetch.state() === 'rejected' ?
-    app.verifiedMods.fetch() : verifiedModsFetch;
 
   const fetches = [
     ownFollowingFetch,
     exchangeRatesFetch,
     walletBalanceFetch,
     searchProvidersFetch,
-    verifiedModsFetch,
   ];
 
   $.whenAll(fetches.slice())
@@ -371,14 +367,9 @@ function fetchStartupData() {
           title = app.polyglot.t('startUp.dialogs.unableToGetFollowData.title');
         } else if (walletBalanceFetch.state() === 'rejected') {
           title = app.polyglot.t('startUp.dialogs.unableToGetWalletBalance.title');
-        } else if (searchProvidersFetch.state() === 'rejected') {
+        } else {
           title = app.polyglot.t('startUp.dialogs.unableToGetSearchProviders.title');
           btnText = app.polyglot.t('startUp.dialogs.unableToGetSearchProviders.btnClose');
-          btnFrag = 'continue';
-        } else {
-          title = app.polyglot.t('startUp.dialogs.unableToGetVerifiedMods.title');
-          msg = app.polyglot.t('startUp.dialogs.unableToGetVerifiedMods.msg', { reason: msg });
-          btnText = app.polyglot.t('startUp.dialogs.unableToGetVerifiedMods.btnClose');
           btnFrag = 'continue';
         }
 
@@ -613,6 +604,7 @@ function start() {
               .on('mouseenter', () => getBody().addClass('chatHover'))
               .on('mouseleave', () => getBody().removeClass('chatHover'));
 
+          fetchVerifiedMods();
           setInterval(() => fetchVerifiedMods(), 1000 * 60 * 60);
 
           // have our walletBalance model update from the walletUpdate socket event

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import _ from 'underscore';
 import app from '../app';
 import loadTemplate from '../utils/loadTemplate';
 import { openSimpleMessage } from '../views/modals/SimpleMessage';

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import _ from 'underscore';
 import app from '../app';
 import loadTemplate from '../utils/loadTemplate';
 import { openSimpleMessage } from '../views/modals/SimpleMessage';
@@ -102,9 +103,10 @@ export default class extends baseVw {
     this.verifiedMods = app.verifiedMods.matched(this.model.get('moderators'));
 
     this.listenTo(app.verifiedMods, 'update', () => {
-      const newverifiedMods = app.verifiedMods.matched(this.model.get('moderators'));
-      if (newverifiedMods !== this.verifiedMods) {
-        this.verifiedMods = newverifiedMods;
+      const newVerifiedMods = app.verifiedMods.matched(this.model.get('moderators'));
+      if ((this.verifiedMods.length && !newVerifiedMods.length) ||
+        (!this.verifiedMods.length && newVerifiedMods.length)) {
+        this.verifiedMods = newVerifiedMods;
         this.render();
       }
     });

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -98,6 +98,16 @@ export default class extends baseVw {
       this._userClickedShowNsfw = null;
       this.setHideNsfwClass();
     });
+
+    this.verifiedModIDs = app.verifiedMods.matched(this.model.get('moderators'));
+
+    this.listenTo(app.verifiedMods, 'update', () => {
+      const newVerifiedModIDs = app.verifiedMods.matched(this.model.get('moderators'));
+      if (newVerifiedModIDs !== this.verifiedModIDs) {
+        this.verifiedModIDs = newVerifiedModIDs;
+        this.render();
+      }
+    });
   }
 
   className() {
@@ -416,15 +426,12 @@ export default class extends baseVw {
           .el
       );
     }
-    const moderators = this.model.get('moderators') || [];
-    const verifiedIDs = app.verifiedMods.matched(moderators);
-    const verifiedID = verifiedIDs[0];
 
     if (this.verifiedMod) this.verifiedMod.remove();
 
-    if (verifiedID) {
+    if (this.verifiedModIDs.length) {
       this.verifiedMod = new VerifiedMod({
-        model: app.verifiedMods.get(verifiedID),
+        model: this.verifiedModIDs[0],
         data: app.verifiedMods.data,
         showLongText: true,
         genericText: true,

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -99,12 +99,12 @@ export default class extends baseVw {
       this.setHideNsfwClass();
     });
 
-    this.verifiedModIDs = app.verifiedMods.matched(this.model.get('moderators'));
+    this.verifiedMods = app.verifiedMods.matched(this.model.get('moderators'));
 
     this.listenTo(app.verifiedMods, 'update', () => {
-      const newVerifiedModIDs = app.verifiedMods.matched(this.model.get('moderators'));
-      if (newVerifiedModIDs !== this.verifiedModIDs) {
-        this.verifiedModIDs = newVerifiedModIDs;
+      const newverifiedMods = app.verifiedMods.matched(this.model.get('moderators'));
+      if (newverifiedMods !== this.verifiedMods) {
+        this.verifiedMods = newverifiedMods;
         this.render();
       }
     });
@@ -429,9 +429,9 @@ export default class extends baseVw {
 
     if (this.verifiedMod) this.verifiedMod.remove();
 
-    if (this.verifiedModIDs.length) {
+    if (this.verifiedMods.length) {
       this.verifiedMod = new VerifiedMod({
-        model: this.verifiedModIDs[0],
+        model: this.verifiedMods[0],
         data: app.verifiedMods.data,
         showLongText: true,
         genericText: true,

--- a/js/views/modals/Settings/Store.js
+++ b/js/views/modals/Settings/Store.js
@@ -68,6 +68,31 @@ export default class extends baseVw {
       fetchErrorTitle: app.polyglot.t('settings.storeTab.errors.availableModsTitle'),
       showLoadBtn: true,
     });
+
+    const modsToCheckOnVerifiedUpdate = [
+      {
+        view: this.modsSelected,
+        hasVerifiedMods: app.verifiedMods.matched(this.modsSelected.allIDs).length > 0,
+      },
+      {
+        view: this.modsByID,
+        hasVerifiedMods: app.verifiedMods.matched(this.modsByID.allIDs).length > 0,
+      },
+      {
+        view: this.modsAvailable,
+        hasVerifiedMods: app.verifiedMods.matched(this.modsAvailable.allIDs).length > 0,
+      },
+    ];
+
+    this.listenTo(app.verifiedMods, 'update', () => {
+      modsToCheckOnVerifiedUpdate.forEach(obj => {
+        const nowSelected = app.verifiedMods.matched(obj.view.allIDs).length > 0;
+        if (nowSelected !== obj.hasVerifiedMods) {
+          obj.hasVerifiedMods = nowSelected;
+          obj.view.render();
+        }
+      });
+    });
   }
 
   events() {

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -98,6 +98,8 @@ export default class extends BaseModal {
       this.listenTo(app.localSettings, 'change:bitcoinUnit', () => this.showDataChangedMessage());
     }
 
+    this.listenTo(app.verifiedMods, 'change', () => this.showDataChangedMessage());
+
     this.rating = this.createChild(Rating);
 
     // get the ratings data, if any

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -98,7 +98,15 @@ export default class extends BaseModal {
       this.listenTo(app.localSettings, 'change:bitcoinUnit', () => this.showDataChangedMessage());
     }
 
-    this.listenTo(app.verifiedMods, 'change', () => this.showDataChangedMessage());
+    this.hasVerifiedMods = app.verifiedMods.matched(this.model.get('moderators')).length > 0;
+
+    this.listenTo(app.verifiedMods, 'change', () => {
+      const nowHasVerifiedMods = app.verifiedMods.matched(this.model.get('moderators')).length > 0;
+      if (nowHasVerifiedMods !== this.hasVerifiedMods) {
+        this.showDataChangedMessage();
+        this.hasVerifiedMods = nowHasVerifiedMods;
+      }
+    });
 
     this.rating = this.createChild(Rating);
 
@@ -527,7 +535,6 @@ export default class extends BaseModal {
   render() {
     if (this.dataChangePopIn) this.dataChangePopIn.remove();
 
-    const hasVerifiedMods = app.verifiedMods.matched(this.model.get('moderators')).length > 0;
     const defaultBadge = app.verifiedMods.defaultBadge(this.model.get('moderators'));
     let nsfwWarning;
 

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -101,9 +101,9 @@ export default class extends BaseModal {
     this.hasVerifiedMods = app.verifiedMods.matched(this.model.get('moderators')).length > 0;
 
     this.listenTo(app.verifiedMods, 'update', () => {
-      const nowHasVerifiedMods = app.verifiedMods.matched(this.model.get('moderators')).length > 0;
-      if (nowHasVerifiedMods !== this.hasVerifiedMods) {
-        this.hasVerifiedMods = nowHasVerifiedMods;
+      const newHasVerifiedMods = app.verifiedMods.matched(this.model.get('moderators')).length > 0;
+      if (newHasVerifiedMods !== this.hasVerifiedMods) {
+        this.hasVerifiedMods = newHasVerifiedMods;
         this.showDataChangedMessage();
       }
     });

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -100,11 +100,11 @@ export default class extends BaseModal {
 
     this.hasVerifiedMods = app.verifiedMods.matched(this.model.get('moderators')).length > 0;
 
-    this.listenTo(app.verifiedMods, 'change', () => {
+    this.listenTo(app.verifiedMods, 'update', () => {
       const nowHasVerifiedMods = app.verifiedMods.matched(this.model.get('moderators')).length > 0;
       if (nowHasVerifiedMods !== this.hasVerifiedMods) {
-        this.showDataChangedMessage();
         this.hasVerifiedMods = nowHasVerifiedMods;
+        this.showDataChangedMessage();
       }
     });
 
@@ -563,7 +563,7 @@ export default class extends BaseModal {
         currencyValidity: getCurrencyValidity(
           this.model.get('metadata').get('pricingCurrency')
         ),
-        hasVerifiedMods,
+        hasVerifiedMods: this.hasVerifiedMods,
         verifiedModsData: app.verifiedMods.data,
         defaultBadge,
       }));

--- a/js/views/modals/moderatorDetails.js
+++ b/js/views/modals/moderatorDetails.js
@@ -19,7 +19,7 @@ export default class extends BaseModal {
     if (!this.model || !(this.model instanceof Profile)) {
       throw new Error('Please provide a Profile model.');
     }
-    
+
     this.verifiedModModel = app.verifiedMods.get(this.model.get('peerID'));
 
     this.listenTo(app.verifiedMods, 'update', () => {
@@ -29,7 +29,6 @@ export default class extends BaseModal {
         this.render();
       }
     });
-
   }
 
   className() {

--- a/js/views/modals/moderatorDetails.js
+++ b/js/views/modals/moderatorDetails.js
@@ -23,9 +23,9 @@ export default class extends BaseModal {
     this.verifiedModModel = app.verifiedMods.get(this.model.get('peerID'));
 
     this.listenTo(app.verifiedMods, 'update', () => {
-      const nowIsVerifiedMod = app.verifiedMods.get(this.model.get('peerID'));
-      if (nowIsVerifiedMod !== this.verifiedModModel) {
-        this.verifiedModModel = nowIsVerifiedMod;
+      const newVerifiedModModel = app.verifiedMods.get(this.model.get('peerID'));
+      if (newVerifiedModModel !== this.verifiedModModel) {
+        this.verifiedModModel = newVerifiedModModel;
         this.render();
       }
     });

--- a/js/views/modals/moderatorDetails.js
+++ b/js/views/modals/moderatorDetails.js
@@ -19,6 +19,17 @@ export default class extends BaseModal {
     if (!this.model || !(this.model instanceof Profile)) {
       throw new Error('Please provide a Profile model.');
     }
+    
+    this.verifiedModModel = app.verifiedMods.get(this.model.get('peerID'));
+
+    this.listenTo(app.verifiedMods, 'update', () => {
+      const nowIsVerifiedMod = app.verifiedMods.get(this.model.get('peerID'));
+      if (nowIsVerifiedMod !== this.verifiedModModel) {
+        this.verifiedModModel = nowIsVerifiedMod;
+        this.render();
+      }
+    });
+
   }
 
   className() {
@@ -45,8 +56,6 @@ export default class extends BaseModal {
         return langData && langData.name || lang;
       });
 
-    const verifiedMod = app.verifiedMods.get(this.model.get('peerID'));
-
     loadTemplate('modals/moderatorDetails.html', (t) => {
       this.$el.html(t({
         followedByYou: this.followedByYou,
@@ -55,7 +64,7 @@ export default class extends BaseModal {
         purchase: this.options.purchase,
         cardState: this.options.cardState,
         modLanguages,
-        verifiedMod,
+        verifiedMod: this.verifiedModModel,
         ...this.model.toJSON(),
       }));
       super.render();
@@ -75,7 +84,7 @@ export default class extends BaseModal {
 
       if (this.verifiedMod) this.verifiedMod.remove();
       this.verifiedMod = this.createChild(VerifiedMod, {
-        model: verifiedMod,
+        model: this.verifiedModModel,
         data: app.verifiedMods.data,
         showLongText: true,
       });

--- a/js/views/modals/orderDetail/ModFragment.js
+++ b/js/views/modals/orderDetail/ModFragment.js
@@ -14,6 +14,16 @@ export default class extends BaseVw {
       showAvatar: false,
       ...options.initialState || {},
     };
+
+    this.verifiedModModel = app.verifiedMods.get(this._state.peerID);
+
+    this.listenTo(app.verifiedMods, 'update', () => {
+      const nowIsVerifiedMod = app.verifiedMods.get(this._state.peerID);
+      if (nowIsVerifiedMod !== this.verifiedModModel) {
+        this.verifiedModModel = nowIsVerifiedMod;
+        this.render();
+      }
+    });
   }
 
   getState() {
@@ -45,10 +55,9 @@ export default class extends BaseVw {
         ...this._state,
       }));
 
-      const verifiedMod = app.verifiedMods.get(this._state.peerID);
       if (this.verifiedMod) this.verifiedMod.remove();
       this.verifiedMod = this.createChild(VerifiedMod, {
-        model: verifiedMod,
+        model: this.verifiedModModel,
         data: app.verifiedMods.data,
         showShortText: true,
         inOrder: true,

--- a/js/views/modals/orderDetail/ModFragment.js
+++ b/js/views/modals/orderDetail/ModFragment.js
@@ -18,9 +18,9 @@ export default class extends BaseVw {
     this.verifiedModModel = app.verifiedMods.get(this._state.peerID);
 
     this.listenTo(app.verifiedMods, 'update', () => {
-      const nowIsVerifiedMod = app.verifiedMods.get(this._state.peerID);
-      if (nowIsVerifiedMod !== this.verifiedModModel) {
-        this.verifiedModModel = nowIsVerifiedMod;
+      const newVerifiedModModel = app.verifiedMods.get(this._state.peerID);
+      if (newVerifiedModModel !== this.verifiedModModel) {
+        this.verifiedModModel = newVerifiedModModel;
         this.render();
       }
     });

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -146,9 +146,9 @@ export default class extends BaseModal {
     this.hasVerifiedMods = app.verifiedMods.matched(this.moderatorIDs).length > 0;
 
     this.listenTo(app.verifiedMods, 'update', () => {
-      const nowHasVerifiedMods = app.verifiedMods.matched(moderatorIDs).length > 0;
-      if (nowHasVerifiedMods !== this.hasVerifiedMods) {
-        this.hasVerifiedMods = nowHasVerifiedMods;
+      const newHasVerifiedMods = app.verifiedMods.matched(moderatorIDs).length > 0;
+      if (newHasVerifiedMods !== this.hasVerifiedMods) {
+        this.hasVerifiedMods = newHasVerifiedMods;
         this.showDataChangedMessage({ modsChanged: true });
       }
     });

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -149,7 +149,7 @@ export default class extends BaseModal {
       const newHasVerifiedMods = app.verifiedMods.matched(moderatorIDs).length > 0;
       if (newHasVerifiedMods !== this.hasVerifiedMods) {
         this.hasVerifiedMods = newHasVerifiedMods;
-        this.showDataChangedMessage({ modsChanged: true });
+        this.showDataChangedMessage();
       }
     });
   }
@@ -175,7 +175,7 @@ export default class extends BaseModal {
     };
   }
 
-  showDataChangedMessage(opts) {
+  showDataChangedMessage() {
     if (this.dataChangePopIn && !this.dataChangePopIn.isRemoved()) {
       this.dataChangePopIn.$el.velocity('callout.shake', { duration: 500 });
     } else {
@@ -185,12 +185,8 @@ export default class extends BaseModal {
       });
 
       this.listenTo(this.dataChangePopIn, 'clickRefresh', () => {
-        if (opts.modsChanged) {
-          this.moderators.render();
-          this.dataChangePopIn.remove();
-        } else {
-          this.render();
-        }
+        this.render();
+        this.moderators.render();
       });
 
       this.listenTo(this.dataChangePopIn, 'clickDismiss', () => {

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -142,6 +142,16 @@ export default class extends BaseModal {
     this.listenTo(this.order.get('items').at(0), 'someChange ', () => this.refreshPrices());
     this.listenTo(this.order.get('items').at(0).get('shipping'), 'change', () =>
       this.refreshPrices());
+
+    this.hasVerifiedMods = app.verifiedMods.matched(this.moderatorIDs).length > 0;
+
+    this.listenTo(app.verifiedMods, 'update', () => {
+      const nowHasVerifiedMods = app.verifiedMods.matched(moderatorIDs).length > 0;
+      if (nowHasVerifiedMods !== this.hasVerifiedMods) {
+        this.hasVerifiedMods = nowHasVerifiedMods;
+        this.showDataChangedMessage({ modsChanged: true });
+      }
+    });
   }
 
   className() {
@@ -165,7 +175,7 @@ export default class extends BaseModal {
     };
   }
 
-  showDataChangedMessage() {
+  showDataChangedMessage(opts) {
     if (this.dataChangePopIn && !this.dataChangePopIn.isRemoved()) {
       this.dataChangePopIn.$el.velocity('callout.shake', { duration: 500 });
     } else {
@@ -174,7 +184,14 @@ export default class extends BaseModal {
           buildRefreshAlertMessage(app.polyglot.t('purchase.purchaseDataChangedPopin')),
       });
 
-      this.listenTo(this.dataChangePopIn, 'clickRefresh', () => (this.render()));
+      this.listenTo(this.dataChangePopIn, 'clickRefresh', () => {
+        if (opts.modsChanged) {
+          this.moderators.render();
+          this.dataChangePopIn.remove();
+        } else {
+          this.render();
+        }
+      });
 
       this.listenTo(this.dataChangePopIn, 'clickDismiss', () => {
         this.dataChangePopIn.remove();


### PR DESCRIPTION
This will change the verified moderators call to a lazy loading pattern. All the affected views will listen for updates to the verified moderators collection, and refresh any parts that need to. 

This will account for the verified moderators taking a while to load, and for any changes to the list that happen between loads.

Loading the verified moderators is no longer blocking startup of the rest of the app. If the users first view has verified moderator badges, they may see them pop in after it loads.