### PR TITLE
fix typo in change listener

### DIFF
--- a/js/views/MiniProfile.js
+++ b/js/views/MiniProfile.js
@@ -27,7 +27,7 @@ export default class extends baseVw {
     this._followsYou = false;
 
     if (this.model.id === app.profile.id) {
-      this.listenTo(app.profile, 'change:name, change:location', () => this.render());
+      this.listenTo(app.profile, 'change:name change:location', () => this.render());
       this.listenTo(app.profile.get('avatarHashes'), 'change', () => this.render());
     } else {
       if (opts.fetchFollowsYou) {


### PR DESCRIPTION
There was a typo that prevented the change listener in the miniProfile view from firing when the name or location of the user changed.

Closes #1671