### PR TITLE
switching the  block explorer used for urls to one supporting bech32 …

### DIFF
--- a/js/data/cryptoCurrencies.js
+++ b/js/data/cryptoCurrencies.js
@@ -24,12 +24,12 @@ const currencies = [
     getBlockChainAddressUrl: (address, isTestnet) => (
       isTestnet ?
         `https://www.blocktrail.com/tBTC/address/${address}` :
-        `https://blockchain.info/address/${address}`
+        `https://blockchair.com/bitcoin/address/${address}`
     ),
     getBlockChainTxUrl: (txid, isTestnet) => (
       isTestnet ?
         `https://www.blocktrail.com/tBTC/tx/${txid}` :
-        `https://blockchain.info/tx/${txid}`
+        `https://blockchair.com/bitcoin/transaction/${txid}`
     ),
     canShapeShiftIntoWallet: true,
     canShapeShiftIntoPurchase: false,


### PR DESCRIPTION
…addresses

closes #1291 

@jjeffryes FWIW, I didn't test the address one. I wiped recently and don't have a moderated transaction handy. Hoping you do and it would be an easy test for you...? If you only have it on tn, you could probably just fudge `isTestnet` inside that addr function.