### PR TITLE
Hide Unused Crypto Select in Edit

### DIFF
--- a/styles/modules/modals/_editListing.scss
+++ b/styles/modules/modals/_editListing.scss
@@ -331,7 +331,7 @@
 
   .cryptoTypeWrap {
     display: none;
-  }  
+  }
 
   &.TYPE_PHYSICAL_GOOD {
     .tab-shipping,
@@ -362,6 +362,10 @@
       .skuMatureContentRow {
         display: none;
       }
+
+      .acceptedCurrenciesSection {
+        display: none;
+      }
     }
   }
 
@@ -372,6 +376,6 @@
   &.editMode {
     .viewListingLinks {
       display: block;
-    }    
+    }
   }
 }


### PR DESCRIPTION
When the edit listing has a type of crypto currency, the crypto currency selector isn't needed, this will hide it.