### PR TITLE
Fix Undefined In ListingCard

### DIFF
--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -287,7 +287,8 @@ export default class extends baseVw {
         .fail(xhr => {
           endAjaxEvent('Listing_LoadFromCard', {
             ownListing: !!this.ownListing,
-            errors: xhr.responseJSON.reason || xhr.statusText || 'unknown error',
+            errors: xhr.responseJSON && xhr.responseJSON.reason ||
+            xhr.statusText || 'unknown error',
           });
           if (xhr.statusText === 'abort') return;
           app.router.listingError(xhr, this.model.get('slug'), `#${this.ownerGuid}/store`);
@@ -357,8 +358,7 @@ export default class extends baseVw {
     this.fullListingFetch = this.fullListing.fetch()
       .fail(xhr => {
         if (!opts.showErrorOnFetchFail) return;
-        let failReason = xhr.responseJSON && xhr.responseJSON &&
-          xhr.responseJSON.reason || '';
+        let failReason = xhr.responseJSON && xhr.responseJSON.reason || '';
 
         if (xhr.status === 404) {
           failReason = app.polyglot.t('listingCard.editFetchErrorDialog.bodyNotFound');

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -357,7 +357,8 @@ export default class extends baseVw {
     this.fullListingFetch = this.fullListing.fetch()
       .fail(xhr => {
         if (!opts.showErrorOnFetchFail) return;
-        let failReason = xhr.responseJSON && xhr.responseJSON.reason || '';
+        let failReason = xhr.responseJSON && xhr.responseJSON &&
+          xhr.responseJSON.reason || '';
 
         if (xhr.status === 404) {
           failReason = app.polyglot.t('listingCard.editFetchErrorDialog.bodyNotFound');


### PR DESCRIPTION
This fixes a problem where on fail for a full listing fetch xhr.responseJSON was undefined.

I was able to reproduce this issue live, it happens whenever a user hits the back button while a listing is loading when opened from the listing card.

Closes #1471