### PR TITLE
fix line overlap

### DIFF
--- a/styles/modules/modals/_orderDetail.scss
+++ b/styles/modules/modals/_orderDetail.scss
@@ -470,6 +470,7 @@
     hr {
       margin-left: $padLg;
       margin-right: $padLg;
+      width: calc(100% - #{$padLg * 2})
     }
 
     .buttonBar {


### PR DESCRIPTION
This was pulled out of #1688.

It fixes a visual bug where the horizontal line overlaps it's container.

Closes #1684 