### PR TITLE
Add missing parenthesis

### DIFF
--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -560,7 +560,7 @@ export default class extends BaseVw {
           const fundedHeight = this.model.fundedBlockHeight;
           const blocksPerTimeout = (timeoutHours * 60 * 60 * 1000) / paymentCurData.blockTime;
           const blocksRemaining = fundedHeight ?
-            blocksPerTimeout - curHeight - fundedHeight :
+            blocksPerTimeout - (curHeight - fundedHeight) :
             blocksPerTimeout;
           const msRemaining = blocksRemaining * paymentCurData.blockTime;
 


### PR DESCRIPTION
This fixes a problem that was causing the timeout button to appear too early.

Instead of subtracting the number of blocks that had passed since the purchase, the current and funded height were both being subtracted, so after only a short period the blocksRemaining was a negative number.