### PR TITLE
Fix Missing Shipping In Receipt

### DIFF
--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -142,7 +142,7 @@ export default class extends BaseModal {
       });
       this.listenTo(this.shipping, 'shippingOptionSelected', () => this.updateShippingOption());
       // set the initial shipping option
-      this.updateShippingOption(this.shipping.selectedOption);
+      this.updateShippingOption();
       this.refreshPrices();
     }
 

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -143,6 +143,7 @@ export default class extends BaseModal {
       this.listenTo(this.shipping, 'shippingOptionSelected', () => this.updateShippingOption());
       // set the initial shipping option
       this.updateShippingOption(this.shipping.selectedOption);
+      this.refreshPrices();
     }
 
     this.complete = this.createChild(Complete, {


### PR DESCRIPTION
When the purchase view is constructed, the shipping price in the receipt is not updated until it is changed, due to it being triggered by a listener on the model which isn't applied until after the initial shipping price is set.

When the initial state of the view had a valid shipping option selected by default this caused the shipping price in the receipt to show as zero, even though it was correct in the purchase model.

This fixes the issue by refreshing the receipt prices after the shipping view is created.