### PR TITLE
Fix: 1383 Peer ID Not Translatable

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -251,6 +251,7 @@
     }
   },
   "userPage": {
+    "peerID": "Peer ID",
     "followsYou": "Follows You",
     "message": "Message",
     "customize": "Customize",

--- a/js/templates/userPage/home.html
+++ b/js/templates/userPage/home.html
@@ -34,7 +34,7 @@
       </div>
       <div class="listItem">
         <div class="flex">
-          <span class="flexExpand">Peer ID</span>
+          <span class="flexExpand"><%= ob.polyT('userPage.peerID') %></span>
           <span class="clrT hide js-guidCopied"><%= ob.polyT('copiedToClipboard') %></span>
         </div>
         <div class="clrT2">


### PR DESCRIPTION
Fix for [1383](https://github.com/OpenBazaar/openbazaar-desktop/issues/1383)
Added peerID under userPage. Changed static text in home.html to translated text.