### PR TITLE
don't set init shipping if there is no shipping

### DIFF
--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -141,9 +141,9 @@ export default class extends BaseModal {
         model: this.listing,
       });
       this.listenTo(this.shipping, 'shippingOptionSelected', () => this.updateShippingOption());
+      // set the initial shipping option
+      this.updateShippingOption(this.shipping.selectedOption);
     }
-    // set the initial shipping option
-    this.updateShippingOption(this.shipping.selectedOption);
 
     this.complete = this.createChild(Complete, {
       listing: this.listing,


### PR DESCRIPTION
Fixes a bug where the shipping was trying to be set for products with no shipping.