### PR TITLE
Improve Quantity Error Check

### DIFF
--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -309,7 +309,7 @@ export default class extends BaseModal {
   }
 
   setModelQuantity(quantity, cur = this.cryptoAmountCurrency) {
-    if (this.listing.isCrypto && typeof cur !== 'string') {
+    if (this.listing.isCrypto && (typeof cur !== 'string' || !cur)) {
       throw new Error('Please provide the currency code as a string.');
     }
 

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -310,7 +310,7 @@ export default class extends BaseModal {
 
   setModelQuantity(quantity, cur = this.cryptoAmountCurrency) {
     if (this.listing.isCrypto && (typeof cur !== 'string' || !cur)) {
-      throw new Error('Please provide the currency code as a string.');
+      throw new Error('Please provide the currency code as a valid, non-empty string.');
     }
 
     let mdQuantity = quantity;

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -309,7 +309,7 @@ export default class extends BaseModal {
   }
 
   setModelQuantity(quantity, cur = this.cryptoAmountCurrency) {
-    if (typeof cur !== 'string') {
+    if (this.listing.isCrypto && typeof cur !== 'string') {
       throw new Error('Please provide the currency code as a string.');
     }
 


### PR DESCRIPTION
In the setModelQuantity method, an error is thrown when `cur` is not a string, even though `cur` is only used when changing the quantity of cryptocurrency listings. This PR updates it to only throw the error for crypto listings, and to check for empty values. 

This works currently because the API returns a `metadata.coinType` value of "" (which is still a string), but when fetching from IPFS that parameter is missing for non-crypto listings.