### PR TITLE
Add a Copy Contract Link

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -1596,8 +1596,6 @@
       "contract": "Contract (JSON)"
     },
     "backToSummary": "Back to summary",
-    "copyContract": "Copy Contract",
-    "copyContractDone": "Copied",
     "discussionTab": {
       "roleVendor": "vendor",
       "roleBuyer": "buyer",
@@ -1623,7 +1621,9 @@
       "buyerContractNotArrived": "The buyer's contract has not yet arrived. It will be sent over the next time they come online.",
       "vendorContractNotArrivedPotentialProcErr": "The vendor's contract has not yet arrived. The buyer's contract indicates the vendor had a processing error, but this cannot be validated because the buyer's contract has validation errors. Please contact the vendor to confirm.",
       "contractHeadingVendor": "Vendor's contract:",
-      "contractHeadingBuyer": "Buyer's contract:"
+      "contractHeadingBuyer": "Buyer's contract:",
+      "copyContract": "Copy Contract",
+      "copyContractDone": "Copied"
     },
     "contractMenuItem": {
       "tipBothContractsHaveError": "Both the buyer and vendor contracts have validation errors.",

--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -1596,6 +1596,8 @@
       "contract": "Contract (JSON)"
     },
     "backToSummary": "Back to summary",
+    "copyContract": "Copy Contract",
+    "copyContractDone": "Copied",
     "discussionTab": {
       "roleVendor": "vendor",
       "roleBuyer": "buyer",

--- a/js/templates/modals/orderDetail/contractTab/contract.html
+++ b/js/templates/modals/orderDetail/contractTab/contract.html
@@ -19,8 +19,8 @@
 
 <div class="flexHRight">
   <div class="posR">
-    <a class="js-copyContract clrTEm"><%= ob.polyT(`orderDetail.copyContract`) %></a>
-    <a class="copied js-copyContractDone clrT2"><%= ob.polyT(`orderDetail.copyContractDone`) %></a>
+    <a class="js-copyContract clrTEm"><%= ob.polyT(`orderDetail.contractTab.copyContract`) %></a>
+    <a class="copied js-copyContractDone clrT2"><%= ob.polyT(`orderDetail.contractTab.copyContractDone`) %></a>
   </div>
 </div>
 

--- a/js/templates/modals/orderDetail/contractTab/contract.html
+++ b/js/templates/modals/orderDetail/contractTab/contract.html
@@ -16,3 +16,11 @@
 <% } %>
 
 <div class="border clrBr clrP clrT rowLg js-jsonContractContainer"></div>
+
+<div class="flexHRight">
+  <div class="posR">
+    <a class="js-copyContract clrTEm"><%= ob.polyT(`orderDetail.copyContract`) %></a>
+    <a class="copied js-copyContractDone clrT2"><%= ob.polyT(`orderDetail.copyContractDone`) %></a>
+  </div>
+</div>
+

--- a/js/views/modals/orderDetail/contractTab/Contract.js
+++ b/js/views/modals/orderDetail/contractTab/Contract.js
@@ -1,5 +1,8 @@
+import $ from 'jquery';
+import { clipboard } from 'electron';
 import renderjson from '../../../../lib/renderjson';
 import BaseVw from '../../../baseVw';
+import '../../../../utils/lib/velocity';
 import loadTemplate from '../../../../utils/loadTemplate';
 
 export default class extends BaseVw {
@@ -25,6 +28,31 @@ export default class extends BaseVw {
 
   tagName() {
     return 'section';
+  }
+
+  events() {
+    return {
+      'click .js-copyContract': 'onClickCopyContract',
+    };
+  }
+
+  onClickCopyContract() {
+    clipboard.writeText(JSON.stringify(this.contract));
+    // Fade the link and make it unclickable, but maintain its position in the DOM.
+    this.getCachedEl('.js-copyContract')
+      .addClass('unclickable')
+      .velocity('stop')
+      .velocity({ opacity: 0 })
+      .velocity({ opacity: 1 }, {
+        delay: 5000,
+        complete: (els) => {
+          $(els[0]).removeClass('unclickable');
+        },
+      });
+    this.getCachedEl('.js-copyContractDone')
+      .velocity('stop')
+      .velocity({ opacity: 1 })
+      .velocity({ opacity: 0 }, { delay: 5000 });
   }
 
   render() {

--- a/js/views/modals/orderDetail/contractTab/Contract.js
+++ b/js/views/modals/orderDetail/contractTab/Contract.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 import { clipboard } from 'electron';
 import renderjson from '../../../../lib/renderjson';
-import BaseVw from '../../../baseVw';
 import '../../../../utils/lib/velocity';
 import loadTemplate from '../../../../utils/loadTemplate';
+import BaseVw from '../../../baseVw';
 
 export default class extends BaseVw {
   constructor(options = {}) {
@@ -56,6 +56,8 @@ export default class extends BaseVw {
   }
 
   render() {
+    super.render();
+
     let renderjsonEl;
 
     if (this.rendered) {

--- a/styles/modules/modals/_orderDetail.scss
+++ b/styles/modules/modals/_orderDetail.scss
@@ -232,6 +232,14 @@
         font-weight: bold;
       }
     }
+
+    .copied {
+      position: absolute;
+      top: 0;
+      left: 0;
+      opacity: 0;
+      pointer-events: none;
+    }
   }
 
   .summaryTab {
@@ -330,7 +338,7 @@
 
           &::before {
             padding-top: 4px;
-          }          
+          }
         }
       }
     }


### PR DESCRIPTION
This adds a copy link to the contract in the order details.

@morebrownies I used the same style we use everywhere else for copying things, and put it below the contract. This seemed simple and obvious enough we didn't need a design for it, but we can change it if you have any suggestions.

Closes #1545

![image](https://user-images.githubusercontent.com/1584275/48727303-d9ea5100-ebff-11e8-92e3-18e869329f66.png)
