### PR TITLE
More listings

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -994,6 +994,7 @@
     "noRefundPolicy": "No return policy entered",
     "termsAndConditions": "Terms Of Service",
     "noTermsAndConditions": "No terms and conditions entered",
+    "moreBy": "More by %{name}",
     "shipping": "Shipping",
     "shipsFrom": "Ships from %{country}",
     "shipTo": "Ship to:",

--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -279,4 +279,6 @@
     <% if (!ob.termsAndConditions) { print(`<i class="clrT2">${ob.polyT('listingDetail.noTermsAndConditions')}</i>`) } %>
   </div>
 
+  <div class="js-moreListings"></div>
+
 </div>

--- a/js/templates/modals/listingDetail/moreListings.html
+++ b/js/templates/modals/listingDetail/moreListings.html
@@ -1,0 +1,4 @@
+<div class="contentBox padLg clrP clrBr clrSh3">
+  <h2 class="txUnb"><%= ob.polyT('listingDetail.moreBy', { name: ob.name }) %></h2>
+  <div class="listingsGrid flex js-cardWrapper"></div>
+</div>

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -271,6 +271,7 @@ export default class extends baseVw {
             modelContentClass: 'modalContent',
             openedFromStore: !!this.options.onStore,
             checkNsfw: !this._userClickedShowNsfw,
+            listings: this.options.listings,
           }).render()
             .open();
 

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -283,6 +283,7 @@ export default class extends baseVw {
         .always(() => {
           if (this.isRemoved()) return;
           app.loadingModal.close();
+          this.trigger('cardOpened');
         })
         .fail(xhr => {
           endAjaxEvent('Listing_LoadFromCard', {

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -665,6 +665,10 @@ export default class extends BaseModal {
         vendor: this.vendor,
         parentListingHash: this.model.get('hash'),
       });
+      // If a card is opened, close this modal so you don't get a stack of modals.
+      this.listenTo(this.moreListings, 'cardOpened', () => {
+        this.close();
+      });
       this.getCachedEl('.js-moreListings')
         .append(this.moreListings.render().$el);
 

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -29,6 +29,8 @@ import PopInMessage, { buildRefreshAlertMessage } from '../../components/PopInMe
 import { openSimpleMessage } from '../SimpleMessage';
 import NsfwWarning from '../NsfwWarning';
 import CryptoTradingPair from '../../components/CryptoTradingPair';
+import Listings from '../../../collections/Listings';
+import MoreListings from './MoreListings';
 
 export default class extends BaseModal {
   constructor(options = {}) {
@@ -170,6 +172,9 @@ export default class extends BaseModal {
       this.listenTo(inventoryEvents, 'inventory-change',
         e => (this._inventory = e.inventory));
     }
+
+    this.moreListingsCol = new Listings([], { guid: this.vendor.peerID });
+    this.moreListingsCol.fetch();
 
     this.boundDocClick = this.onDocumentClick.bind(this);
     $(document).on('click', this.boundDocClick);
@@ -653,6 +658,15 @@ export default class extends BaseModal {
         });
         this.$('.js-socialBtns').append(this.socialBtns.render().$el);
       }
+
+      if (this.moreListings) this.moreListings.remove();
+      this.moreListings = this.createChild(MoreListings, {
+        collection: this.moreListingsCol,
+        vendor: this.vendor,
+        parentListingHash: this.model.get('hash'),
+      });
+      this.getCachedEl('.js-moreListings')
+        .append(this.moreListings.render().$el);
 
       this.$photoSelectedInner = this.$('.js-photoSelectedInner');
       this._$deleteListing = null;

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -173,8 +173,9 @@ export default class extends BaseModal {
         e => (this._inventory = e.inventory));
     }
 
-    this.moreListingsCol = new Listings([], { guid: this.vendor.peerID });
-    this.moreListingsCol.fetch();
+    // If a listings collection wasn't passed in, fetch it now.
+    this.moreListingsCol = this.options.listings || new Listings([], { guid: this.vendor.peerID });
+    if (!this.options.listings) this.moreListingsCol.fetch();
 
     this.boundDocClick = this.onDocumentClick.bind(this);
     $(document).on('click', this.boundDocClick);

--- a/js/views/modals/listingDetail/MoreListings.js
+++ b/js/views/modals/listingDetail/MoreListings.js
@@ -39,7 +39,6 @@ export default class extends BaseVw {
   }
 
   createListingCardView(model) {
-    console.log(model.toJSON())
     const options = {
       listingBaseUrl: `${this.options.vendor.peerID}/store/`,
       viewType: 'grid',
@@ -66,13 +65,12 @@ export default class extends BaseVw {
       }
     });
 
-    console.log(listingsFrag)
     this.getCachedEl('.js-cardWrapper').append(listingsFrag);
   }
+
   render() {
     // Don't show anything if there are no listings to show, or if the only
     // listing is the same as the parent listing.
-    console.log(this.collection.length)
     if (this.collection.length < 1 ||
       this.collection.length === 1 &&
       this.isParent(this.collection.at(0).get('hash'))) return this;
@@ -87,33 +85,6 @@ export default class extends BaseVw {
       this.renderListingCards(this.collection);
     });
 
-    console.log('foo')
-
     return this;
   }
-/*
-  render() {
-    // Don't show anything if there are no listings to show
-    console.log(this.collection.length)
-    if (this.collection.length < 1) return this;
-
-    super.render();
-
-    loadTemplate('modals/listingDetail/rating.html', t => {
-      this.$el.html(t({
-        name: this.options.ownerName,
-      }));
-
-      console.log('foo')
-
-      this.listingCardViews.forEach(vw => vw.remove());
-      this.listingCardViews = [];
-      this.$el.empty();
-      // Render only the first 8 cards maximum
-      this.renderListingCards(this.collection.first(8));
-    });
-
-    return this;
-  }
-  */
 }

--- a/js/views/modals/listingDetail/MoreListings.js
+++ b/js/views/modals/listingDetail/MoreListings.js
@@ -1,0 +1,119 @@
+import BaseVw from '../../baseVw';
+import loadTemplate from '../../../utils/loadTemplate';
+import ListingCard from '../../ListingCard';
+
+export default class extends BaseVw {
+  constructor(options = {}) {
+    super(options);
+    this.options = options;
+
+    if (!this.collection) {
+      throw new Error('Please provide a collection.');
+    }
+
+    if (!options.vendor) {
+      throw new Error('Please provide a vendor object.');
+    }
+
+    if (!options.vendor.peerID) {
+      throw new Error('Please provide a vendor peerID.');
+    }
+
+    if (!options.vendor.name) {
+      throw new Error('Please provide a vendor name');
+    }
+
+    this.listingCardViews = [];
+
+    this.listenTo(this.collection, 'update', () => {
+      this.render();
+    });
+  }
+
+  className() {
+    return 'moreListings';
+  }
+
+  isParent(hash) {
+    return hash === this.options.parentListingHash;
+  }
+
+  createListingCardView(model) {
+    console.log(model.toJSON())
+    const options = {
+      listingBaseUrl: `${this.options.vendor.peerID}/store/`,
+      viewType: 'grid',
+      model,
+      vendor: this.options.vendor,
+      onStore: true,
+      ownerGuid: this.options.vendor.peerID,
+    };
+
+    return this.createChild(ListingCard, options);
+  }
+
+  renderListingCards(models = []) {
+    const listingsFrag = document.createDocumentFragment();
+
+    models.forEach(model => {
+      // Add up to 8 models.
+      // If a parent hash was provided, don't add that model.
+      if (this.listingCardViews.length < 8 &&
+        !this.isParent(model.get('hash'))) {
+        const listingCardVw = this.createListingCardView(model);
+        this.listingCardViews.push(listingCardVw);
+        listingCardVw.render().$el.appendTo(listingsFrag);
+      }
+    });
+
+    console.log(listingsFrag)
+    this.getCachedEl('.js-cardWrapper').append(listingsFrag);
+  }
+  render() {
+    // Don't show anything if there are no listings to show, or if the only
+    // listing is the same as the parent listing.
+    console.log(this.collection.length)
+    if (this.collection.length < 1 ||
+      this.collection.length === 1 &&
+      this.isParent(this.collection.at(0).get('hash'))) return this;
+
+    super.render();
+    loadTemplate('modals/listingDetail/moreListings.html', t => {
+      this.$el.html(t({
+        name: this.options.vendor.name,
+      }));
+      this.listingCardViews.forEach(vw => vw.remove());
+      this.listingCardViews = [];
+      this.renderListingCards(this.collection);
+    });
+
+    console.log('foo')
+
+    return this;
+  }
+/*
+  render() {
+    // Don't show anything if there are no listings to show
+    console.log(this.collection.length)
+    if (this.collection.length < 1) return this;
+
+    super.render();
+
+    loadTemplate('modals/listingDetail/rating.html', t => {
+      this.$el.html(t({
+        name: this.options.ownerName,
+      }));
+
+      console.log('foo')
+
+      this.listingCardViews.forEach(vw => vw.remove());
+      this.listingCardViews = [];
+      this.$el.empty();
+      // Render only the first 8 cards maximum
+      this.renderListingCards(this.collection.first(8));
+    });
+
+    return this;
+  }
+  */
+}

--- a/js/views/modals/listingDetail/MoreListings.js
+++ b/js/views/modals/listingDetail/MoreListings.js
@@ -46,6 +46,7 @@ export default class extends BaseVw {
       vendor: this.options.vendor,
       onStore: true,
       ownerGuid: this.options.vendor.peerID,
+      listings: this.collection,
     };
 
     const card = this.createChild(ListingCard, options);

--- a/js/views/modals/listingDetail/MoreListings.js
+++ b/js/views/modals/listingDetail/MoreListings.js
@@ -48,7 +48,10 @@ export default class extends BaseVw {
       ownerGuid: this.options.vendor.peerID,
     };
 
-    return this.createChild(ListingCard, options);
+    const card = this.createChild(ListingCard, options);
+    this.listenTo(card, 'cardOpened', () => this.trigger('cardOpened'));
+
+    return card;
   }
 
   renderListingCards(models = []) {

--- a/js/views/userPage/ListingsGrid.js
+++ b/js/views/userPage/ListingsGrid.js
@@ -96,6 +96,7 @@ export default class extends BaseVw {
       viewType: this.viewType,
       model,
     };
+    console.log(model.toJSON())
 
     if (this.options.storeOwnerProfile) {
       options.profile = this.options.storeOwnerProfile;

--- a/js/views/userPage/ListingsGrid.js
+++ b/js/views/userPage/ListingsGrid.js
@@ -94,6 +94,7 @@ export default class extends BaseVw {
     const options = {
       listingBaseUrl,
       viewType: this.viewType,
+      listings: this.collection,
       model,
     };
 

--- a/js/views/userPage/ListingsGrid.js
+++ b/js/views/userPage/ListingsGrid.js
@@ -96,7 +96,6 @@ export default class extends BaseVw {
       viewType: this.viewType,
       model,
     };
-    console.log(model.toJSON())
 
     if (this.options.storeOwnerProfile) {
       options.profile = this.options.storeOwnerProfile;


### PR DESCRIPTION
This adds a more listings section to the bottom of each listings details modal. 

Clicking on a listing card in the more listings section will open a new modal and close the parent modal.

Up to 8 listing cards are shown. If none have loaded, or the user doesn't have other listings, the more listings section isn't shown.

Closes #344 