### PR TITLE
Consolidate Avatar on Listing Cards

### DIFF
--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -4,7 +4,7 @@
   <% if (ob.vendor) { %>
     <div class="contentBox clrP clrSh3 clrBr clrT">
       <div class="padSm gutterHSm overflowAuto margRSm flexVCent">
-        <a class="clrBr2 clrSh1 disc storeOwnerAvatar flexNoShrink js-storeOwnerAvatar" style="<%= ob.getAvatarBgImage(ob.vendor.avatar) %>"></a>
+        <a class="clrBr2 clrSh1 disc storeOwnerAvatar flexNoShrink js-storeOwnerAvatar" style="<%= ob.getAvatarBgImage(ob.vendor.avatarHashes) %>"></a>
         <p class="txUnl tx3 clamp"><%= ob.vendor.name %></p>
         <a class="link flexNoShrink tx6 js-goToStore"><% print(ob.openedFromStore ? ob.polyT('listingDetail.returnToStore'): ob.polyT('listingDetail.goToStore')) %></a>
       </div>

--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -10,7 +10,7 @@
   <% if (ob.vendor) { %>
   <div class="contentBox clrP clrSh3 clrBr clrT">
     <div class="padSm gutterHSm overflowAuto margRSm flexVCent">
-      <a class="clrBr2 clrSh1 discTn flexNoShrink" style="<%= ob.getAvatarBgImage(ob.vendor.avatar) %>"></a>
+      <a class="clrBr2 clrSh1 discTn flexNoShrink" style="<%= ob.getAvatarBgImage(ob.vendor.avatarHashes) %>"></a>
       <p class="txUnl tx3 clamp"><%= ob.vendor.name %></p>
       <a class="link flexNoShrink tx6 js-goToListing"><% print(ob.polyT('purchase.returnToListing')) %></a>
     </div>

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -134,9 +134,9 @@ export default class extends baseVw {
     this.listingImage.src = listingImageSrc;
 
     const vendor = this.model.get('vendor');
-    if (vendor && vendor.avatarHashes) {
+    if (vendor && vendor.avatar) {
       const avatarImageSrc = app.getServerUrl(
-        `ob/images/${isHiRez() ? vendor.avatarHashes.small : vendor.avatarHashes.tiny}`
+        `ob/images/${isHiRez() ? vendor.avatar.small : vendor.avatar.tiny}`
       );
 
       this.avatarImage = new Image();

--- a/js/views/ListingCard.js
+++ b/js/views/ListingCard.js
@@ -134,9 +134,9 @@ export default class extends baseVw {
     this.listingImage.src = listingImageSrc;
 
     const vendor = this.model.get('vendor');
-    if (vendor && vendor.avatar) {
+    if (vendor && vendor.avatarHashes) {
       const avatarImageSrc = app.getServerUrl(
-        `ob/images/${isHiRez() ? vendor.avatar.small : vendor.avatar.tiny}`
+        `ob/images/${isHiRez() ? vendor.avatarHashes.small : vendor.avatarHashes.tiny}`
       );
 
       this.avatarImage = new Image();

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -56,16 +56,11 @@ export default class extends BaseModal {
     // Sometimes a profile model is available and the vendor info
     // can be obtained from that.
     if (opts.profile) {
-      const avatarHashes = opts.profile.get('avatarHashes');
-
       this.vendor = {
         peerID: opts.profile.id,
         name: opts.profile.get('name'),
         handle: opts.profile.get('handle'),
-        avatar: {
-          tiny: avatarHashes.get('tiny'),
-          small: avatarHashes.get('small'),
-        },
+        avatarHashes: opts.profile.get('avatarHashes').toJSON(),
       };
     }
 

--- a/js/views/search/Results.js
+++ b/js/views/search/Results.js
@@ -49,7 +49,6 @@ export default class extends baseVw {
     // models can be listings or nodes
     if (model instanceof ListingCardModel) {
       const vendor = model.get('vendor') || {};
-      vendor.avatar = vendor.avatarHashes;
       const base = vendor.handle ?
         `@${vendor.handle}` : vendor.peerID;
 


### PR DESCRIPTION
Sometimes an avatar object with the same values as the avatarHashes object was being injected into the vendor for the listingCard and listing templates to use. But the code in the listingCard always used the avatarHashes, leading the avatar to be missing sometimes.

This PR refactors things to just always use an avatarHashes object in the vendor object.

Closes #1686 