### PR TITLE
Left align right text, add margin, keep right column aligned.

### DIFF
--- a/js/templates/modals/purchase/receipt.html
+++ b/js/templates/modals/purchase/receipt.html
@@ -13,12 +13,12 @@
     } else {
       basePrice = ob.currencyMod.convertCurrency(priceObj.price, ob.listingCurrency, viewingCurrency);
     }
-    
+
     const shippingPrice = ob.currencyMod.convertCurrency(priceObj.sPrice, ob.listingCurrency, viewingCurrency);
     const additionalShippingPrice = ob.currencyMod.convertCurrency(priceObj.aPrice, ob.listingCurrency, viewingCurrency);
     const surcharge = ob.currencyMod.convertCurrency(priceObj.vPrice, ob.listingCurrency, viewingCurrency);
     let quantity = Number.isInteger(priceObj.quantity) && priceObj.quantity > 0 ? priceObj.quantity : 1;
-    
+
     if (ob.isCrypto) {
       quantity = typeof priceObj.quantity === 'number' && priceObj.quantity > 0 ?
         priceObj.quantity :
@@ -42,32 +42,28 @@
     }).format(quantity);
 %>
   <div class="flexRow">
-    <span class="flexExpand">
+    <span class="expandedWidth">
       <%= ob.polyT('purchase.receipt.listing') %>
     </span>
     <div class="constrainedWidth">
-      <div class="flexHRight">
-        <b>
-          <%= ob.currencyMod.formatCurrency(preCouponPrice, viewingCurrency) %>
-        </b>
-      </div>
+      <b>
+        <%= ob.currencyMod.formatCurrency(preCouponPrice, viewingCurrency) %>
+      </b>
     </div>
   </div>
   <% ob.coupons.forEach((coupon) => { %>
     <div class="flexRow">
-      <span class="flexExpand">
+      <span class="expandedWidth">
         <%= ob.polyT('purchase.receipt.coupon') %>
       </span>
       <div class="constrainedWidth">
-        <div class="flexHRight">
-          <b>
-            <% if (coupon.percentDiscount) {
-                 print(`-${coupon.percentDiscount}%`);
-            } else if (coupon.priceDiscount) {
-              print(`-${ob.currencyMod.convertAndFormatCurrency(Number(coupon.priceDiscount), ob.listingCurrency, viewingCurrency)}`);
-            } %>
-          </b>
-        </div>
+        <b>
+          <% if (coupon.percentDiscount) {
+               print(`-${coupon.percentDiscount}%`);
+          } else if (coupon.priceDiscount) {
+            print(`-${ob.currencyMod.convertAndFormatCurrency(Number(coupon.priceDiscount), ob.listingCurrency, viewingCurrency)}`);
+          } %>
+        </b>
       </div>
     </div>
   <% }); %>
@@ -79,82 +75,70 @@
         </span>
   </div>
   <div class="flexRow subShipping">
-    <span class="flexExpand">
+    <span class="expandedWidth">
       <%= ob.polyT('purchase.receipt.firstItem') %>
     </span>
     <div class="constrainedWidth">
-      <div class="flexHRight">
-        <b>
-          <%= ob.currencyMod.formatCurrency(shippingPrice, viewingCurrency) %>
-        </b>
-      </div>
+      <b>
+        <%= ob.currencyMod.formatCurrency(shippingPrice, viewingCurrency) %>
+      </b>
     </div>
   </div>
   <div class="flexRow subShipping">
-    <span class="flexExpand">
+    <span class="expandedWidth">
       <%= ob.polyT('purchase.receipt.additionalItems') %>
     </span>
     <div class="constrainedWidth">
-      <div class="flexHRight">
-        <b>
-          <%= ob.currencyMod.formatCurrency(additionalShippingPrice, viewingCurrency) %>
-        </b>
-      </div>
+      <b>
+        <%= ob.currencyMod.formatCurrency(additionalShippingPrice, viewingCurrency) %>
+      </b>
     </div>
   </div>
   <% } else if (ob.listing.shippingOptions && ob.listing.shippingOptions.length) { %>
     <div class="flexRow">
-      <span class="flexExpand">
+      <span class="expandedWidth">
         <%= ob.polyT('purchase.receipt.shipping') %>
       </span>
       <div class="constrainedWidth">
-        <div class="flexHRight">      
-          <b>
-            <%= ob.currencyMod.formatCurrency(shippingPrice, viewingCurrency) %>
-          </b>
-        </div>
+        <b>
+          <%= ob.currencyMod.formatCurrency(shippingPrice, viewingCurrency) %>
+        </b>
       </div>
     </div>
   <% } %>
   <hr class="clrBr">
   <% if (quantity) { %>
     <div class="flexRow">
-      <span class="flexExpand">
+      <span class="expandedWidth">
         <%= ob.polyT('purchase.receipt.subtotal', { quantity: formattedQuantity }) %>
       </span>
       <div class="constrainedWidth">
-        <div class="flexHRight">      
-          <b>
-            <%= ob.currencyMod.formatCurrency(subTotal, viewingCurrency) %>
-          </b>
-        </div>
+        <b>
+          <%= ob.currencyMod.formatCurrency(subTotal, viewingCurrency) %>
+        </b>
       </div>
     </div>
     <% if (ob.listing.shippingOptions && ob.listing.shippingOptions.length && shippingTotal) { %>
       <div class="flexRow">
-        <span class="flexExpand">
+        <span class="expandedWidth">
           <%= ob.polyT('purchase.receipt.shippingTotal') %>
         </span>
         <div class="constrainedWidth">
-          <div class="flexHRight">        
-            <b>
-              <%= ob.currencyMod.formatCurrency(shippingTotal, viewingCurrency) %>
-            </b>
-          </div>
+          <b>
+            <%= ob.currencyMod.formatCurrency(shippingTotal, viewingCurrency) %>
+          </b>
         </div>
       </div>
     <% } %>
   <% } %>
   <div class="flexRow">
-    <span class="flexExpand">
+    <span class="expandedWidth">
       <%= ob.polyT('purchase.receipt.total') %>
     </span>
     <div class="constrainedWidth">
-      <div class="flexHRight">    
-        <b>
-          <%= ob.currencyMod.formatCurrency(subTotal + shippingTotal, viewingCurrency) %>
-        </b>
-      </div>
+      <b>
+        <%= ob.currencyMod.formatCurrency(subTotal + shippingTotal, viewingCurrency) %>
+      </b>
     </div>
   </div>
 <% }); %>

--- a/styles/modules/modals/_purchase.scss
+++ b/styles/modules/modals/_purchase.scss
@@ -74,10 +74,14 @@
         padding-left: $pad;
       }
 
-      .constrainedWidth {
-        max-width: 50%;
+      .expandedWidth {
+        flex-basis: 50%;
         flex-grow: 1;
-        flex-shrink: 0;        
+        margin-right: 10px;
+      }
+
+      .constrainedWidth {
+        max-width: calc(50% - 10px);
       }
     }
   }


### PR DESCRIPTION
This adjusts #1330 to keep the right side text left aligned when it wraps, keeps both "columns" in alignment, and adds a margin between them.

Text wrapping before:
![image](https://user-images.githubusercontent.com/1584275/39720051-17d54f7e-5209-11e8-95bd-e522b6a9465d.png)

Text wrapping after:
![image](https://user-images.githubusercontent.com/1584275/39723479-f782007c-5213-11e8-9221-2cc15d7038ae.png)
