### PR TITLE
Fix disabled verified only

### DIFF
--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -144,7 +144,7 @@
             <div class="flexVCentClearMarg">
               <h2 class="h4 flexExpand required"><%= ob.polyT('purchase.paymentTypeTitle') %></h2>
               <% if (ob.showModerators) { %>
-                <input type="checkbox" id="purchaseVerifiedOnly" class="js-purchaseVerifiedOnly"<% if(ob.showOnlyVerified) print('checked') %>>
+                <input type="checkbox" id="purchaseVerifiedOnly" class="js-purchaseVerifiedOnly"<% if(ob.showOnlyVerified && !ob.unverifedSelected) print('checked') %>>
                 <label class="tx5b <% if (ob.unverifedSelected) print('disabled') %>" for="purchaseVerifiedOnly"><%= ob.polyT('settings.storeTab.verifiedOnly') %></label>
               <% } %>
             </div>

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -259,7 +259,8 @@ export default class extends BaseModal {
 
     this.order.moderated = false;
     this.moderators.deselectOthers();
-    this.render();
+    this.setState({ unverifedSelected: false }, { renderOnChange: false });
+    this.render(); // always render even if the state didn't change
   }
 
   onNoValidModerators() {


### PR DESCRIPTION
This fixes two small bugs:
- it's possible to end up in a state where an unverified moderator is selected in the purchase, but the show verified moderators only checkbox is checked, so the selected moderator is hidden and the checkbox is disabled so it can't be unhidden.
- when an unverified moderator is selected, the show verified moderators chekcbox is disabled, but not re-enabled when the direct payment option is selected.