### PR TITLE
testnet suffix for data dir

### DIFF
--- a/js/utils/serverConnect.js
+++ b/js/utils/serverConnect.js
@@ -319,7 +319,7 @@ export default function connect(server, options = {}) {
   }
 
   if (newServerDataDir && typeof newServerDataDir === 'string') {
-    commandLineArgs = commandLineArgs.concat(['-d', newServerDataDir]);
+    commandLineArgs = commandLineArgs.concat(['-d', `${newServerDataDir}-testnet`]);
   }
 
   // If we're not connecting to the local bundled server or it's running with incompatible


### PR DESCRIPTION
@hoffmabc @jjeffryes Before mainnet release, in addition to removing staring the `-t` flag on the bundled server, it is *critical* we also reverse this change.