### PR TITLE
Catch Socket Data Before REST Returns in Moderators

### DIFF
--- a/js/views/components/Moderators.js
+++ b/js/views/components/Moderators.js
@@ -226,18 +226,20 @@ export default class extends baseVw {
         showSpinner: op.showSpinner, //unhides the spinner if it's been hidden by the timer
       });
 
-      if (op.async) this.listenForIDs.push(...IDs);
+      if (op.async) {
+        this.listenForIDs.push(...IDs);
 
-      /* Listen to the websocket for moderators, the data may arrive before the POST that triggers
-         it returns. It's possible socket data for profiles will arrive from some other call, that's
-         fine as long as the socket responses have valid data.
-      */
+        /* Listen to the websocket for moderators, the data may arrive before the POST that triggers
+           it returns. It's possible socket data for profiles will arrive from some other call,
+           that's fine as long as the socket responses have valid data.
+        */
 
-      const serverSocket = getSocket();
-      if (serverSocket) {
-        this.listenTo(serverSocket, 'message', this.onSocketMessage);
-      } else {
-        throw new Error('There is no connection to the server to listen to.');
+        const serverSocket = getSocket();
+        if (serverSocket) {
+          this.listenTo(serverSocket, 'message', this.onSocketMessage);
+        } else {
+          throw new Error('There is no connection to the server to listen to.');
+        }
       }
 
       const fetch = $.ajax({

--- a/js/views/modals/Settings/Store.js
+++ b/js/views/modals/Settings/Store.js
@@ -41,7 +41,7 @@ export default class extends baseVw {
     this.currentMods = this.settings.get('storeModerators');
     this._showVerifiedOnly = true;
 
-    this.modsSelected = new Moderators({
+    this.modsSelected = this.createChild(Moderators, {
       fetchErrorTitle: app.polyglot.t('settings.storeTab.errors.selectedModsTitle'),
       cardState: 'selected',
       notSelected: 'deselected',
@@ -50,7 +50,7 @@ export default class extends baseVw {
       showSpinner: false,
     });
 
-    this.modsByID = new Moderators({
+    this.modsByID = this.createChild(Moderators, {
       async: false,
       fetchErrorTitle: app.polyglot.t('settings.storeTab.errors.modNotFoundTitle'),
       excludeIDs: this.currentMods,
@@ -61,7 +61,7 @@ export default class extends baseVw {
 
     this.listenTo(this.modsByID, 'noModsFound', (mOpts) => this.noModsFound(mOpts.guids));
 
-    this.modsAvailable = new Moderators({
+    this.modsAvailable = this.createChild(Moderators, {
       apiPath: 'moderators',
       excludeIDs: this.currentMods,
       showVerifiedOnly: true,


### PR DESCRIPTION
This PR moves the socket listener to before the REST call to get moderators is made, and checked incoming messages for peerId and other data instead of relying on the socket id returned by the REST call.

This prevents issues with the socket returning data before the socket ID is known, which causes the moderator in the socket data not to be added.