### PR TITLE
Check if user is still a mod

### DIFF
--- a/js/views/UserCard.js
+++ b/js/views/UserCard.js
@@ -258,7 +258,7 @@ export default class extends BaseVw {
       const createOptions = getModeratorOptions({
         model: verifiedMod,
       });
-      if (verifiedMod) {
+      if (verifiedMod && this.model.isModerator) {
         this.verifiedMod = this.createChild(VerifiedMod, {
           ...createOptions,
           initialState: {


### PR DESCRIPTION
If the user is not a mod, but they are in the verified moderator list, don't show the verified mod badge on their user card.

This is the only place a verified moderator badge can appear when a user isn't a mod, the other places are the moderator card and moderator details modals, which won't be shown or will show an error state if the user isn't a moderator any more.

Closes #1528 