### PR TITLE
Let Users See Their Own Mod Details

### DIFF
--- a/js/views/modals/moderatorDetails.js
+++ b/js/views/modals/moderatorDetails.js
@@ -72,14 +72,17 @@ export default class extends BaseModal {
       this.$unFollowBtn = this.$('.js-unFollow');
 
       if (this.socialBtns) this.socialBtns.remove();
-      this.socialBtns = this.createChild(SocialBtns, {
-        targetID: this.model.id,
-        initialState: {
-          stripClasses: 'flexHCent gutterH',
-          btnClasses: 'clrP clrBr clrSh2',
-        },
-      });
-      this.$('.js-socialBtns').append(this.socialBtns.render().$el);
+      // Don't include the social buttons if this is the viewer's own moderator details
+      if (this.model.get('peerID') !== app.profile.id) {
+        this.socialBtns = this.createChild(SocialBtns, {
+          targetID: this.model.id,
+          initialState: {
+            stripClasses: 'flexHCent gutterH',
+            btnClasses: 'clrP clrBr clrSh2',
+          },
+        });
+        this.$('.js-socialBtns').append(this.socialBtns.render().$el);
+      }
 
       if (this.verifiedMod) this.verifiedMod.remove();
       this.verifiedMod = this.createChild(VerifiedMod, getModeratorOptions({


### PR DESCRIPTION
This prevents the moderator details view from having the social buttons if the moderator you're looking at is you.

The social buttons view was throwing an error in that situation, the simple solution is to not add that view in this case since you won't ever need to block, follow, or message yourself.