### PR TITLE
Only Sanitize Strings in Forms

### DIFF
--- a/js/views/baseVw.js
+++ b/js/views/baseVw.js
@@ -18,7 +18,8 @@ export default class baseVw extends View {
     const data = [];
 
     $fields.each((index, field) => {
-      if (field.checked) data.push(sanitizeHtml(field.value));
+      const val = typeof field.value !== 'number' ? sanitizeHtml(field.value) : field.value;
+      if (field.checked) data.push(val);
     });
 
     return data;
@@ -112,7 +113,7 @@ export default class baseVw extends View {
       } else if (field.type === 'checkbox') {
         data[name] = field.checked;
       } else {
-        data[name] = sanitizeHtml(val);
+        data[name] = typeof val !== 'number' ? sanitizeHtml(val) : val;
       }
     });
 

--- a/js/views/baseVw.js
+++ b/js/views/baseVw.js
@@ -18,7 +18,7 @@ export default class baseVw extends View {
     const data = [];
 
     $fields.each((index, field) => {
-      const val = typeof field.value !== 'number' ? sanitizeHtml(field.value) : field.value;
+      const val = typeof field.value === 'string' ? sanitizeHtml(field.value) : field.value;
       if (field.checked) data.push(val);
     });
 
@@ -113,7 +113,7 @@ export default class baseVw extends View {
       } else if (field.type === 'checkbox') {
         data[name] = field.checked;
       } else {
-        data[name] = typeof val !== 'number' ? sanitizeHtml(val) : val;
+        data[name] = typeof val === 'string' ? sanitizeHtml(val) : val;
       }
     });
 


### PR DESCRIPTION
The new form sanitation code was sanitizing numbers and booleans, and turning them into strings. This caused some issues, for example in the connection management form. This fixes it.