### PR TITLE
adjusting an error msg to handle an empty variable better

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -1030,7 +1030,7 @@
     "returnToStore": "Return to store",
     "goToStore": "Go to store",
     "unableToPurchase": {
-      "incompatibleCrypto": "Your wallet does not support payment in any of the currencies the listing accepts. The listing accepts %{acceptedCurs}, whereas your wallet supports %{walletCurs}.",
+      "incompatibleCrypto": "Your wallet does not support payment in any of the currencies the listing accepts. The listing accepts [%{acceptedCurs}], whereas your wallet supports [%{walletCurs}].",
       "unrecognizedCur": "The item is priced in an unrecognized currency (%{cur}).",
       "noExchangeRateInfo": "The item is priced in a currency for which exchange rate data is currently unavailable (%{cur}).",
       "unpurchaseable": "This listing is not purchasable."


### PR DESCRIPTION
Minor tweak to make an error message better reflect an empty list passed into it. Want to avoid this:

![image](https://user-images.githubusercontent.com/794517/48809121-f57d5680-ece8-11e8-857a-ba577a52239f.png)


