### PR TITLE
removing jsdom-global and adding the --exit flag to mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "cross-env NODE_ENV=development npm-run-all sass:build process-index --parallel sass:watch index:watch browsersync start-app",
     "start-app": "cross-env NODE_ENV=development electron .",
-    "test": "mocha --compilers js:babel-core/register --recursive",
+    "test": "mocha --compilers js:babel-core/register --recursive --exit",
     "test:watch": "npm run test -- --watch",
     "lint": "eslint .",
     "lint:watch": "nodemon -e js -x \"npm run lint\"",

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import { before, after } from 'mocha';
 import sinon from 'sinon';
+import { JSDOM } from 'jsdom';
 import app from '../js/app';
 
 const tmpFolderPath = path.join(__dirname, '../.tmp');
@@ -11,8 +12,12 @@ if (!fs.existsSync(tmpFolderPath)) {
 }
 
 const indexPage = fs.readFileSync(`${__dirname}/../index.html`);
-global.jsdom = require('jsdom-global')(indexPage);
-global.$ = require('jquery')(document.defaultView);
+const dom = new JSDOM(indexPage);
+
+global.document = dom.window.document;
+global.window = dom.window;
+global.navigator = window.navigator;
+global.$ = require('jquery')(window);
 
 let getServerUrl;
 
@@ -27,5 +32,4 @@ before(function () {
 
 after(function () {
   getServerUrl.restore();
-  global.jsdom();
 });


### PR DESCRIPTION
A couple tweaks to #1592:

1.)

```
the newest version of js-dom no longer supports putting the window, etc. in the global scope like we were doing
```

That's not true. It looks like it considers it an anti-pattern, but doesn't block it. And, if we're going to use a whole other lib to implement the anti-pattern, I think we might as well use the anti-pattern in the original lib. Which is what I did.

2.) I also added the `--exit` flag to the `mocha` command, otherwise the test process was hanging for me. It looks like the newer version of mocha doesn't force exit like the old version did.

```
If the mocha process is still alive after your tests seem "done", then your tests have scheduled something to happen (asynchronously) and haven't cleaned up after themselves properly. Did you leave a socket open?

Supply the --exit flag to use pre-v4 behavior.
```

It's possible we are missing some clean-up somewhere... but it didn't seem to be a problem in the old version. Anyhow, I think a missed cleanup would probably be a lesser evil than the process hanging, since a hanging process would limit programatic use of it.

