### PR TITLE
Use Smart Counts in Found Phrases

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -124,7 +124,7 @@
   },
   "connectedPeersPage": {
     "heading": "Connected Peers",
-    "totalPeers": "%{totalPeers} Found",
+    "totalPeers": "%{smart_count} Found",
     "noResults": "No connected peers",
     "loadMore": "Load More"
   },
@@ -314,7 +314,7 @@
       "shipsToFilterAny": "(Any country)",
       "sortBy": "Sort By",
       "countListings": "%{smart_count} listing |||| %{smart_count} listings",
-      "countListingsFound": "%{countListings} found",
+      "countListingsFound": "%{smart_count} found",
       "inactive": "Your store is currently inactive and hidden from the public. %{link}",
       "inactiveLink": "Change",
       "listingDataChangedPopin": "Listing data has changed.",
@@ -1458,7 +1458,7 @@
     "sales": {
       "heading": "Sales",
       "countTransactions": "%{smart_count} sale |||| %{smart_count} sales",
-      "countTransactionsFound": "%{countTransactions} found",
+      "countTransactionsFound": "%{smart_count} found",
       "unableToFetch": "Unable to obtain your sales.",
       "noResults": "No sales found",
       "returnToFromOrder": "Return to sales",
@@ -1472,7 +1472,7 @@
     "purchases": {
       "heading": "Purchases",
       "countTransactions": "%{smart_count} purchase |||| %{smart_count} purchases",
-      "countTransactionsFound": "%{countTransactions} found",
+      "countTransactionsFound": "%{smart_count} found",
       "unableToFetch": "Unable to obtain your purchases.",
       "noResults": "No purchases found",
       "returnToFromOrder": "Return to purchases"
@@ -1480,7 +1480,7 @@
     "cases": {
       "heading": "Cases",
       "countTransactions": "%{smart_count} case |||| %{smart_count} cases",
-      "countTransactionsFound": "%{countTransactions} found",
+      "countTransactionsFound": "%{smart_count} found",
       "noResults": "No cases found",
       "returnToFromOrder": "Return to cases"
     },

--- a/js/templates/connectedPeersPage.html
+++ b/js/templates/connectedPeersPage.html
@@ -2,7 +2,7 @@
   <div class="rowLg">
     <div class="flex">
       <h1 class="flexExpand"><%= ob.polyT('connectedPeersPage.heading') %></h1>
-      <div class="tx4 border clrBr clrP pad"><%= ob.polyT('connectedPeersPage.totalPeers', { totalPeers: ob.peers.length }) %></div>
+      <div class="tx4 border clrBr clrP pad"><%= ob.polyT('connectedPeersPage.totalPeers', { smart_count: ob.peers.length }) %></div>
     </div>
   </div>
   <div class="userPageFollow">

--- a/js/views/transactions/Tab.js
+++ b/js/views/transactions/Tab.js
@@ -61,7 +61,7 @@ export default class extends baseVw {
             this.$queryTotalWrapper.find('.js-queryTotalLine')
               .html(
                 app.polyglot.t(`transactions.${this.type}.countTransactionsFound`,
-                  { countTransactions: count })
+                  { smart_count: count })
               );
             this.$queryTotalWrapper.removeClass('hide');
           });

--- a/js/views/userPage/Store.js
+++ b/js/views/userPage/Store.js
@@ -459,7 +459,7 @@ export default class extends BaseVw {
       `<span class="txB">${app.polyglot.t('userPage.store.countListings', col.length)}</span>`;
     const fullListingCount =
         app.polyglot.t('userPage.store.countListingsFound',
-          { countListings: listingCount });
+          { smart_count: listingCount });
     this.$listingCount.html(fullListingCount);
 
     if (col.length) {


### PR DESCRIPTION
There are several places in the app where the phrase "X found" is used, where a smart count is not used for X. 

This creates an issue where translations that change based on the number can't be used.

This PR replaces the variables for the number with smart_count.

Closes #1510