### PR TITLE
Added support for Crypto fulfillment to include urls/links & Fixed Issue with HTML in fulfillment breaking display/copy functionality.

### DIFF
--- a/js/templates/modals/orderDetail/summaryTab/fulfilled.html
+++ b/js/templates/modals/orderDetail/summaryTab/fulfilled.html
@@ -53,7 +53,6 @@
       </div>
     </div>
   <% } else if (ob.contractType === 'CRYPTOCURRENCY') { %>
-    <% const cryptocurrencyDelivery = ob.cryptocurrencyDelivery && ob.cryptocurrencyDelivery[0] || {}; %>
     <div class="flex gutterH clrT">
       <div class="statusIconCol"><span class="clrBr ion-cash"></span></div>
       <div class="flexExpand tx5 posR">
@@ -71,9 +70,13 @@
         }) %></div>
 
         <div class="row">
-          <span><%= ob.polyT('orderDetail.summaryTab.fulfilled.transactionIdLabel') %></span> <span class="clamp3 inline"><%= cryptocurrencyDelivery.transactionID %></span>
-          <a class="clrTEm js-copyText flexNoShrink" data-content="<%= cryptocurrencyDelivery.transactionID %>" data-status-indicator=".js-transactionIdCopiedToClipboard"><%= ob.polyT('orderDetail.summaryTab.fulfilled.copyLink') %></a>
+          <% if (ob.isTransactionIdAUrl) { %>
+          <a class="clrTEm" href="<%= ob.transactionIDOrUrl %>" data-open-external><%= ob.transactionIDOrUrl %></a>
+          <% } else { %>
+          <span><%= ob.polyT('orderDetail.summaryTab.fulfilled.transactionIdLabel') %></span> <span class="clamp3 inline"><%= ob.transactionIDOrUrl %></span>
+          <a class="clrTEm js-copyText flexNoShrink" data-content="<%= ob.transactionIDOrUrl %>" data-status-indicator=".js-transactionIdCopiedToClipboard"><%= ob.polyT('orderDetail.summaryTab.fulfilled.copyLink') %></a>
           <a class="hide js-transactionIdCopiedToClipboard"><%= ob.polyT('copiedToClipboard') %></a>
+          <% } %>
         </div>
         <div class="rowTn txB"><%= ob.noteFromLabel %></div>
         <div><%= ob.note ? ob.parseEmojis(ob.note) : ob.polyT('orderDetail.summaryTab.notApplicable') %></div>

--- a/js/views/modals/orderDetail/summaryTab/Fulfilled.js
+++ b/js/views/modals/orderDetail/summaryTab/Fulfilled.js
@@ -6,6 +6,8 @@ import '../../../../utils/lib/velocity';
 import app from '../../../../app';
 import loadTemplate from '../../../../utils/loadTemplate';
 import BaseVw from '../../../baseVw';
+import is from 'is_js';
+import { stripHtml } from '../../../../utils/dom';
 
 export default class extends BaseVw {
   constructor(options = {}) {
@@ -73,10 +75,19 @@ export default class extends BaseVw {
   }
 
   render() {
+    const cryptocurrencyDelivery = this.dataObject.cryptocurrencyDelivery;
+    let transactionIDOrUrl = cryptocurrencyDelivery && cryptocurrencyDelivery[0] || {};
+    transactionIDOrUrl = transactionIDOrUrl.transactionID || '';
+    const isTransactionIdAUrl = is.url(transactionIDOrUrl);
+
+    transactionIDOrUrl = stripHtml(transactionIDOrUrl);
+
     loadTemplate('modals/orderDetail/summaryTab/fulfilled.html', (t) => {
       this.$el.html(t({
         ...this._state,
         ...this.dataObject || {},
+        isTransactionIdAUrl,
+        transactionIDOrUrl,
         moment,
       }));
     });


### PR DESCRIPTION
Fixed [1338: Make Crypto TX ID Clickable](https://github.com/OpenBazaar/openbazaar-desktop/issues/1338)

- Changed template to conditionally display either a URL/Link the user has entered or simply the transaction ID.
21b8e32

- Check to determine if the Crypto Transaction ID is a url, if so present it to the template. Either way, we now strip html from the input - which was previously possible and did break the display and functionality of 'copy'.