### PR TITLE
Fix Unsettable Moderation

### DIFF
--- a/js/templates/modals/settings/moderation.html
+++ b/js/templates/modals/settings/moderation.html
@@ -15,7 +15,7 @@
       <form class="box padMdKids padStack">
         <div class="flexRow gutterH">
           <div class="col3">
-            <label class="required"><%= ob.polyT('settings.moderationTab.moderationStatus') %></label>
+            <span class="required"><%= ob.polyT('settings.moderationTab.moderationStatus') %></span>
           </div>
           <div class="col9">
             <div class="btnStrip">


### PR DESCRIPTION
I'm a bit baffled by this one. 

In settings/moderation, if you set your node to be a moderator, save, then set it to not be a moderator any more, if you click the radio button to turn moderation back on, it barely flickers on then immediately sets the false radio button to checked.

Changing the label next to those buttons to a span element fixed it.

Weirdly, adding a label earlier in the page, even if it had no association with those radio buttons, also fixed it.

I can't find anything that changed that would have caused this, nor any reason having a label elsewhere on the page would affect that pair of radio buttons that way.