### PR TITLE
Fix: 1023 Misaligned shipping

### DIFF
--- a/js/templates/listingCard.html
+++ b/js/templates/listingCard.html
@@ -141,7 +141,7 @@
         <span class="clrE1 clrTOnEmph clamp4 phraseBox"><%= ob.polyT('listingCard.freeShippingBanner') %></span>
       </div>
       <% } %>
-      <div class="priceCol flexNoShrink">
+      <div class="priceCol flexNoShrink clamp4">
         <span class="txB">
           <%=
             ob.currencyMod.formattedCurrency(

--- a/js/templates/listingCard.html
+++ b/js/templates/listingCard.html
@@ -138,7 +138,7 @@
       </div>
       <% if (ob.shipsFreeToMe) { %>
       <div class="freeShipCol flexNoShrink txCtr">
-        <span class="clrE1 clrTOnEmph phraseBox"><%= ob.polyT('listingCard.freeShippingBanner') %></span>
+        <span class="clrE1 clrTOnEmph clamp4 phraseBox"><%= ob.polyT('listingCard.freeShippingBanner') %></span>
       </div>
       <% } %>
       <div class="priceCol flexNoShrink">

--- a/styles/components/_listingCard.scss
+++ b/styles/components/_listingCard.scss
@@ -240,13 +240,11 @@
     // The price column is a set width and the free shipping column is a maximum of 200px and 4 lines.
     // This leaves the title/description/rating to flex to take up the remaining space.
     .priceCol {
-      padding-right: 20px;
       width: 100px;
       text-align: right;
     }
 
     .freeShipCol {
-      padding-right: 20px;
       max-width: 200px;
       word-break: break-word;
     }

--- a/styles/components/_listingCard.scss
+++ b/styles/components/_listingCard.scss
@@ -237,14 +237,18 @@
   }
 
   .listingsGridListView & {
-    // This isn't ideal, but there's inconistent spacing / widths of cols, plus there's variable
-    // content width on the price (e.g. some currencies may have quite large numbers)
+    // The price column is a set width and the free shipping column is a maximum of 200px and 4 lines.
+    // This leaves the title/description/rating to flex to take up the remaining space.
     .priceCol {
       padding-right: 20px;
+      width: 100px;
+      text-align: right;
     }
 
     .freeShipCol {
       padding-right: 20px;
+      max-width: 200px;
+      word-break: break-word;
     }
   }
 


### PR DESCRIPTION
Fixed [1023](https://github.com/OpenBazaar/openbazaar-desktop/issues/1023)

closes #1023 

Fixed this by fixing the price column to 100px, setting a max width on the free shipping column and clamping both to 4 to match the title/description box.

From @rmisio : Another optimization we could do in the future if we see a problem is progressively decrease the font of the price as the number of digits increase. So, just dummy numbers, but… if the price reaches 15 characters, we drop the font a little, if it reaches 20, we drop it some more. I’ve done that in some other places. Not sure it’s really necessary here at this point though. We could keep that card up our sleeve.