### PR TITLE
loading listing card images in a cancelable way

### DIFF
--- a/js/templates/listingCard.html
+++ b/js/templates/listingCard.html
@@ -1,6 +1,6 @@
 <% if (ob.viewType === 'grid') { %>
 <div class="gridViewContent posR">
-  <div class="listingImage" style="background-image: url(<%= ob.getServerUrl(`ob/images/${ob.isHiRez() ? ob.thumbnail.medium : ob.thumbnail.small}`) %>), url('../imgs/defaultItem.png')">
+  <div class="listingImage js-listingImage" style="url('../imgs/defaultItem.png')">
     <div class="nsfwOverlay overlayPanel clrP">
       <div class="flexCent">
         <div>
@@ -60,13 +60,7 @@
     <% if (ob.vendor) { %>
       <a class="userIconWrapper js-userIcon" href="#<%= `${ob.vendor.peerID}/store` %>">
         <% const dataTip = ob.vendor.name ? `data-tip="${ob.vendor.name}"` : ''; %>
-        <div class="userIcon disc clrBr2 clrSh1 toolTipNoWrap" <%= dataTip %>
-        <% var avatarHash = ob.vendor.avatarHashes ? ob.isHiRez() ? ob.vendor.avatarHashes.small : ob.vendor.avatarHashes.tiny : ''; %>
-        <% if (avatarHash) { %>
-        style="background-image: url(<%= ob.getServerUrl(`ob/images/${avatarHash}`) %>), url('../imgs/defaultAvatar.png')"
-        <% } else { %>
-        style="background-image: url('../imgs/defaultAvatar.png')"
-        <% } %>>
+        <div class="userIcon disc clrBr2 clrSh1 toolTipNoWrap js-vendorIcon" style="background-image: url('../imgs/defaultAvatar.png')" <%= dataTip %>>
         </div>
       </a>
       <div class="userIconWrapper nsfwAvatarOverlay">
@@ -82,7 +76,7 @@
     <% } %>
     <div class="rowSm">
       <% const tooltipClass = ob.title.length > 60 ? 'toolTip' : 'toolTipNoWrap' %>
-      <div class="<%= tooltipClass %> toolTipTop inlineBlock <% if(ob.vendor) print('trimWidth') %>" data-tip="<%= ob.title %>">
+      <div class="<%= tooltipClass %> toolTipTop inlineBlock <% if (ob.vendor) print('trimWidth') %>" data-tip="<%= ob.title %>">
         <a class="clrT clamp"><%= ob.title %></a>
       </div>
     </div>
@@ -116,7 +110,7 @@
     <div class="flexVCent gutterHSm">
     <% // Since we have inconsistent padding/gutters, we'll inline some padding settings. %>
       <div class="flexNoShrink posR">
-        <div class="listingImage posR" style="background-image: url(<%= ob.getServerUrl(`ob/images/${ob.isHiRez() ? ob.thumbnail.small : ob.thumbnail.tiny}`) %>), url('../imgs/defaultItem.png')"></div>
+        <div class="listingImage js-listingImage posR" style="url('../imgs/defaultItem.png')"></div>
         <div class="center tx2 nsfwAvatarOverlay"><%= ob.parseEmojis('😲') %></div>
       </div>
       <div class="flexExpand">

--- a/js/templates/listingCard.html
+++ b/js/templates/listingCard.html
@@ -1,6 +1,13 @@
-<% if (ob.viewType === 'grid') { %>
+<%
+  const listingImageSrc = ob.listingImageSrc ?
+    `url(${ob.listingImageSrc}), ` : '';
+  const listingImageBgStyle =
+    `background-image: ${listingImageSrc}url('../imgs/defaultItem.png')`;
+
+  if (ob.viewType === 'grid') {
+%>
 <div class="gridViewContent posR">
-  <div class="listingImage js-listingImage" style="url('../imgs/defaultItem.png')">
+  <div class="listingImage js-listingImage" style="<%= listingImageBgStyle %>">
     <div class="nsfwOverlay overlayPanel clrP">
       <div class="flexCent">
         <div>
@@ -59,8 +66,12 @@
   <div class="pad clrBr borderTop infoArea">
     <% if (ob.vendor) { %>
       <a class="userIconWrapper js-userIcon" href="#<%= `${ob.vendor.peerID}/store` %>">
-        <% const dataTip = ob.vendor.name ? `data-tip="${ob.vendor.name}"` : ''; %>
-        <div class="userIcon disc clrBr2 clrSh1 toolTipNoWrap js-vendorIcon" style="background-image: url('../imgs/defaultAvatar.png')" <%= dataTip %>>
+        <%
+          const dataTip = ob.vendor.name ? `data-tip="${ob.vendor.name}"` : '';
+          const vendorAvatarImageSrc = ob.vendorAvatarImageSrc ?
+            `url(${ob.vendorAvatarImageSrc}), ` : '';
+        %>
+        <div class="userIcon disc clrBr2 clrSh1 toolTipNoWrap js-vendorIcon" style="<%= `background-image: ${vendorAvatarImageSrc}url('../imgs/defaultAvatar.png')` %>" <%= dataTip %>>
         </div>
       </a>
       <div class="userIconWrapper nsfwAvatarOverlay">
@@ -110,7 +121,7 @@
     <div class="flexVCent gutterHSm">
     <% // Since we have inconsistent padding/gutters, we'll inline some padding settings. %>
       <div class="flexNoShrink posR">
-        <div class="listingImage js-listingImage posR" style="url('../imgs/defaultItem.png')"></div>
+        <div class="listingImage js-listingImage posR" style="<%= listingImageBgStyle %>"></div>
         <div class="center tx2 nsfwAvatarOverlay"><%= ob.parseEmojis('😲') %></div>
       </div>
       <div class="flexExpand">

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -123,6 +123,7 @@ export default class extends baseVw {
 
     this.listingImage = new Image();
     this.listingImage.addEventListener('load', () => {
+      this.listingImage.loaded = true;
       this.$('.js-listingImage')
         .css('backgroundImage', `url(${listingImageSrc})`);
     });
@@ -136,6 +137,7 @@ export default class extends baseVw {
 
       this.avatarImage = new Image();
       this.avatarImage.addEventListener('load', () => {
+        this.avatarImage.loaded = true;
         this.$('.js-vendorIcon')
           .css('backgroundImage', `url(${avatarImageSrc})`);
       });
@@ -434,6 +436,10 @@ export default class extends baseVw {
         displayCurrency: app.settings.get('localCurrency'),
         isBlocked,
         isUnblocking,
+        listingImageSrc: this.listingImage.loaded &&
+          this.listingImage.src || '',
+        vendorAvatarImageSrc: this.avatarImage && this.avatarImage.loaded &&
+          this.avatarImage.src || '',
       }));
     });
 

--- a/js/views/search/Results.js
+++ b/js/views/search/Results.js
@@ -92,6 +92,7 @@ export default class extends baseVw {
   }
 
   loadPage(page = this.serverPage, size = this.pageSize) {
+    this.removeCardViews();
     // get the new page
     const url = new URL(this.searchUrl);
     const params = new URLSearchParams(url.search);
@@ -140,11 +141,16 @@ export default class extends baseVw {
     this.loadPage(this.serverPage);
   }
 
+  removeCardViews() {
+    this.cardViews.forEach(vw => vw.remove());
+    this.cardViews = [];
+  }
+
   remove() {
+    this.removeCardViews();
     if (this.newPageFetch) this.newPageFetch.abort();
     super.remove();
   }
-
 
   render() {
     loadTemplate('search/results.html', (t) => {
@@ -152,8 +158,7 @@ export default class extends baseVw {
 
       this.$resultsGrid = this.$('.js-resultsGrid');
       this.$displayText = this.$('.js-displayingText');
-      this.cardViews.forEach(vw => vw.remove());
-      this.cardViews = [];
+      this.removeCardViews();
 
       if (this.pageControls) this.pageControls.remove();
       this.pageControls = this.createChild(PageControls);


### PR DESCRIPTION
The problem with image loads not being cancelled is most prevalent in search. Since we can only make 6 requests at a time and we're loading 48 images per page of search results, if a bunch of those are slow they clog up the request queue. This is most noticeable when sometimes you go from search to a different page in the app and find that page taking abnormally long.

The most dramatic way to see this in action would be to add `time.Sleep(5000 * time.Millisecond)` to GETImage on the server, then load a search page and navigate away. You'll find the new page takes a long time to load it's content. This PR fixes that so as you nav away from search or proceed to a new page of results, any image requests are cancelled.