### PR TITLE
Set Initial Shipping Option

### DIFF
--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -140,10 +140,10 @@ export default class extends BaseModal {
       this.shipping = this.createChild(Shipping, {
         model: this.listing,
       });
-      this.listenTo(this.shipping, 'shippingOptionSelected', ((sOpts) => {
-        this.updateShippingOption(sOpts);
-      }));
+      this.listenTo(this.shipping, 'shippingOptionSelected', () => this.updateShippingOption());
     }
+    // set the initial shipping option
+    this.updateShippingOption(this.shipping.selectedOption);
 
     this.complete = this.createChild(Complete, {
       listing: this.listing,
@@ -373,10 +373,10 @@ export default class extends BaseModal {
     this.order.get('items').at(0).set('coupons', codes);
   }
 
-  updateShippingOption(opts) {
+  updateShippingOption() {
     // set the shipping option
     this.order.get('items').at(0).get('shipping')
-      .set(opts);
+      .set(this.shipping.selectedOption);
   }
 
   purchaseListing() {

--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -53,7 +53,7 @@ export default class extends baseView {
   set selectedOption(opts) {
     if (!_.isEqual(this._selectedOption, opts)) {
       this._selectedOption = opts;
-      this.trigger('shippingOptionSelected', opts);
+      this.trigger('shippingOptionSelected');
     }
   }
 


### PR DESCRIPTION
This fixes a problem where the initial shipping option wasn't set in the purchase when the shipping components were refactored.

It includes a small refactor to always use the getter in the shipping view for the shipping option instead of passing options in the event.