### PR TITLE
Remove path from page tracking

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -53,7 +53,7 @@ export default class ObRouter extends Router {
     $(window).on('hashchange', () => {
       this.setAddressBarText();
       if (window.Countly) {
-        window.Countly.q.push(['track_pageview', location.pathname + location.hash]);
+        window.Countly.q.push(['track_pageview', location.hash]);
       }
     });
 

--- a/js/utils/metrics.js
+++ b/js/utils/metrics.js
@@ -66,7 +66,7 @@ export function addMetrics() {
     window.Countly.url = 'https://countly.openbazaar.org';
     window.Countly.interval = 30000;
     window.Countly.q.push(['track_sessions']);
-    window.Countly.q.push(['track_pageview', location.pathname + location.hash]);
+    window.Countly.q.push(['track_pageview', location.hash]);
     window.Countly.q.push(['track_clicks']);
     window.Countly.q.push(['track_links']);
     window.Countly.q.push(['track_scrolls']);


### PR DESCRIPTION
This removes the location from the tracking data, which reduces the path information we're collecting from users.

The path is still being collected in the view data, I haven't found a way to remove that yet.