### PR TITLE
More resilience

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -1031,8 +1031,8 @@
     "goToStore": "Go to store",
     "unableToPurchase": {
       "incompatibleCrypto": "Your wallet does not support payment in any of the currencies the listing accepts. The listing accepts %{acceptedCurs}, whereas your wallet supports %{walletCurs}.",
-      "unrecognizedCur": "The item is priced in an unrecognized currency.",
-      "noExchangeRateInfo": "The item is priced in a currency for which exchange rate data is currently unavailable.",
+      "unrecognizedCur": "The item is priced in an unrecognized currency (%{cur}).",
+      "noExchangeRateInfo": "The item is priced in a currency for which exchange rate data is currently unavailable (%{cur}).",
       "unpurchaseable": "This listing is not purchasable."
     },
     "confirmDelete": {

--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -127,16 +127,12 @@
                   ob.crypto.anySupportedByWallet([priceCryptoCode.code, priceCryptoCode.testnetCode])
                 ) &&
                 ob.currencyMod.getCurrencyValidity(ob.price.currencyCode) !== 'VALID') {
-                // Ensure we have exchange rate data based on the currency the listing is listed
-                // in. Otherwise, it is not purchaseable since the price cannot be determined.
-                // If the listing price code is one of the accepted currencies AND the user pays in
-                // that currency, then exchange rate data is not needed.
-                // TODO:
-                // TODO:
-                // TODO: ugh - how to handle that case?
                 tip = ob.currencyValidity === 'UNRECOGNIZED_CURRENCY' ?
-                   ob.polyT('listingDetail.unableToPurchase.unrecognizedCur') :
-                  ob.polyT('listingDetail.unableToPurchase.noExchangeRateInfo');
+                   ob.polyT('listingDetail.unableToPurchase.unrecognizedCur',
+                    { cur: ob.price.currencyCode }) :
+                  ob.polyT('listingDetail.unableToPurchase.noExchangeRateInfo', {
+                    cur: ob.price.currencyCode
+                  });
               } else if (ob.metadata.contractType === 'CRYPTOCURRENCY' &&
                 !ob.currencyMod.getExchangeRate(ob.price.currencyCode)) {
                 tip = ob.polyT('listingDetail.unableToPurchase.noExchangeRateInfo');

--- a/js/utils/crypto.js
+++ b/js/utils/crypto.js
@@ -15,11 +15,11 @@ export function renderCryptoIcon(options = {}) {
   }
 
   const opts = {
-    code: ensureMainnetCode(options.code),
     className: '',
     attrs: {},
     defaultIcon: `${baseIconPath}default-coin-icon.png`,
     ...options,
+    code: ensureMainnetCode(options.code),
   };
 
   const attrs = Object.keys(opts.attrs).reduce(

--- a/js/utils/currency.js
+++ b/js/utils/currency.js
@@ -49,31 +49,38 @@ UnrecognizedCurrencyError.prototype.constructor = UnrecognizedCurrencyError;
  * it will convert to its base units.
  */
 export function decimalToInteger(amount, currency, options = {}) {
-  if (typeof amount !== 'number') {
-    throw new Error('Please provide an amount as a number.');
-  }
-
-  if (typeof currency !== 'string') {
-    throw new Error('Please provide a currency as a string.');
-  }
-
   const opts = {
     returnUndefinedOnError: true,
     ...options,
   };
 
-  const curData = getCurrencyByCode(currency);
   let returnVal;
 
-  if (!curData) {
-    if (!opts.returnUndefinedOnError) {
-      throw new UnrecognizedCurrencyError(`${currency} is not a recognized currency.`);
+  try {
+    if (typeof amount !== 'number') {
+      throw new Error('Please provide an amount as a number.');
     }
-  } else {
-    if (getWalletCurByCode(currency)) {
-      returnVal = Math.round(amount * curData.baseUnit);
+
+    if (typeof currency !== 'string') {
+      throw new Error('Please provide a currency as a string.');
+    }
+
+    const curData = getCurrencyByCode(currency);
+
+    if (!curData) {
+      if (!opts.returnUndefinedOnError) {
+        throw new UnrecognizedCurrencyError(`${currency} is not a recognized currency.`);
+      }
     } else {
-      returnVal = Math.round(amount * 100);
+      if (getWalletCurByCode(currency)) {
+        returnVal = Math.round(amount * curData.baseUnit);
+      } else {
+        returnVal = Math.round(amount * 100);
+      }
+    }
+  } catch (e) {
+    if (!opts.returnUndefinedOnError) {
+      throw e;
     }
   }
 
@@ -90,18 +97,33 @@ export function integerToDecimal(amount, currency, options = {}) {
     ...options,
   };
 
-  const curData = getCurrencyByCode(currency);
   let returnVal;
 
-  if (!curData) {
-    if (!opts.returnUndefinedOnError) {
-      throw new UnrecognizedCurrencyError(`${currency} is not a recognized currency.`);
+  try {
+    if (typeof amount !== 'number') {
+      throw new Error('Please provide an amount as a number.');
     }
-  } else {
-    if (getWalletCurByCode(currency)) {
-      returnVal = Number(amount / curData.baseUnit);
+
+    if (typeof currency !== 'string') {
+      throw new Error('Please provide a currency as a string.');
+    }
+
+    const curData = getCurrencyByCode(currency);
+
+    if (!curData) {
+      if (!opts.returnUndefinedOnError) {
+        throw new UnrecognizedCurrencyError(`${currency} is not a recognized currency.`);
+      }
     } else {
-      returnVal = Number(amount / 100);
+      if (getWalletCurByCode(currency)) {
+        returnVal = Number(amount / curData.baseUnit);
+      } else {
+        returnVal = Number(amount / 100);
+      }
+    }
+  } catch (e) {
+    if (!opts.returnUndefinedOnError) {
+      throw e;
     }
   }
 

--- a/js/utils/index.js
+++ b/js/utils/index.js
@@ -57,6 +57,10 @@ export function splitIntoRows(items, itemsPerRow) {
 // todo: move to the number util mod...?
 // http://stackoverflow.com/a/2686098/632806
 export function abbrNum(_number, _maxDecPlaces = 1) {
+  if (typeof _number !== 'number' || isNaN(_number)) {
+    return '';
+  }
+
   // 2 decimal places => 100, 3 => 1000, etc
   const decPlaces = Math.pow(10, _maxDecPlaces);
   const isNegative = _number < 0;

--- a/js/utils/number.js
+++ b/js/utils/number.js
@@ -6,9 +6,9 @@ import app from '../app';
  * scientific notation for small numbers, e.g. 0.00000001 => 1E-8).
  */
 export function toStandardNotation(number, options) {
-  if (typeof number !== 'number') {
-    throw new Error('Please provide a number.');
-  }
+  // if (typeof number !== 'number') {
+  //   throw new Error('Please provide a number.');
+  // }
 
   const opts = {
     minDisplayDecimals: 0,

--- a/js/utils/number.js
+++ b/js/utils/number.js
@@ -6,9 +6,9 @@ import app from '../app';
  * scientific notation for small numbers, e.g. 0.00000001 => 1E-8).
  */
 export function toStandardNotation(number, options) {
-  // if (typeof number !== 'number') {
-  //   throw new Error('Please provide a number.');
-  // }
+  if (typeof number !== 'number') {
+    throw new Error('Please provide a number.');
+  }
 
   const opts = {
     minDisplayDecimals: 0,

--- a/styles/modules/modals/_orderDetail.scss
+++ b/styles/modules/modals/_orderDetail.scss
@@ -236,7 +236,7 @@
     .copied {
       position: absolute;
       top: 0;
-      left: 0;
+      right: 0;
       opacity: 0;
       pointer-events: none;
     }


### PR DESCRIPTION
Various tweaks:

- updated decimalToInteger and integerToDecimal to optionally return undefined on bad data. This way templates will render a blank value rather bombing.
- fixed an issue in renderCryptoIcon that was preventing crypto icons from rendering properly in testnet.
- Added the currency code to certain error messages when a purchase is blocked.
- Right-aligned the `Copied` text after clicking the Copy link on the Contract tab of Order Details. IMHO, it looked odd to have it left-aligned and just kind of hanging out in the middle of line - this was extra pronounced on long translations.
- adjusted abbrNum to return an empty string on bad data, which would be in liu of `NaN` being returned.

closes #1553 
closes #1450