### PR TITLE
not assuming the exchange rate ref cur is btc

### DIFF
--- a/js/start.js
+++ b/js/start.js
@@ -1,9 +1,3 @@
-// TODO
-// TODizzle
-// TODO
-// TODO
-// TODO Confirm if any hard-coded ZEC related code is neeeded anymore.
-
 import { remote, ipcRenderer } from 'electron';
 import $ from 'jquery';
 import Backbone from 'backbone';


### PR DESCRIPTION
This PR updates the url used to fetch the exchange rate so it doesn't assume BTC, since BTC may not be supported on the node. Instead, it will try to use BTC if it is supported, otherwise it will use the first supported currency in the list.