### PR TITLE
add width to tooltip parent

### DIFF
--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -77,6 +77,7 @@
         .addProvider {
           position: absolute;
           height: $thumb;
+          width: $thumb;
         }
       }
 


### PR DESCRIPTION
This corrects the centering of the Add Provider tooltip by giving the parent container the same width as the add button. Previously it had zero width, so the center was the left edge of the button.

closes #1483