### PR TITLE
Remove Unused Memo Parameter

### DIFF
--- a/js/models/purchase/Order.js
+++ b/js/models/purchase/Order.js
@@ -21,7 +21,6 @@ export default class extends BaseModel {
       addressNotes: '',
       moderator: '',
       items: new Items(),
-      memo: '',
       alternateContactInfo: '',
     };
   }


### PR DESCRIPTION
The memo in the order isn't used, I think it was confused with the memo in the item and added to the defaults for the order by accident.