### PR TITLE
Fix blockdozer URLs.

### DIFF
--- a/js/data/cryptoCurrencies.js
+++ b/js/data/cryptoCurrencies.js
@@ -65,12 +65,12 @@ const currencies = [
     getBlockChainAddressUrl: (address, isTestnet) => (
       isTestnet ?
         `https://www.blocktrail.com/tBCC/address/${address}` :
-        `https://blockdozer.com/insight/address/${address}`
+        `https://blockdozer.com/address/${address}`
     ),
     getBlockChainTxUrl: (txid, isTestnet) => (
       isTestnet ?
         `https://www.blocktrail.com/tBCC/tx/${txid}` :
-        `https://blockdozer.com/insight/tx/${txid}`
+        `https://blockdozer.com/tx/${txid}`
     ),
     canShapeShiftIntoWallet: true,
     canShapeShiftIntoPurchase: false,


### PR DESCRIPTION
Blockdozer removed the `insight` path fragment from the URLs and the URLs we link to redirect to the Blockdozer home page, not the correct new page. This change removes the `insight` path fragment.

@placer14 gets credit for finding the bug.