### PR TITLE
Add a default fixed fee currency

### DIFF
--- a/js/models/profile/FixedFee.js
+++ b/js/models/profile/FixedFee.js
@@ -6,7 +6,7 @@ import is from 'is_js';
 export default class extends BaseModel {
   defaults() {
     return {
-      currencyCode: '',
+      currencyCode: 'USD',
       amount: 0,
     };
   }


### PR DESCRIPTION
This prevents an unhandled error when mobile nodes are returned as moderators without a fixedFee object.

Closes #1672 