### PR TITLE
Pretty Print Copied Contract JSON

### DIFF
--- a/js/views/modals/orderDetail/contractTab/Contract.js
+++ b/js/views/modals/orderDetail/contractTab/Contract.js
@@ -37,7 +37,7 @@ export default class extends BaseVw {
   }
 
   onClickCopyContract() {
-    clipboard.writeText(JSON.stringify(this.contract));
+    clipboard.writeText(JSON.stringify(this.contract, null, 2));
     // Fade the link and make it unclickable, but maintain its position in the DOM.
     this.getCachedEl('.js-copyContract')
       .addClass('unclickable')


### PR DESCRIPTION
This adds the formatting parameter to the stringify used when copying the contract JSON in the order details modal.

Closes #1680