### PR TITLE
updating getFormData in the baseVw to handle checkbox groups

### DIFF
--- a/js/views/baseVw.js
+++ b/js/views/baseVw.js
@@ -87,23 +87,22 @@ export default class baseVw extends View {
         }
       }
 
-      const name = $field.attr('name');
+      let name = $field.attr('name');
       const isCheckboxGroup = field.type === 'checkbox' &&
         name.endsWith('[]');
+      if (isCheckboxGroup) name = name.slice(0, name.length - 2);
 
       if (name.indexOf('.') !== -1) {
         let deepVal = val;
-        let deepName = name;
 
         if (isCheckboxGroup) {
           deepVal = this._getCheckboxGroupData($formFields.filter(`[name="${name}"]`));
-          deepName = name.slice(0, name.length - 2);
         } else if (field.type === 'checkbox') {
           deepVal = field.checked;
         }
 
         // handle nested model
-        setDeepValue(data, deepName, deepVal);
+        setDeepValue(data, name, deepVal);
       } else if (isCheckboxGroup) {
         data[name] = this._getCheckboxGroupData($formFields.filter(`[name="${name}"]`));
       } else if (field.type === 'checkbox') {

--- a/js/views/baseVw.js
+++ b/js/views/baseVw.js
@@ -87,24 +87,27 @@ export default class baseVw extends View {
         }
       }
 
-      let name = $field.attr('name');
+      const name = $field.attr('name');
       const isCheckboxGroup = field.type === 'checkbox' &&
         name.endsWith('[]');
-      if (isCheckboxGroup) name = name.slice(0, name.length - 2);
+      const checkboxGroupName = name.slice(0, name.length - 2);
 
       if (name.indexOf('.') !== -1) {
         let deepVal = val;
+        let deepName = name;
 
         if (isCheckboxGroup) {
           deepVal = this._getCheckboxGroupData($formFields.filter(`[name="${name}"]`));
+          deepName = checkboxGroupName;
         } else if (field.type === 'checkbox') {
           deepVal = field.checked;
         }
 
         // handle nested model
-        setDeepValue(data, name, deepVal);
+        setDeepValue(data, deepName, deepVal);
       } else if (isCheckboxGroup) {
-        data[name] = this._getCheckboxGroupData($formFields.filter(`[name="${name}"]`));
+        data[checkboxGroupName] =
+          this._getCheckboxGroupData($formFields.filter(`[name="${name}"]`));
       } else if (field.type === 'checkbox') {
         data[name] = field.checked;
       } else {

--- a/js/views/baseVw.js
+++ b/js/views/baseVw.js
@@ -13,6 +13,16 @@ export default class baseVw extends View {
     this.setState((options.initialState || {}), { renderOnChange: false });
   }
 
+  _getCheckboxGroupData($fields) {
+    const data = [];
+
+    $fields.each((index, field) => {
+      if (field.checked) data.push(field.value);
+    });
+
+    return data;
+  }
+
   /**
    * This is a way to handle most common scenarios of getting data
    * from your form into a JS object. This function is very much a
@@ -78,18 +88,26 @@ export default class baseVw extends View {
       }
 
       const name = $field.attr('name');
+      const isCheckboxGroup = field.type === 'checkbox' &&
+        name.endsWith('[]');
 
-      if (name.indexOf('[') !== -1) {
-        // handle nested collection
-        // for now not handling nested collection, please
-        // manage manually
-        data[name] = val;
-      } else if (name.indexOf('.') !== -1) {
+      if (name.indexOf('.') !== -1) {
+        let deepVal = val;
+        let deepName = name;
+
+        if (isCheckboxGroup) {
+          deepVal = this._getCheckboxGroupData($formFields.filter(`[name="${name}"]`));
+          deepName = name.slice(0, name.length - 2);
+        } else if (field.type === 'checkbox') {
+          deepVal = field.checked;
+        }
+
         // handle nested model
-        setDeepValue(data, name, val);
+        setDeepValue(data, deepName, deepVal);
+      } else if (isCheckboxGroup) {
+        data[name] = this._getCheckboxGroupData($formFields.filter(`[name="${name}"]`));
       } else if (field.type === 'checkbox') {
-        if (!Array.isArray(data[name])) data[name] = [];
-        if ($(field).prop('checked')) data[name].push(val);
+        data[name] = field.checked;
       } else {
         data[name] = val;
       }


### PR DESCRIPTION
This augments #1637 by updating `getFormData` to handle checkbox groups.

> The old code was just adding a value of "true" if at least one checkbox was checked.

Well, in 95% of the cases, that's what we want. We simply want whether a checkbox is checked or not to map to a boolean. For example:

`<input type="checkbox" name="useTor" checked />`

would get you: `{ useTor: true }`

`<input type="checkbox" name="useTor" />`

would get you: `{ useTor: false }`

I think what you're looking for is checkbox group functionality which by convention is denoted by appending the `name` attribute with `[]`. In that scenario, the field maps to an array containing the `value` attribute of any checked checkboxes.

https://www.dyn-web.com/tutorials/forms/checkbox/same-name-group.php

This code updates `getFormData` to support that while leaving the existing checkbox to boolean functionality in place.
