### PR TITLE
Use ISO instead of moment for chat timestamp,

### DIFF
--- a/js/models/chat/ChatMessage.js
+++ b/js/models/chat/ChatMessage.js
@@ -211,7 +211,7 @@ export default class ChatMessage extends BaseModel {
     options.attrs = options.attrs || model.toJSON(options);
 
     if (method === 'create') {
-      const timestamp = moment(Date.now()).format();
+      const timestamp = new Date().toISOString();
       options.attrs.timestamp = timestamp;
       this.set('timestamp', timestamp);
     }


### PR DESCRIPTION
Uses toISOString instead of moment for chat timestamps, closes Issue: #1276

tested in ar and uk