### PR TITLE
CSS Fix and No Auto Radio Select

### DIFF
--- a/js/templates/components/cryptoCurSelector.html
+++ b/js/templates/components/cryptoCurSelector.html
@@ -1,6 +1,6 @@
 <% ob.processedCurs.forEach(cur => { %>
   <li class="clrBr curRow">
-    <label class="gutterHSm <% if (cur.disabled) print('disabled') %>" for="<%=`curSel${cur.code}${ob.cid}` %>">
+    <label class="gutterHSm <% if (cur.disabled) print('disabled') %>">
       <input type="<%= ob.controlType %>"
              id="<%=`curSel${cur.code}${ob.cid}` %>"
              class="centerLabel js-curControl"
@@ -9,8 +9,10 @@
       name="currencies"
       <%} %>
       <% if (cur.active && !cur.disabled) print('checked') %>>
-      <%= ob.crypto.cryptoIcon({ code: cur.code }) %>
-      <span class="curName noOverflow"><%= cur.displayName %></span>
+      <label for="<%=`curSel${cur.code}${ob.cid}` %>">
+        <%= ob.crypto.cryptoIcon({ code: cur.code }) %>
+        <span class="curName noOverflow"><%= cur.displayName %></span>
+      </label>
     </label>
     <% if (cur.disabled && ob.disabledMsg) { %>
     <span class="disabledMsg noOverflow clrTErr tx5b"><%= ob.disabledMsg %></span>

--- a/js/templates/components/cryptoCurSelector.html
+++ b/js/templates/components/cryptoCurSelector.html
@@ -1,10 +1,9 @@
 <% ob.processedCurs.forEach(cur => { %>
   <li class="clrBr curRow">
-    <label class="gutterHSm <% if (cur.disabled) print('disabled') %>">
+    <span class="curControlWrapper js-curControl gutterHSm <% if (cur.disabled) print('disabled') %>" data-code="<%= cur.code %>">
       <input type="<%= ob.controlType %>"
              id="<%=`curSel${cur.code}${ob.cid}` %>"
-             class="centerLabel js-curControl"
-             data-code="<%= cur.code %>"
+             class="centerLabel"
       <% if (ob.controlType === 'radio') {%>
         name="currencies"
       <%} %>
@@ -13,7 +12,7 @@
         <%= ob.crypto.cryptoIcon({ code: cur.code }) %>
         <span class="curName noOverflow"><%= cur.displayName %></span>
       </label>
-    </label>
+    </span>
     <% if (cur.disabled && ob.disabledMsg) { %>
       <span class="disabledMsg noOverflow clrTErr tx5b"><%= ob.disabledMsg %></span>
     <% }%>

--- a/js/templates/components/cryptoCurSelector.html
+++ b/js/templates/components/cryptoCurSelector.html
@@ -6,7 +6,7 @@
              class="centerLabel js-curControl"
              data-code="<%= cur.code %>"
       <% if (ob.controlType === 'radio') {%>
-      name="currencies"
+        name="currencies"
       <%} %>
       <% if (cur.active && !cur.disabled) print('checked') %>>
       <label for="<%=`curSel${cur.code}${ob.cid}` %>">
@@ -15,7 +15,7 @@
       </label>
     </label>
     <% if (cur.disabled && ob.disabledMsg) { %>
-    <span class="disabledMsg noOverflow clrTErr tx5b"><%= ob.disabledMsg %></span>
+      <span class="disabledMsg noOverflow clrTErr tx5b"><%= ob.disabledMsg %></span>
     <% }%>
   </li>
 <% }) %>

--- a/js/views/components/CryptoCurSelector.js
+++ b/js/views/components/CryptoCurSelector.js
@@ -99,18 +99,18 @@ export default class extends baseVw {
         [...new Set(state.currencies)] : curState.currencies,
     };
 
-    // Remove any disabled currencies from the active list.
+    // Radio controls must have no more than one active currency. If the list passed in is not
+    // already alphabetized, it's possible the alphabetization will change the order.
+    if (processedState.controlType === 'radio') {
+      processedState.activeCurs = processedState.activeCurs && processedState.activeCurs.length ?
+        [processedState.activeCurs[0]] : [];
+    }
+
+    // Remove any disabled currencies from the active list. It's possible for a radio control to
+    // have the first active cur disabled, in which case none will be selected, which is ok.
     if (state.activeCurs || state.disabledCurs) {
       processedState.activeCurs = [...new Set(processedState.activeCurs
         .filter(c => !processedState.disabledCurs.includes(c)))];
-    }
-
-    // Radio controls must have exactly one active currency.
-    // TODO: If no active currency is passed in, the one set here may not be the first one after
-    // they are alphabetized. Move the logic to the sort?
-    if (processedState.controlType === 'radio') {
-      processedState.activeCurs = processedState.activeCurs && processedState.activeCurs.length ?
-        [processedState.activeCurs[0]] : [processedState.currencies[0]];
     }
 
     // If necessary, create the processed curs

--- a/js/views/components/CryptoCurSelector.js
+++ b/js/views/components/CryptoCurSelector.js
@@ -105,8 +105,7 @@ export default class extends baseVw {
         [processedState.activeCurs[0]] : [];
     }
 
-    // Remove any disabled currencies from the active list. It's possible for a radio control to
-    // have the first active cur disabled, in which case none will be selected, which is ok.
+    // Remove any disabled currencies from the active list.
     if (state.activeCurs || state.disabledCurs) {
       processedState.activeCurs = [...new Set(processedState.activeCurs
         .filter(c => !processedState.disabledCurs.includes(c)))];

--- a/js/views/components/CryptoCurSelector.js
+++ b/js/views/components/CryptoCurSelector.js
@@ -99,8 +99,7 @@ export default class extends baseVw {
         [...new Set(state.currencies)] : curState.currencies,
     };
 
-    // Radio controls must have no more than one active currency. If the list passed in is not
-    // already alphabetized, it's possible the alphabetization will change the order.
+    // Radio controls must have no more than one active currency.
     if (processedState.controlType === 'radio') {
       processedState.activeCurs = processedState.activeCurs && processedState.activeCurs.length ?
         [processedState.activeCurs[0]] : [];

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -129,7 +129,6 @@ export default class extends BaseModal {
       initialState: {
         controlType: 'radio',
         currencies,
-        activeCurs: [currencies[0]],
         disabledCurs,
         sort: false,
       },

--- a/styles/components/_cryptoCurSelector.scss
+++ b/styles/components/_cryptoCurSelector.scss
@@ -3,19 +3,24 @@
     display: flex;
     align-items: center;
     font-size: 1.5rem;
+    padding-right: 14px;
 
-    label {
-      line-height: 42px; // Makes the entire row clickable.
+    & > label {
+      height: 42px;
       cursor: pointer;
       padding-left: 14px;
       display: flex;
       flex-grow: 1;
       align-items: center;
+    }
+
+    label {
       overflow: hidden;
     }
 
     input {
       cursor: pointer;
+      flex-shrink: 0;
     }
 
     input:checked + label {
@@ -30,7 +35,7 @@
     }
 
     input[type="radio"] {
-      margin-right: 0.6em;
+      margin: 0 0.6em 0 0;
 
       & + label {
         display: flex;
@@ -39,19 +44,22 @@
     }
 
     .cryptoIcon {
-      // add visual space for icons after the checkbox
+      // add visual space for icons
       margin-left: 0.2em;
+      margin-right: 0.5em;
+      // Center vertically
+      position: relative;
+      top: 0.05em;
     }
 
     .curName {
-      // Bump text down to center it visually. It looks off because it has
-      // ascenders but not decenders most of the time.
+      // Bump text down to center it visually.
       position: relative;
-      top: 0.09em;
+      top: 0.1em;
+      margin-right: 2em;
     }
 
     .disabledMsg {
-      padding-right: 14px;
       pointer-events: none;
     }
   }

--- a/styles/components/_cryptoCurSelector.scss
+++ b/styles/components/_cryptoCurSelector.scss
@@ -3,24 +3,26 @@
     display: flex;
     align-items: center;
     font-size: 1.5rem;
-    padding-right: 14px;
 
-    & > label {
+    .curControlWrapper {
       height: 42px;
       cursor: pointer;
-      padding-left: 14px;
+      padding: 0 14px;
       display: flex;
       flex-grow: 1;
       align-items: center;
+      overflow: hidden;
     }
 
     label {
       overflow: hidden;
+      pointer-events: none; // The label is for display only, the wrapper takes the click event.
     }
 
     input {
       cursor: pointer;
       flex-shrink: 0;
+      pointer-events: none; // The input is for display only, the wrapper takes the click event.
     }
 
     input:checked + label {
@@ -50,6 +52,7 @@
       // Center vertically
       position: relative;
       top: 0.05em;
+      flex-shrink: 0;
     }
 
     .curName {
@@ -61,6 +64,7 @@
 
     .disabledMsg {
       pointer-events: none;
+      padding-right: 14px;
     }
   }
 }


### PR DESCRIPTION
This PR fixes some issues with the currency selector CSS and HTML (like no checkbox appearing), and removes the logic to always select at least one active currency if the control is set to radio behavior.

The purchase view will no longer set an active currency, requiring the user to pick one. If they don't, they'll get an error if they try to move past that screen.