### PR TITLE
De-duplicate active currencies.

### DIFF
--- a/js/views/components/CryptoCurSelector.js
+++ b/js/views/components/CryptoCurSelector.js
@@ -99,8 +99,8 @@ export default class extends baseVw {
 
     // Remove any disabled currencies from the active list.
     if (state.activeCurs || state.disabledCurs) {
-      processedState.activeCurs = processedState.activeCurs
-        .filter(c => !processedState.disabledCurs.includes(c));
+      processedState.activeCurs = [...new Set(processedState.activeCurs
+        .filter(c => !processedState.disabledCurs.includes(c)))];
     }
 
     // Radio controls can only have one active currency.


### PR DESCRIPTION
Minor tweak to de-duplicate active currencies in the crypto currency selector.

This doesn't remove the need for the server to fix the bug that allows duplicate copies of currencies to be saved, but I think it's beneficial if the control makes sure it's own data is correct regardless of where it comes from.