### PR TITLE
Inventory unknown text

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -954,7 +954,8 @@
   "inventoryDisplay": {
     "retryLink": "Retry",
     "fetchError": "There was an error obtaining the inventory. %{retryLink}",
-    "fetchErrorWithMsg": "There was an error obtaining the inventory: %{msg}"
+    "fetchErrorWithMsg": "There was an error obtaining the inventory: %{msg}",
+    "unknownInventory": "unknown"
   },
   "listingDetail": {
     "edit": "Edit",
@@ -1038,8 +1039,7 @@
     "btnShowMatureContent": "Show Mature Content",
     "tipShowMatureContent": "Show Mature Content",
     "tipHideMatureContent": "Hide Mature Content",
-    "blockedUser": "You blocked this user",
-    "unknownInventory": "unknown"
+    "blockedUser": "You blocked this user"
   },
   "listingDelete": {
     "deletingListing": "Deleting listing %{listing}…",

--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -1038,7 +1038,8 @@
     "btnShowMatureContent": "Show Mature Content",
     "tipShowMatureContent": "Show Mature Content",
     "tipHideMatureContent": "Hide Mature Content",
-    "blockedUser": "You blocked this user"
+    "blockedUser": "You blocked this user",
+    "unknownInventory": "unknown"
   },
   "listingDelete": {
     "deletingListing": "Deleting listing %{listing}…",

--- a/js/templates/components/quantityDisplay.html
+++ b/js/templates/components/quantityDisplay.html
@@ -17,8 +17,8 @@
   print(ob.spinner({ className: `${ob.spinnerClass}` }))
 } else if (ob.fetchFailed) { %>
   <div class="content">
-    <div class="arrowBoxTipWrap <%= ob.tipClass %>">
-      <i class="ion-alert-circled margRSm clrTAlert"></i>
+    <div class="arrowBoxTipWrap">
+      <i class="clrT2"><%= ob.polyT('inventoryDisplay.unknownInventory') %></i>
       <% if (ob.fetchError) { %>
         <%
           const retryLink = `<a class="js-retry">${ob.polyT('inventoryDisplay.retryLink')}</a>`;
@@ -27,13 +27,12 @@
           });
 
           if (ob.fetchError) {
-            message = ob.polyT('inventoryDisplay.fetchErrorWithMsg', {
+            message = `<div class="rowSm">${ob.polyT('inventoryDisplay.fetchErrorWithMsg', {
               msg: ob.fetchError,
-            });
-            message += `<br /> <br /><div class="txCtr">${retryLink}</div>`;
+            })}</div><div class="txCtr">${retryLink}</div>`;
           }
         %>
-        <div class="arrowBoxCenteredTop clrBr clrP"><%= message %></div>
+        <div class="arrowBoxCenteredTop clrBr clrP <%= ob.tipClass %>"><%= message %></div>
       <% } %>
     </div>
   </div>

--- a/js/templates/listingCard.html
+++ b/js/templates/listingCard.html
@@ -200,7 +200,7 @@
     </div>
     <div class="priceCol clrTEm txB"><%= ob.currencyMod.formattedCurrency(1, ob.coinType, ob.displayCurrency) %></div>
     <%
-      let inventory = `<i class="clrT2 tx6">${ob.polyT('listingCard.unknownInventory')}</i>`;
+      let inventory = `<i class="clrT2 tx6">${ob.polyT('inventoryDisplay.unknownInventory')}</i>`;
       let inventoryTxClass = '';
 
       if (ob.totalInventoryQuantity >= 0) {

--- a/js/templates/listingCard.html
+++ b/js/templates/listingCard.html
@@ -166,7 +166,7 @@
       <div class="flex gutterH">
         <div class="verifiedModWrapper">
           <div class="js-verifiedMod"></div>
-        </div>    
+        </div>
         <div class="flexCol gutterVTn">
           <% const tooltipClass = ob.title.length > 60 ? 'toolTip' : 'toolTipNoWrap' %>
           <div class="<%= tooltipClass %> toolTipTop" data-tip="<%= ob.title %>">
@@ -200,7 +200,7 @@
     </div>
     <div class="priceCol clrTEm txB"><%= ob.currencyMod.formattedCurrency(1, ob.coinType, ob.displayCurrency) %></div>
     <%
-      let inventory = '<i class="ion-alert-circled margRSm clrTAlert"></i>';
+      let inventory = `<i class="clrT2 tx6">${ob.polyT('listingCard.unknownInventory')}</i>`;
       let inventoryTxClass = '';
 
       if (ob.totalInventoryQuantity >= 0) {


### PR DESCRIPTION

This switches the warning icon for the world 'unknown' when inventory for an item fails to load.

This also has some minor tweaks to the quantity display template to allow the unknown text to keep the size of the container it's in, and to reduce the space between the text and the retry link.

Closes #1340 

![image](https://user-images.githubusercontent.com/1584275/39788216-64f9db1e-52f7-11e8-93fe-36331c442670.png)