### PR TITLE
Fix forked CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ addons:
     packages:
       - fakeroot
 before_script:
-- openssl aes-256-cbc -k "$ENCRYPTION_SECRET" -in .travis/cert.p12.enc -d -a -out ./.travis/cert.p12
-- openssl aes-256-cbc -k "$OB1_SECRET" -in .travis/ob1.cert.spc.enc -d -a -out ./.travis/ob1.cert.spc
-- openssl aes-256-cbc -k "$OB1_SECRET" -in .travis/ob1.cert.spc.enc -d -a -out ./.travis/ob1.pvk
--  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then "./.travis/add-key.sh" ; fi
+- if [[ -n "$TRAVIS_TAG" ]]; then openssl aes-256-cbc -k "$ENCRYPTION_SECRET" -in .travis/cert.p12.enc -d -a -out ./.travis/cert.p12; fi
+- if [[ -n "$TRAVIS_TAG" ]]; then openssl aes-256-cbc -k "$OB1_SECRET" -in .travis/ob1.cert.spc.enc -d -a -out ./.travis/ob1.cert.spc; fi
+- if [[ -n "$TRAVIS_TAG" ]]; then openssl aes-256-cbc -k "$OB1_SECRET" -in .travis/ob1.cert.spc.enc -d -a -out ./.travis/ob1.pvk; fi
+- if [[ -n "$TRAVIS_TAG" ]]; then if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then "./.travis/add-key.sh"; fi ; fi
 script:
 - npm run lint
 - npm run test


### PR DESCRIPTION
This should not attempt to decrypt build keys when not building a tag, fixing the error outs for forked PRs.