### PR TITLE
support back/forward mouse buttons

### DIFF
--- a/js/start.js
+++ b/js/start.js
@@ -37,6 +37,7 @@ import { fetchExchangeRates } from './utils/currency';
 import './utils/exchangeRateSyncer';
 import { launchDebugLogModal, launchSettingsModal } from './utils/modalManager';
 import listingDeleteHandler from './startup/listingDelete';
+import initMouseForwardBack from './startup/mouseForwardBack';
 import { fixLinuxZoomIssue, handleServerShutdownRequests } from './startup';
 import ConnectionManagement from './views/modals/connectionManagement/ConnectionManagement';
 import Onboarding from './views/modals/onboarding/Onboarding';
@@ -951,6 +952,8 @@ ipcRenderer.on('close-attempt', (e) => {
 
 // initialize our listing delete handler
 listingDeleteHandler();
+
+initMouseForwardBack();
 
 if (remote.getGlobal('isBundledApp')) {
   console.log(`%c${app.polyglot.t('consoleWarning.heading')}`,

--- a/js/startup/mouseForwardBack.js
+++ b/js/startup/mouseForwardBack.js
@@ -1,12 +1,12 @@
+const mouseForwardBack = require('mouse-forward-back');
 import $ from 'jquery';
 import { remote } from 'electron';
 
 // handles mouse back/forward buttons
 
 export default function () {
-
   // app-command event is triggered on Windows only
-  $(window).on("app-command", (e, cmd) => {
+  $(window).on('app-command', (e, cmd) => {
     if (cmd === 'browser-backward') {
       window.history.back();
     } else if (cmd === 'browser-forward') {
@@ -16,7 +16,7 @@ export default function () {
 
 
   if (process.platform === 'linux') {
-    require('mouse-forward-back').register((button) => {
+    mouseForwardBack.register((button) => {
       if (button === 'back') {
         window.history.back();
       } else if (button === 'forward') {

--- a/js/startup/mouseForwardBack.js
+++ b/js/startup/mouseForwardBack.js
@@ -1,4 +1,4 @@
-const mouseForwardBack = require('mouse-forward-back');
+import mouseForwardBack from 'mouse-forward-back';
 import $ from 'jquery';
 import { remote } from 'electron';
 

--- a/js/startup/mouseForwardBack.js
+++ b/js/startup/mouseForwardBack.js
@@ -1,0 +1,26 @@
+import { remote } from 'electron';
+
+// handles mouse back/forward buttons
+
+export default function () {
+
+  // app-command works on Windows only
+  $(window).on("app-command", (e, cmd) => {
+    if (cmd === 'browser-backward') {
+      window.history.back();
+    } else if (cmd === 'browser-forward') {
+      window.history.forward();
+    }
+  });
+
+
+  if (process.platform === 'linux') {
+    require('mouse-forward-back').register((button) => {
+      if (button === 'back') {
+        window.history.back();
+      } else if (button === 'forward') {
+        window.history.forward();
+      }
+    }, remote.getCurrentWindow().getNativeWindowHandle());
+  }
+}

--- a/js/startup/mouseForwardBack.js
+++ b/js/startup/mouseForwardBack.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import { remote } from 'electron';
 
 // handles mouse back/forward buttons

--- a/js/startup/mouseForwardBack.js
+++ b/js/startup/mouseForwardBack.js
@@ -5,7 +5,7 @@ import { remote } from 'electron';
 
 export default function () {
 
-  // app-command works on Windows only
+  // app-command event is triggered on Windows only
   $(window).on("app-command", (e, cmd) => {
     if (cmd === 'browser-backward') {
       window.history.back();

--- a/package.json
+++ b/package.json
@@ -89,9 +89,7 @@
     "underscore": "^1.8.3",
     "url-parse": "^1.1.7",
     "velocity-animate": "^1.2.3",
-    "yargs": "^6.6.0"
-  },
-  "optionalDependencies": {
+    "yargs": "^6.6.0",
     "mouse-forward-back": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "url-parse": "^1.1.7",
     "velocity-animate": "^1.2.3",
     "yargs": "^6.6.0"
+  },
+  "optionalDependencies": {
+    "mouse-forward-back": "^1.0.1"
   }
 }


### PR DESCRIPTION
This adds support for back and forward mouse buttons.
Tested on linux. 
Could anyone please try this (fix it) on Windows?

On windows, it should be supported natively by https://electronjs.org/docs/all#event-app-command-windows
On linux there is electron/electron/issues/6996 and https://github.com/jostrander/mouse-forward-back