### PR TITLE
Fix no valid mods text

### DIFF
--- a/js/templates/components/moderators.html
+++ b/js/templates/components/moderators.html
@@ -6,26 +6,29 @@
       </div>
     </div>
   <% } %>
-  <% if (ob.noValidModerators || ob.noValidVerifiedModerators && ob.showVerifiedOnly) { %>
-    <div class="moderatorCard moderatorsMessage clrBr">
-      <div class="moderatorCardInner">
-        <div class="flexCent">
-          <div class="flexColRows flexHCent gutterVTn">
-            <% if (ob.noValidModerators) { %>
-              <h4 class="clrTErr"><%= ob.polyT('moderators.noValidModerators') %></h4>
-              <div class="tx4 clrTErr"><%= ob.polyT('moderators.noValidModeratorsBody') %></div>
-            <% } else if (ob.noValidVerifiedModerators && ob.showVerifiedOnly) { %>
-              <h4><%= ob.polyT('moderators.noVerifiedModerators') %></h4>
-              <div class="tx4 clrT2"><%= ob.polyT('moderators.noVerifiedModeratorsBody') %></div>
-              <div class="padTn"><% // just a spacer %></div>
-              <div>
-                <button class="btn clrP clrBr js-showUnverified"><%= ob.polyT('moderators.showUnverified') %></button>
-              </div>
-            <% } %>
+  <% if (ob.purchase) { %>
+  <% // only show the errors below if this is a purchase. TODO: move this to the purchase template. %>
+    <% if (ob.noValidModerators || ob.noValidVerifiedModerators && ob.showVerifiedOnly) { %>
+      <div class="moderatorCard moderatorsMessage clrBr">
+        <div class="moderatorCardInner">
+          <div class="flexCent">
+            <div class="flexColRows flexHCent gutterVTn">
+              <% if (ob.noValidModerators) { %>
+                <h4 class="clrTErr"><%= ob.polyT('moderators.noValidModerators') %></h4>
+                <div class="tx4 clrTErr"><%= ob.polyT('moderators.noValidModeratorsBody') %></div>
+              <% } else if (ob.noValidVerifiedModerators && ob.showVerifiedOnly) { %>
+                <h4><%= ob.polyT('moderators.noVerifiedModerators') %></h4>
+                <div class="tx4 clrT2"><%= ob.polyT('moderators.noVerifiedModeratorsBody') %></div>
+                <div class="padTn"><% // just a spacer %></div>
+                <div>
+                  <button class="btn clrP clrBr js-showUnverified"><%= ob.polyT('moderators.showUnverified') %></button>
+                </div>
+              <% } %>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    <% } %>
   <% } %>
 </div>
 <div class="js-statusWrapper"></div>

--- a/js/templates/components/moderators.html
+++ b/js/templates/components/moderators.html
@@ -6,23 +6,22 @@
       </div>
     </div>
   <% } %>
-  <% if (ob.noValidModerators) { %>
-  <p class="clrTErr">
-    <%= ob.polyT('moderators.noValidModerators') %>
-    <%= ob.polyT('moderators.noValidModeratorsBody') %>
-  </p>
-  <% } %>
-  <% if (ob.noValidVerifiedModerators && ob.showVerifiedOnly) { %>
+  <% if (ob.noValidModerators || ob.noValidVerifiedModerators && ob.showVerifiedOnly) { %>
     <div class="moderatorCard moderatorsMessage clrBr">
       <div class="moderatorCardInner">
         <div class="flexCent">
           <div class="flexColRows flexHCent gutterVTn">
-            <h4><%= ob.polyT('moderators.noVerifiedModerators') %></h4>
-            <div class="tx4 clrT2"><%= ob.polyT('moderators.noVerifiedModeratorsBody') %></div>
-            <div class="padTn"><% // just a spacer %></div>
-            <div>
-            <button class="btn clrP clrBr js-showUnverified"><%= ob.polyT('moderators.showUnverified') %></button>
-            </div>
+            <% if (ob.noValidModerators) { %>
+              <h4 class="clrTErr"><%= ob.polyT('moderators.noValidModerators') %></h4>
+              <div class="tx4 clrTErr"><%= ob.polyT('moderators.noValidModeratorsBody') %></div>
+            <% } else if (ob.noValidVerifiedModerators && ob.showVerifiedOnly) { %>
+              <h4><%= ob.polyT('moderators.noVerifiedModerators') %></h4>
+              <div class="tx4 clrT2"><%= ob.polyT('moderators.noVerifiedModeratorsBody') %></div>
+              <div class="padTn"><% // just a spacer %></div>
+              <div>
+                <button class="btn clrP clrBr js-showUnverified"><%= ob.polyT('moderators.showUnverified') %></button>
+              </div>
+            <% } %>
           </div>
         </div>
       </div>

--- a/js/templates/components/moderators.html
+++ b/js/templates/components/moderators.html
@@ -16,7 +16,7 @@
               <% if (ob.noValidModerators) { %>
                 <h4 class="clrTErr"><%= ob.polyT('moderators.noValidModerators') %></h4>
                 <div class="tx4 clrTErr"><%= ob.polyT('moderators.noValidModeratorsBody') %></div>
-              <% } else if (ob.noValidVerifiedModerators && ob.showVerifiedOnly) { %>
+              <% } else { %>
                 <h4><%= ob.polyT('moderators.noVerifiedModerators') %></h4>
                 <div class="tx4 clrT2"><%= ob.polyT('moderators.noVerifiedModeratorsBody') %></div>
                 <div class="padTn"><% // just a spacer %></div>

--- a/js/views/components/Moderators.js
+++ b/js/views/components/Moderators.js
@@ -400,6 +400,7 @@ export default class extends baseVw {
         wrapperClasses: this.options.wrapperClasses,
         showVerifiedOnly: this.options.showVerifiedOnly,
         placeholder: !this.modCards.length,
+        purchase: this.options.purchase,
         ...this.getState(),
       }));
 


### PR DESCRIPTION
This fixes the no valid moderators text to use the same formatting as the no verified moderators text, and prevents them from showing at the same time. If no moderators are valid, then the no verified moderators text shouldn't be visible.

This PR is marked WIP because it overlaps with some of the other PRs that haven't been merged yet, and probably needs to be updated once they're merged into master.

Closes #1305 