### PR TITLE
Ensure BCH prefix exists when using qrCodeText

### DIFF
--- a/js/data/cryptoCurrencies.js
+++ b/js/data/cryptoCurrencies.js
@@ -64,7 +64,7 @@ const currencies = [
 
       const prefix = app.serverConfig.testnet ? 'bchtest' : 'bitcoincash';
       prefixedAddress = address.startsWith(prefix) ?
-      prefixedAddress : `${prefix}:${address}`;
+        prefixedAddress : `${prefix}:${address}`;
 
       return prefixedAddress;
     },

--- a/js/data/cryptoCurrencies.js
+++ b/js/data/cryptoCurrencies.js
@@ -59,7 +59,16 @@ const currencies = [
     maxDisplayDecimals: 8,
     averageModeratedTransactionSize: 184,
     feeBumpTransactionSize: 154,
-    qrCodeText: address => address,
+    qrCodeText: address => {
+      let prefixedAddress = address;
+
+      if (address.split(':').length === 1) {
+        const prefix = app.serverConfig.testnet ? 'bchtest' : 'bitcoincash';
+        prefixedAddress = `${prefix}:${address}`;
+      }
+
+      return prefixedAddress;
+    },
     icon: 'imgs/cryptoIcons/BCH.png',
     url: 'https://bitcoincash.org/',
     getBlockChainAddressUrl: (address, isTestnet) => (

--- a/js/data/cryptoCurrencies.js
+++ b/js/data/cryptoCurrencies.js
@@ -62,10 +62,9 @@ const currencies = [
     qrCodeText: address => {
       let prefixedAddress = address;
 
-      if (address.split(':').length === 1) {
-        const prefix = app.serverConfig.testnet ? 'bchtest' : 'bitcoincash';
-        prefixedAddress = `${prefix}:${address}`;
-      }
+      const prefix = app.serverConfig.testnet ? 'bchtest' : 'bitcoincash';
+      prefixedAddress = address.startsWith(prefix) ?
+      prefixedAddress : `${prefix}:${address}`;
 
       return prefixedAddress;
     },


### PR DESCRIPTION
Adds the prefix to the QR Code text if it is missing.