### PR TITLE
Reorder disclaimer text

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -1765,7 +1765,7 @@
   "metrics": {
     "title": "Optional Anonymous Metrics",
     "msg1": "Please help improve OpenBazaar by agreeing to share anonymous data about your experience with the development team.",
-    "msg2": "No information that can be used to identify you, your orders, or any of your transactions is shared with us. Your private data is always stored on your own computer, and is not accessible by anyone else.",
+    "msg2": "No information that can be used to identify you, your orders, or any of your transactions is shared with us. Your private data is always stored on your own computer, and cannot be accessed by anyone else.",
     "listTitle": "The following data will be shared:",
     "list": {
       "pages": "Which pages you load, such as the search page or the store page.",

--- a/js/templates/modals/metricsModal.html
+++ b/js/templates/modals/metricsModal.html
@@ -3,20 +3,21 @@
   <div class="rowMd innerMessage">
     <div class="rowHg">
       <p><%= ob.polyT('metrics.msg1') %></p>
+      <p><i><%= ob.polyT('metrics.msg2') %></i></p>
     </div>
     <h4><%= ob.polyT('metrics.listTitle') %></h4>
-    <ul class="tx5 clrT2 padSmKids rowLg">
+    <ul class="tx5 padSmKids rowLg">
       <li><%= ob.polyT('metrics.list.pages') %></li>
       <li><%= ob.polyT('metrics.list.clicks') %></li>
-      <li><%= ob.polyT('metrics.list.orders') %></li>
+      <li><%= ob.polyT('metrics.list.errors') %></li>
       <li><%= ob.polyT('metrics.list.user') %></li>
       <li><%= ob.polyT('metrics.list.node') %></li>
+      <li><%= ob.polyT('metrics.list.orders') %></li>
       <li><%= ob.polyT('metrics.list.app') %></li>
       <li><%= ob.polyT('metrics.list.system') %></li>
       <li><%= ob.polyT('metrics.list.path') %></li>
-      <li><%= ob.polyT('metrics.list.errors') %></li>
+
     </ul>
-    <p class="tx5"><i><%= ob.polyT('metrics.msg2') %></i></p>
   </div>
   <div class="flexVCent flexHRight gutterH">
     <% if (ob.shareMetrics !== undefined) {%>


### PR DESCRIPTION
This moves some of the text in the metrics modal around, adjusts some styles and fixes a grammatical error.