### PR TITLE
Fix Coupon Not Appearing in Receipt

### DIFF
--- a/js/views/modals/purchase/Receipt.js
+++ b/js/views/modals/purchase/Receipt.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import app from '../../../app';
 import loadTemplate from '../../../utils/loadTemplate';
 import BaseView from '../../baseVw';
@@ -40,10 +39,8 @@ export default class extends BaseView {
   }
 
   updatePrices(prices) {
-    if (!_.isEqual(prices, this.prices)) {
-      this.prices = prices;
-      this.render();
-    }
+    this.prices = prices;
+    this.render();
   }
 
   render() {


### PR DESCRIPTION
This fixes an issue where coupons where not appearing in the receipt on a purchase when the coupon was added. Doing anything else to change the price would make the coupon appear, and it was still being applied to the order on purchase.

The cause was updatePrices was called when a coupon was applied, and had a check to only render if the prices object was changed. The coupon discount is not currently part of the price object, so that check caused the receipt not to re-render when only the coupon was changed.

Removing the check seems like the simplest solution, since it's not really needed.

Closes #1485