### PR TITLE
Tied in use of existing translation for 'send' in complete order.

### DIFF
--- a/js/templates/modals/purchase/complete.html
+++ b/js/templates/modals/purchase/complete.html
@@ -64,6 +64,6 @@
         <%= ob.polyT('purchase.completeSection.vendorMessageSent', { name: ob.vendorName, orderLink }) %>
       </span>
     </div>
-    <button class="btn floR clrP clrBr clrSh2 js-send disabled">Send</button>
+    <button class="btn floR clrP clrBr clrSh2 js-send disabled"><%= ob.polyT('purchase.completeSection.send') %></button>
   </div>
 </div>


### PR DESCRIPTION
 closes #1495 

Simple fix for send translation in order completion.