### PR TITLE
Retain shipping option on refresh

### DIFF
--- a/js/templates/modals/purchase/shipping.html
+++ b/js/templates/modals/purchase/shipping.html
@@ -8,7 +8,7 @@
   <% if (ob.userAddresses.length) { %>
   <select id="shippingAddress">
     <% ob.userAddresses.forEach((a, i) => { %>
-    <option value="<%= i %>">
+    <option value="<%= i %>" <% if (ob.selectedAddressIndex === i) print('selected') %>>
       <% const addr = [];
          addr.push(a.name);
          if (a.company) addr.push(a.company);

--- a/js/templates/modals/purchase/shippingOptions.html
+++ b/js/templates/modals/purchase/shippingOptions.html
@@ -3,7 +3,7 @@
     <% ob.validShippingOptions.forEach((option, i) => {
       option.services.forEach((service, j) => {
       const selected = ob.selectedOption && ob.selectedOption.name === option.name && ob.selectedOption.service === service.name;
-      const optionId = `${option.name}-${service.name}`;
+      const optionId = `option${i}${j}`;
     %>
         <div>
           <div class="btnRadio width100">

--- a/js/templates/modals/purchase/shippingOptions.html
+++ b/js/templates/modals/purchase/shippingOptions.html
@@ -1,6 +1,6 @@
-<% if (ob.services.length) { %>
+<% if (ob.validOptions.length) { %>
   <div class="flexColRows boxList border borderStacked clrP clrBr">
-    <% ob.services.forEach((service, i) => {
+    <% ob.validOptions.forEach((service, i) => {
          const selected = ob.selectedOption && ob.selectedOption.name === service.name && ob.selectedOption.service === service.service;
     %>
       <div>

--- a/js/templates/modals/purchase/shippingOptions.html
+++ b/js/templates/modals/purchase/shippingOptions.html
@@ -1,32 +1,29 @@
-<% if (ob.validShippingOptions.length) { %>
+<% if (ob.services.length) { %>
   <div class="flexColRows boxList border borderStacked clrP clrBr">
-    <% ob.validShippingOptions.forEach((option, i) => {
-      option.services.forEach((service, j) => {
-      const selected = ob.selectedOption && ob.selectedOption.name === option.name && ob.selectedOption.service === service.name;
-      const optionId = `option${i}${j}`;
+    <% ob.services.forEach((service, i) => {
+         const selected = ob.selectedOption && ob.selectedOption.name === service.name && ob.selectedOption.service === service.service;
     %>
-        <div>
-          <div class="btnRadio width100">
-            <input type="radio"
-                   class="js-shippingOption"
-                   id="<%= optionId %>"
-                   <% if (ob.selectedOption && selected || i===0 && j === 0) print('checked') %>
-                   data-name="<%= option.name %>"
-                   data-service="<%= service.name%>"
-                   name="shippingOption">
-            <label for="<%= optionId %>" class="flex gutterH pad">
-              <div>
-                <div class="tx5 rowSm txB"><%= option.name %>: <%= service.name %></div>
-                <div class="tx5b clrT2 txUnb">
-                  <% const price = ob.currencyMod.convertAndFormatCurrency(service.price, ob.metadata.pricingCurrency, ob.displayCurrency) %>
-                  <% if (service.estimatedDelivery) print(ob.polyT('purchase.serviceDetails', { price, delivery: service.estimatedDelivery })) %>
-                </div>
+      <div>
+        <div class="btnRadio width100">
+          <input type="radio"
+                 class="js-shippingOption"
+                 id="<%= `option${i}` %>"
+                 <% if (selected) print('checked') %>
+                 data-name="<%= service.name %>"
+                 data-service="<%= service.service%>"
+                 name="shippingOption">
+          <label for="<%= `option${i}` %>" class="flex gutterH pad">
+            <div>
+              <div class="tx5 rowSm txB"><%= service.name %>: <%= service.service %></div>
+              <div class="tx5b clrT2 txUnb">
+                <% const price = ob.currencyMod.convertAndFormatCurrency(service.price, ob.metadata.pricingCurrency, ob.displayCurrency) %>
+                <% if (service.estimatedDelivery) print(ob.polyT('purchase.serviceDetails', { price, delivery: service.estimatedDelivery })) %>
               </div>
-            </label>
-          </div>
+            </div>
+          </label>
         </div>
-      <% }); %>
-     <% }); %>
+      </div>
+    <% }); %>
   </div>
 <% } else { %>
   <div class="padGi flexCent">

--- a/js/templates/modals/purchase/shippingOptions.html
+++ b/js/templates/modals/purchase/shippingOptions.html
@@ -1,18 +1,20 @@
 <% if (ob.validShippingOptions.length) { %>
   <div class="flexColRows boxList border borderStacked clrP clrBr">
     <% ob.validShippingOptions.forEach((option, i) => {
-      option.services.forEach((service, j) => { %>
+      option.services.forEach((service, j) => {
+      const selected = ob.selectedOption && ob.selectedOption.name === option.name && ob.selectedOption.service === service.name;
+      const optionId = `${option.name}-${service.name}`;
+    %>
         <div>
           <div class="btnRadio width100">
             <input type="radio"
                    class="js-shippingOption"
-                   id="<%= `${i}${j}` %>"
-                   <% if (i===0 && j === 0) print('checked') %>
+                   id="<%= optionId %>"
+                   <% if (ob.selectedOption && selected || i===0 && j === 0) print('checked') %>
                    data-name="<%= option.name %>"
-                   data-type="<%= option.type %>"
-                   data-service="<%= service.name %>"
+                   data-service="<%= service.name%>"
                    name="shippingOption">
-            <label for="<%= `${i}${j}` %>" class="flex gutterH pad">
+            <label for="<%= optionId %>" class="flex gutterH pad">
               <div>
                 <div class="tx5 rowSm txB"><%= option.name %>: <%= service.name %></div>
                 <div class="tx5b clrT2 txUnb">

--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -23,6 +23,11 @@ export default class extends baseView {
       if (!col.models.length) {
         this.selectedAddress = '';
         this.trigger('shippingOptionSelected', { name: '', service: '' });
+      } else {
+        // If the old selected address doesn't exist any more, select the first address.
+        const userAddresses = app.settings.get('shippingAddresses');
+        this.selectedAddress = userAddresses.get(this.selectedAddress) ?
+          this.selectedAddress : userAddresses.at(0);
       }
       this.render();
     });

--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -22,7 +22,7 @@ export default class extends baseView {
     const userAddresses = app.settings.get('shippingAddresses');
     this.selectedAddress = userAddresses.at(0) || '';
 
-    this.listenTo(app.settings.get('shippingAddresses'), 'update', (col) => {
+    this.listenTo(app.settings.get('shippingAddresses'), 'update', col => {
       // If all the addresses were deleted, set the selection to blank.
       if (!col.models.length) {
         this.selectedAddress = '';
@@ -66,7 +66,7 @@ export default class extends baseView {
     const validOptions = [];
     const countryCode = address ? address.get('country') : '';
 
-    const extractedOptions = this.model.get('shippingOptions').toJSON().filter((option) =>
+    const extractedOptions = this.model.get('shippingOptions').toJSON().filter(option =>
       option.regions.includes(countryCode) || option.regions.includes('ALL'));
 
     if (extractedOptions.length) {
@@ -160,9 +160,8 @@ export default class extends baseView {
       validOptions: this.validOptions,
       selectedOption: this.selectedOption,
     });
-    this.listenTo(this.shippingOptions, 'shippingOptionSelected', ((opts) => {
-      this.selectedOption = opts;
-    }));
+    this.listenTo(this.shippingOptions, 'shippingOptionSelected',
+        opts => (this.selectedOption = opts));
 
     this.$('.js-shippingOptionsWrapper').append(this.shippingOptions.render().el);
 

--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -94,7 +94,7 @@ export default class extends baseView {
     if (this.validOptions.length) {
       // If the previously selected shipping option is no longer valid, select the first valid
       // shipping option. this.selectionOption only has a name and service, as that's the expected
-      // data for the server, the validOptions have additonal data in them.
+      // data for the server, the validOptions have additional data in them.
       const isSelectedValid = this.selectedOption && this.selectedOption.name &&
         !!this.validOptions.filter(option => option.name === this.selectedOption.name &&
           option.service === this.selectedOption.service).length;
@@ -114,10 +114,6 @@ export default class extends baseView {
       this.shippingOptions.selectedOption = this.selectedOption;
       this.shippingOptions.render();
     }
-  }
-
-  get countryCode() {
-    return this.selectedAddress ? this.selectedAddress.get('country') : '';
   }
 
   changeShippingAddress(e) {

--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -22,7 +22,7 @@ export default class extends baseView {
     const userAddresses = app.settings.get('shippingAddresses');
     this.selectedAddress = userAddresses.at(0) || '';
 
-    this.listenTo(app.settings.get('shippingAddresses'), 'update', col => {
+    this.listenTo(userAddresses, 'update', col => {
       // If all the addresses were deleted, set the selection to blank.
       if (!col.models.length) {
         this.selectedAddress = '';
@@ -59,7 +59,7 @@ export default class extends baseView {
 
   extractValidOptions(address) {
     // Any time the country is changed, the options valid for that country need to be extracted.
-    if (address !== '' && !address instanceof ShippingAddress) {
+    if (address !== '' && !(address instanceof ShippingAddress)) {
       throw new Error('The address must be blank or an instance of the ShippingAddress model.');
     }
 
@@ -69,22 +69,20 @@ export default class extends baseView {
     const extractedOptions = this.model.get('shippingOptions').toJSON().filter(option =>
       option.regions.includes(countryCode) || option.regions.includes('ALL'));
 
-    if (extractedOptions.length) {
-      extractedOptions.forEach(option => {
-        if (option.type === 'LOCAL_PICKUP') {
-          // local pickup options need a service with a name and price
-          option.services[0] = { name: app.polyglot.t('purchase.localPickup'), price: 0 };
-        }
-        option.services = _.sortBy(option.services, 'price');
-        option.services.forEach(optionService => {
-          validOptions.push({
-            ...optionService,
-            name: option.name,
-            service: optionService.name,
-          });
+    extractedOptions.forEach(option => {
+      if (option.type === 'LOCAL_PICKUP') {
+        // local pickup options need a service with a name and price
+        option.services[0] = { name: app.polyglot.t('purchase.localPickup'), price: 0 };
+      }
+      option.services = _.sortBy(option.services, 'price');
+      option.services.forEach(optionService => {
+        validOptions.push({
+          ...optionService,
+          name: option.name,
+          service: optionService.name,
         });
       });
-    }
+    });
 
     return validOptions;
   }

--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -20,7 +20,7 @@ export default class extends baseView {
     this.validOptions = [];
 
     const userAddresses = app.settings.get('shippingAddresses');
-    this.selectedAddress = this.selectedAddress || userAddresses.length ? userAddresses.at(0) : '';
+    this.selectedAddress = userAddresses.at(0) || '';
 
     this.listenTo(app.settings.get('shippingAddresses'), 'update', (col) => {
       // If all the addresses were deleted, set the selection to blank.

--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -54,12 +54,12 @@ export default class extends baseView {
     }
   }
 
-  extractValidOptions() {
-    // Any time the address is selected, the options valid for that address need to be extracted.
+  extractValidOptions(countryCode) {
+    // Any time the country is changed, the options valid for that country need to be extracted.
     this.validOptions = [];
 
     const extractedOptions = this.model.get('shippingOptions').toJSON().filter((option) =>
-      option.regions.includes(this.countryCode) || option.regions.includes('ALL'));
+      option.regions.includes(countryCode) || option.regions.includes('ALL'));
 
     if (extractedOptions.length) {
       extractedOptions.forEach(option => {
@@ -87,7 +87,7 @@ export default class extends baseView {
     if (this._selectedAddress === address) return;
 
     // if the selected address has a new country, extract the valid shipping options.
-    if (address.get('country') !== this.country) this.extractValidOptions();
+    if (address.get('country') !== this.country) this.extractValidOptions(address.get('country'));
 
     this._selectedAddress = address;
 

--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -55,7 +55,6 @@ export default class extends baseView {
   }
 
   extractValidOptions() {
-    console.log('extract')
     // Any time the address is selected, the options valid for that address need to be extracted.
     this.validOptions = [];
 
@@ -157,7 +156,7 @@ export default class extends baseView {
     }));
 
     this.$('.js-shippingOptionsWrapper').append(this.shippingOptions.render().el);
-    
+
     return this;
   }
 }

--- a/js/views/modals/purchase/ShippingOptions.js
+++ b/js/views/modals/purchase/ShippingOptions.js
@@ -57,13 +57,13 @@ export default class extends baseView {
     if (validShippingOptions.length) {
       validShippingOptions.forEach(option => {
         if (option.type === 'LOCAL_PICKUP') {
-          // local pickup options need a name and price
+          // local pickup options need a service and price
           option.services[0] = { name: app.polyglot.t('purchase.localPickup'), price: 0 };
         }
         option.services = _.sortBy(option.services, 'price');
       });
 
-      if (!this.selectedOption) {
+      if (!this.selectedOption || !this.selectedOption.name) {
         this.selectedOption = {
           name: validShippingOptions[0].name,
           service: validShippingOptions[0].services[0].name,

--- a/js/views/modals/purchase/ShippingOptions.js
+++ b/js/views/modals/purchase/ShippingOptions.js
@@ -54,16 +54,31 @@ export default class extends baseView {
     const validShippingOptions = this.model.get('shippingOptions').toJSON().filter((option) =>
       option.regions.indexOf(this.countryCode) !== -1 || option.regions.indexOf('ALL') !== -1);
 
+    const services = [];
+
     if (validShippingOptions.length) {
       validShippingOptions.forEach(option => {
         if (option.type === 'LOCAL_PICKUP') {
-          // local pickup options need a service and price
+          // local pickup options need a service with a name and price
           option.services[0] = { name: app.polyglot.t('purchase.localPickup'), price: 0 };
         }
         option.services = _.sortBy(option.services, 'price');
+        option.services.forEach(optionService => {
+          services.push({
+            ...optionService,
+            name: option.name,
+            service: optionService.name,
+          });
+        });
       });
 
-      if (!this.selectedOption || !this.selectedOption.name) {
+      // The selected option is an object with just name and service, as that's what's used by the
+      // purchase API. If the previously selected option is still valid, it should be reselected.
+      const isSelectedValid = !!services.filter(service =>
+        service.name === this.selectedOption.name &&
+        service.service === this.selectedOption.service).length;
+
+      if (!this.selectedOption || !this.selectedOption.name || !isSelectedValid) {
         this.selectedOption = {
           name: validShippingOptions[0].name,
           service: validShippingOptions[0].services[0].name,
@@ -74,7 +89,7 @@ export default class extends baseView {
     loadTemplate('modals/purchase/shippingOptions.html', t => {
       this.$el.html(t({
         ...this.model.toJSON(),
-        validShippingOptions,
+        services,
         selectedOption: this.selectedOption,
         displayCurrency: app.settings.get('localCurrency'),
       }));

--- a/js/views/modals/purchase/ShippingOptions.js
+++ b/js/views/modals/purchase/ShippingOptions.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import _ from 'underscore';
 import app from '../../../app';
 import '../../../lib/select2';
 import loadTemplate from '../../../utils/loadTemplate';

--- a/js/views/modals/purchase/ShippingOptions.js
+++ b/js/views/modals/purchase/ShippingOptions.js
@@ -11,12 +11,12 @@ export default class extends baseView {
     super(options);
     this.options = options;
 
-    this._countryCode = options.countryCode || '';
-    this._selectedOption = options.selectedOption || {};
-
     if (!this.model || !(this.model instanceof Listing)) {
       throw new Error('Please provide a listing model');
     }
+
+    this._selectedOption = options.selectedOption || {};
+    this.validOptions = options.validOptions || [];
   }
 
   className() {
@@ -42,54 +42,11 @@ export default class extends baseView {
     this.selectedOption = $(e.target).data();
   }
 
-  get countryCode() {
-    return this._countryCode;
-  }
-
-  set countryCode(code) {
-    this._countryCode = code;
-  }
-
   render() {
-    const validShippingOptions = this.model.get('shippingOptions').toJSON().filter((option) =>
-      option.regions.indexOf(this.countryCode) !== -1 || option.regions.indexOf('ALL') !== -1);
-
-    const services = [];
-
-    if (validShippingOptions.length) {
-      validShippingOptions.forEach(option => {
-        if (option.type === 'LOCAL_PICKUP') {
-          // local pickup options need a service with a name and price
-          option.services[0] = { name: app.polyglot.t('purchase.localPickup'), price: 0 };
-        }
-        option.services = _.sortBy(option.services, 'price');
-        option.services.forEach(optionService => {
-          services.push({
-            ...optionService,
-            name: option.name,
-            service: optionService.name,
-          });
-        });
-      });
-
-      // The selected option is an object with just name and service, as that's what's used by the
-      // purchase API. If the previously selected option is still valid, it should be reselected.
-      const isSelectedValid = !!services.filter(service =>
-        service.name === this.selectedOption.name &&
-        service.service === this.selectedOption.service).length;
-
-      if (!this.selectedOption || !this.selectedOption.name || !isSelectedValid) {
-        this.selectedOption = {
-          name: validShippingOptions[0].name,
-          service: validShippingOptions[0].services[0].name,
-        };
-      }
-    }
-
     loadTemplate('modals/purchase/shippingOptions.html', t => {
       this.$el.html(t({
         ...this.model.toJSON(),
-        services,
+        validOptions: this.validOptions,
         selectedOption: this.selectedOption,
         displayCurrency: app.settings.get('localCurrency'),
       }));


### PR DESCRIPTION
This refactors the shipping and shipping options views to retain choices made by the user in the event of a purchase view refresh, and handles situations where the old selections are no longer valid. 

This solves a number of edge cases where the user could end up with nothing selected or an invalid selection if they did something unexpected while changing their addresses in Settings.

Closes #1375 