### PR TITLE
Add the missing class to the continue button

### DIFF
--- a/js/templates/modals/verifiedModsError.html
+++ b/js/templates/modals/verifiedModsError.html
@@ -14,6 +14,6 @@
         className: `flexExpand btnFlx clrP js-retry ${ob.fetching ? 'processing' : ''}`,
         btnText: ob.polyT('startUp.dialogs.unableToGetVerifiedMods.btnRetry')
         }) %>
-      <a class="flexExpand btnFlx clrP" data-event-name=""><%= ob.polyT('startUp.dialogs.unableToGetVerifiedMods.btnClose') %></a>
+      <a class="flexExpand btnFlx clrP js-continue" data-event-name=""><%= ob.polyT('startUp.dialogs.unableToGetVerifiedMods.btnClose') %></a>
     </div>
   </div>


### PR DESCRIPTION
Somehow the continue button in the error modal if the verified mods don't load didn't get the class it needs to trigger the continue event, this fixes that.