### PR TITLE
Fix: 1382 'Load More' Now Translatable on Connected Peers

### DIFF
--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -11,6 +11,6 @@
 
   <div class="js-morePeers hide">
     <hr class="clrBr">
-    <a class="btn clrBr clrP js-morePeersBtn">Load More</a>
+    <a class="btn clrBr clrP js-morePeersBtn"><%= ob.polyT('connectedPeersPage.loadMore') %></a>
   </div>
 </div>


### PR DESCRIPTION
Fixed [1382](https://github.com/OpenBazaar/openbazaar-desktop/issues/1382)

connectedPeersPage.loadMore was already in our translations, but just not used on the connected peers page. Replaced the static text with the existing translation.