### PR TITLE
Show Warning On Incompatible Mod Coin

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -388,7 +388,7 @@
         "FIXED_PLUS_PERCENTAGE": "%{amount} (+%{percentage}%)*",
         "failed": "The information for this moderator failed to load.",
         "invalid": "This user is not currently a moderator.",
-    "invalidCurrency": "This moderator does not support %{currency}.",
+        "invalidCurrency": "This moderator does not support %{currency}.",
         "languages": "%{lang}, and %{smart_count} other language. |||| %{lang}, and %{smart_count} other languages."
     },
     "moderatorDetails": {

--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -388,6 +388,7 @@
         "FIXED_PLUS_PERCENTAGE": "%{amount} (+%{percentage}%)*",
         "failed": "The information for this moderator failed to load.",
         "invalid": "This user is not currently a moderator.",
+    "invalidCurrency": "This moderator does not support %{currency}.",
         "languages": "%{lang}, and %{smart_count} other language. |||| %{lang}, and %{smart_count} other languages."
     },
     "moderatorDetails": {
@@ -1958,8 +1959,8 @@
         "provideShipper": "Please provide a shipping carrier.",
         "provideUrl": "Please provide a file url.",
         "invalidUrl": "Please provide a valid url.",
-        "provideTransactionId": "Please provide a transaction ID.", 
-        "transactionIDTooLong": "Transaction ID exceeds the maximum length of %{maxLength} characters." 
+        "provideTransactionId": "Please provide a transaction ID.",
+        "transactionIDTooLong": "Transaction ID exceeds the maximum length of %{maxLength} characters."
     },
     "errorPage": {
         "userNotFoundTitle": "This User Could Not Be Found",

--- a/js/templates/components/moderatorCard.html
+++ b/js/templates/components/moderatorCard.html
@@ -30,9 +30,9 @@
         </div>
         <div class="row">
           <% if (ob.valid) { %>
-            <div class="rowSm clamp2"><%=ob.moderatorInfo.description %></div>
+            <div class="rowTn clamp2"><%=ob.moderatorInfo.description %></div>
             <% if (ob.modLanguages && ob.modLanguages.length) { %>
-              <div class="txSm">
+              <div class="txSm rowTn">
                 <% if (ob.modLanguages.length > 1) {
                      print(ob.polyT('moderatorCard.languages', { lang: ob.modLanguages[0], smart_count: ob.modLanguages.length -1 }));
                    } else { %>
@@ -40,23 +40,27 @@
                 <% } %>
               </div>
             <% } %>
-          </div>
-          <div class="flex snipKids gutterH tx5 detailsRow">
-            <div class="flexNoShrink TODO">
-              <%= ob.parseEmojis('👍') %> XX<% // placeholder for reputation %>
+            <div class="flex snipKids gutterH tx5 detailsRow">
+              <% if (ob.hasValidCurrency) { %>
+                <div class="flexNoShrink TODO">
+                  <%= ob.parseEmojis('👍') %> XX<% // placeholder for reputation %>
+                </div>
+                <div class="flexNoShrink">
+                  <% var amount = ob.currencyMod.convertAndFormatCurrency(ob.moderatorInfo.fee.fixedFee.amount, ob.moderatorInfo.fee.fixedFee.currencyCode, ob.displayCurrency) %>
+                  <%= ob.polyT(`moderatorCard.${ob.moderatorInfo.fee.feeType}`, { amount: amount, percentage: ob.moderatorInfo.fee.percentage }) %>
+                </div>
+                <div>
+                  <%= ob.parseEmojis('📍') %><%= ob.location || ob.polyT('userPage.noLocation') %>
+                </div>
+                <div class="flexExpand flexNoShrink verifiedWrapper js-verifiedMod"></div>
+              <% } else { %>
+                <span class="clrTErr"><%= ob.polyT('moderatorCard.invalidCurrency', { currency: ob.userCurrency }) %></span>
+              <% } %>
             </div>
-            <div class="flexNoShrink">
-              <% var amount = ob.currencyMod.convertAndFormatCurrency(ob.moderatorInfo.fee.fixedFee.amount, ob.moderatorInfo.fee.fixedFee.currencyCode, ob.displayCurrency) %>
-              <%= ob.polyT(`moderatorCard.${ob.moderatorInfo.fee.feeType}`, { amount: amount, percentage: ob.moderatorInfo.fee.percentage }) %>
-            </div>
-            <div>
-              <%= ob.parseEmojis('📍') %><%= ob.location || ob.polyT('userPage.noLocation') %>
-            </div>
-            <div class="flexExpand flexNoShrink verifiedWrapper js-verifiedMod"></div>
-            <% } else { %>
-              <span class="clrTErr"><%= ob.polyT('moderatorCard.invalid') %></span>
-            <% } %>
-          </div>
+          <% } else { %>
+            <span class="clrTErr"><%= ob.polyT('moderatorCard.invalid') %></span>
+          <% } %>
+        </div>
       <% } else { %>
         <div class="flexCol gutterVSm clrTErr">
           <strong class="txt5 noOverflow"><%= ob.peerID %></strong>

--- a/js/views/components/ModeratorCard.js
+++ b/js/views/components/ModeratorCard.js
@@ -37,6 +37,11 @@ export default class extends BaseVw {
       throw new Error('Please provide a Profile model.');
     }
 
+    const modInfo = this.model.get('moderatorInfo');
+    const modCurs = modInfo && modInfo.get('acceptedCurrencies') || [];
+    this.userCurrency = app.serverConfig.cryptoCurrency;
+    this.hasValidCurrency = modCurs.includes(this.userCurrency);
+
     handleLinks(this.el);
   }
 
@@ -71,9 +76,10 @@ export default class extends BaseVw {
   rotateSelectState() {
     if (this.cardState === 'selected' && !this.options.radioStyle) {
       this.changeSelectState(this.notSelected);
-    } else if (this.model.isModerator) {
-      /* Only change to selected if this is a valid moderator. Moderators that have become invalid
-         may be displayed, and can be de-selected to remove them. */
+    } else if (this.model.isModerator && this.hasValidCurrency) {
+      /* Only change to selected if this is a valid moderator and the user's currency is supported.
+      Moderators that have become invalid may be displayed, and can be de-selected to remove them.
+      */
       this.changeSelectState('selected');
     }
   }
@@ -109,6 +115,8 @@ export default class extends BaseVw {
         cardState: this.cardState,
         displayCurrency: app.settings.get('localCurrency'),
         valid: this.model.isModerator,
+        userCurrency: this.userCurrency,
+        hasValidCurrency: this.hasValidCurrency,
         radioStyle: this.options.radioStyle,
         controlsOnInvalid: this.options.controlsOnInvalid,
         verified: !!verifiedMod,


### PR DESCRIPTION
This will show a warning in settings/store if a mod doesn't support your crypto currency, and prevent users from adding them. This is mostly an issue if the user pastes a peerID into the find by ID input.

If they've already added the mod (if, for instance, the mod has changed their crypto currency through their config file, or they added them before this PR), they can remove the mod.

The easiest way to test this PR is to have two nodes with different currencies, and paste the peerID of one of them into the find by ID input in settings/store for the other one.

Note: this is a resubmission of #1401, it looks like its history got corrupted. It should be identical to that PR's commit ae9ec1d50dce4fb78e3156ec31a9d3972b4468ca