### PR TITLE
Fix Vertical Centering on Mod Message

### DIFF
--- a/styles/modules/_moderatorsList.scss
+++ b/styles/modules/_moderatorsList.scss
@@ -3,6 +3,7 @@
     display: table;
     table-layout: fixed;
     width: 100%;
+    height: 100%;
     min-height: 127px;
     border-width: 1px;
     border-style: solid;


### PR DESCRIPTION
This fixes the vertical centering on the purchase screen when the "show unverified moderators" message is visible.