### PR TITLE
Fix UserCard Undefined Model

### DIFF
--- a/js/views/UserCard.js
+++ b/js/views/UserCard.js
@@ -258,7 +258,7 @@ export default class extends BaseVw {
       const createOptions = getModeratorOptions({
         model: verifiedMod,
       });
-      if (verifiedMod && this.model.isModerator) {
+      if (verifiedMod && this.model && this.model.isModerator) {
         this.verifiedMod = this.createChild(VerifiedMod, {
           ...createOptions,
           initialState: {


### PR DESCRIPTION
Fixes an issue where isModerator should only be checked if the model is available, since usercards render once before the model has loaded sometimes (to show the placeholder).