### PR TITLE
Enhance error reporting

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -2082,6 +2082,7 @@
   },
   "purchaseItemModelErrors": {
     "provideQuantity": "Please provide a quantity.",
+    "provideCryptoQuantity": "Please provide the amount of this currency you wish to purchase.",
     "mustHaveQuantity": "The quantity must be 1 or more",
     "quantityMustBeInteger": "The quantity must be a valid non-decimal number.",
     "quantityMustBeNumeric": "The quantity must be numeric.",

--- a/js/models/purchase/Item.js
+++ b/js/models/purchase/Item.js
@@ -53,7 +53,8 @@ export default class extends BaseModel {
     };
 
     if (attrs.quantity === undefined) {
-      addError('quantity', app.polyglot.t('purchaseItemModelErrors.provideQuantity'));
+      const isCrypto = this.isCrypto ? 'Crypto' : '';
+      addError('quantity', app.polyglot.t(`purchaseItemModelErrors.provide${isCrypto}Quantity`));
     }
 
     if (!this.isCrypto) {

--- a/js/models/purchase/Order.js
+++ b/js/models/purchase/Order.js
@@ -6,7 +6,7 @@ import { isSupportedWalletCur } from '../../data/walletCurrencies';
 export default class extends BaseModel {
   constructor(attrs, options = {}) {
     super(attrs, options);
-    this.shippable = options.shippable || false;
+    this.shippable = options.shippable;
   }
 
   defaults() {
@@ -64,11 +64,8 @@ export default class extends BaseModel {
     }
 
     if (this.shippable) {
-      if (!attrs.shipTo || typeof attrs.shipTo !== 'string') {
-        addError('shipping', app.polyglot.t('orderModelErrors.missingAddress'));
-      }
-
-      if (!attrs.countryCode || typeof attrs.countryCode !== 'string') {
+      if (!attrs.shipTo || typeof attrs.shipTo !== 'string' ||
+        !attrs.countryCode || typeof attrs.countryCode !== 'string') {
         addError('shipping', app.polyglot.t('orderModelErrors.missingAddress'));
       }
     }

--- a/js/start.js
+++ b/js/start.js
@@ -551,17 +551,22 @@ function start() {
 
           localStorage.serverIdAtLastStart = curConn && curConn.server && curConn.server.id;
 
-          const metricsOn = app.localSettings.get('shareMetrics');
+          // Metrics should only be run on bundled apps.
+          if (remote.getGlobal('isBundledApp')) {
+            const metricsOn = app.localSettings.get('shareMetrics');
 
-          if (metricsOn === undefined || metricsOn && isNewerVersion()) {
-            showMetricsModal({
-              showCloseButton: false,
-              dismissOnEscPress: false,
-              showUndecided: true,
-            })
-              .on('close', () => Backbone.history.start());
+            if (metricsOn === undefined || metricsOn && isNewerVersion()) {
+              showMetricsModal({
+                showCloseButton: false,
+                dismissOnEscPress: false,
+                showUndecided: true,
+              })
+                .on('close', () => Backbone.history.start());
+            } else {
+              if (metricsOn) addMetrics();
+              Backbone.history.start();
+            }
           } else {
-            if (metricsOn) addMetrics();
             Backbone.history.start();
           }
 

--- a/js/templates/modals/settings/advanced/advanced.html
+++ b/js/templates/modals/settings/advanced/advanced.html
@@ -245,25 +245,27 @@
       </div>
     </div>
   </div>
-  <div class="contentBox padMd clrP clrBr clrSh3">
-    <h2 class="h4 clrT"><%= ob.polyT('settings.advancedTab.integrations.sectionName') %></h2>
-    <hr class="clrBr" />
-    <div class="tabFormWrapper clrS">
-      <div class="">
-        <form class="box padMdKids padStack clrP clrBr">
-          <div class="flexRow gutterH">
-            <div class="col3">
-              <label>
-                <%= ob.polyT('settings.advancedTab.integrations.sharing') %>
-              </label>
-              <div class="clrT2 txSm"><%= ob.polyT('settings.advancedTab.integrations.sharingHelper') %></div>
+  <% if (ob.bundled) { %>
+    <div class="contentBox padMd clrP clrBr clrSh3">
+      <h2 class="h4 clrT"><%= ob.polyT('settings.advancedTab.integrations.sectionName') %></h2>
+      <hr class="clrBr" />
+      <div class="tabFormWrapper clrS">
+        <div class="">
+          <form class="box padMdKids padStack clrP clrBr">
+            <div class="flexRow gutterH">
+              <div class="col3">
+                <label>
+                  <%= ob.polyT('settings.advancedTab.integrations.sharing') %>
+                </label>
+                <div class="clrT2 txSm"><%= ob.polyT('settings.advancedTab.integrations.sharingHelper') %></div>
+              </div>
+              <div class="col9 js-metricsStatusWrapper"></div>
             </div>
-            <div class="col9 js-metricsStatusWrapper"></div>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
     </div>
-  </div>
+  <% } %>
   <div class="contentBox js-contentBoxEmailIntegration padMd clrP clrBr clrSh3">
     <h2 class="h4 clrT"><%= ob.polyT('settings.advancedTab.smtp.sectionName') %></h2>
     <hr class="clrBr" />

--- a/js/views/modals/Settings/advanced/Advanced.js
+++ b/js/views/modals/Settings/advanced/Advanced.js
@@ -1,4 +1,4 @@
-import { clipboard } from 'electron';
+import { clipboard, remote } from 'electron';
 import $ from 'jquery';
 import app from '../../../../app';
 import { openSimpleMessage } from '../../SimpleMessage';
@@ -244,6 +244,7 @@ export default class extends baseVw {
 
   render() {
     super.render();
+    const bundled = remote.getGlobal('isBundledApp');
     loadTemplate('modals/settings/advanced/advanced.html', (t) => {
       this.$el.html(t({
         errors: {
@@ -252,6 +253,7 @@ export default class extends baseVw {
         },
         isPurging: this.purge && this.purge.state() === 'pending',
         isGettingBlockData: this.blockData && this.blockData.state() === 'pending',
+        bundled,
         ...this.settings.toJSON(),
         ...this.localSettings.toJSON(),
       }));
@@ -282,8 +284,10 @@ export default class extends baseVw {
       this.getCachedEl('.js-smtpSettingsContainer').html(this.smtpSettings.render().el);
 
       if (this.metricsStatus) this.metricsStatus.remove();
-      this.metricsStatus = this.createChild(MetricsStatus);
-      this.getCachedEl('.js-metricsStatusWrapper').append(this.metricsStatus.render().el);
+      if (bundled) {
+        this.metricsStatus = this.createChild(MetricsStatus);
+        this.getCachedEl('.js-metricsStatusWrapper').append(this.metricsStatus.render().el);
+      }
     });
 
     return this;

--- a/js/views/search/Results.js
+++ b/js/views/search/Results.js
@@ -56,6 +56,7 @@ export default class extends baseVw {
       const options = {
         listingBaseUrl: `${base}/store/`,
         reportsUrl: this.reportsUrl,
+        searchUrl: this.searchUrl,
         model,
         vendor,
         onStore: false,


### PR DESCRIPTION
This does a few things:
1. Does not collect metrics unless the user is using a bundled app, that way we are less likely to pollute the metrics when testing. We'll lose a few users that are installing from source, which is fine.

The metrics controls are hidden if the user is running from source.

2. Improves some errors in purchasing.

3. Adds more metrics around listing loading and purchasing, so we can better diagnose any issues we see.

4. Changes the collection of errors in purchasing to client-side errors are all considered different segments. This is a bit of a kludge, but better than concatenating errors into the errors segment. Concatenating made it difficult to tell how many times an error was happening, since you might have 40 records of "error1" and 23 records of "error1, error2" and 9 records of "error1, error5, error 12", all as different values of the same segment.

This makes it so each category of client-side error concatenates the errors in it, so UserError-shipping is a single segment (for example).

5. Removes the details of the listing that failed to load from the "no link named" server errors. It's not ideal to need to have to manipulate the data, but what we want with that error is how many times it happened, not dozens of individual errors with different names.