### PR TITLE
Show Dispute Started By and IDs for Mod

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -1732,7 +1732,10 @@
         "reviewLabel": "%{name}'s Review:"
       },
       "disputeStarted": {
+        "buyer": "Buyer",
+        "seller": "Seller",
         "heading": "Dispute Started",
+        "modHeading": "Dispute Started by %{openedBy}",
         "partyIsDisputing": "%{name} is disputing the order:",
         "resolveBtn": "Resolve Dispute",
         "genericIsDisputed": "The order is being disputed:",

--- a/js/templates/modals/orderDetail/summaryTab/disputeStarted.html
+++ b/js/templates/modals/orderDetail/summaryTab/disputeStarted.html
@@ -1,6 +1,12 @@
-<h2 class="tx4 margRTn"><%= ob.polyT('orderDetail.summaryTab.disputeStarted.heading') %></h2>
+<% if (ob.buyerOpened !== undefined) {
+    const openedBy = ob.polyT(`orderDetail.summaryTab.disputeStarted.${ob.buyerOpened ? 'buyer' : 'seller'}`);
+%>
+  <h2 class="tx4 margRTn"><%= ob.polyT('orderDetail.summaryTab.disputeStarted.modHeading', { openedBy }) %></h2>
+<% } else { %>
+  <h2 class="tx4 margRTn"><%= ob.polyT('orderDetail.summaryTab.disputeStarted.heading') %></h2>
+<% } %>
 <% if (ob.timestamp) { %>
-<span class="clrT2 tx5b"><%= ob.moment(ob.timestamp).format('lll') %></span>
+  <span class="clrT2 tx5b"><%= ob.moment(ob.timestamp).format('lll') %></span>
 <% } %>
 
 <div class="border clrBr padMd">
@@ -13,7 +19,17 @@
           ob.polyT('orderDetail.summaryTab.disputeStarted.genericIsDisputed');
       %>
       <div class="rowTn txB"><%= introLine %></div>
-      <div><%= ob.claim || ob.polyT('orderDetail.summaryTab.disputeStarted.noReasonProvided') %></div>
+      <div class="rowMd" ><%= ob.claim || ob.polyT('orderDetail.summaryTab.disputeStarted.noReasonProvided') %></div>
+      <% if (ob.buyerID) { %>
+        <div class="rowSm">
+          Buyer: <a href="ob://<%= ob.buyerID %>"><%= ob.buyerID %></a>
+        </div>
+      <% } %>
+      <% if (ob.sellerID) { %>
+        <div>
+          Seller: <a href="ob://<%= ob.sellerID %>"><%= ob.sellerID %></a>
+        </div>
+      <% }%>
     </div>
   </div>
 </div>

--- a/js/views/modals/orderDetail/summaryTab/DisputeStarted.js
+++ b/js/views/modals/orderDetail/summaryTab/DisputeStarted.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import moment from 'moment';
 import {
   events as orderEvents,
@@ -8,14 +7,17 @@ import BaseVw from '../../../baseVw';
 
 export default class extends BaseVw {
   constructor(options = {}) {
-    super(options);
-
-    this._state = {
+    const opts = {
       disputerName: '',
       claim: '',
       showResolveButton: false,
-      ...options.initialState || {},
+      ...options,
+      initialState: {
+        ...options.initialState,
+      },
     };
+
+    super(opts);
 
     this.listenTo(orderEvents, 'resolveDisputeComplete', () => {
       this.setState({
@@ -38,27 +40,11 @@ export default class extends BaseVw {
     this.trigger('clickResolveDispute');
   }
 
-  setState(state, replace = false, renderOnChange = true) {
-    let newState;
-
-    if (replace) {
-      this._state = {};
-    } else {
-      newState = _.extend({}, this._state, state);
-    }
-
-    if (renderOnChange && !_.isEqual(this._state, newState)) {
-      this._state = newState;
-      this.render();
-    }
-
-    return this;
-  }
-
   render() {
+    const state = this.getState();
     loadTemplate('modals/orderDetail/summaryTab/disputeStarted.html', (t) => {
       this.$el.html(t({
-        ...this._state,
+        ...state,
         moment,
       }));
     });

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -799,9 +799,14 @@ export default class extends BaseVw {
   }
 
   renderDisputeStartedView() {
+    const buyerOpened = this.model.get('buyerOpened');
+
     const data = this.model.isCase ? {
       timestamp: this.model.get('timestamp'),
       claim: this.model.get('claim'),
+      buyerOpened,
+      buyerID: this.buyer.id,
+      sellerID: this.vendor.id,
     } : this.contract.get('dispute');
 
     if (!data) {
@@ -819,7 +824,6 @@ export default class extends BaseVw {
     });
 
     // this is only set on the Case.
-    const buyerOpened = this.model.get('buyerOpened');
     if (typeof buyerOpened !== 'undefined') {
       const disputeOpener = buyerOpened ? this.buyer : this.vendor;
       disputeOpener.getProfile()


### PR DESCRIPTION
Adds a "started by buyer/seller" to the case view for the moderator, and the peer IDs of the two parties to make things more convenient for the moderator.

Closes #1703

![image](https://user-images.githubusercontent.com/1584275/53671104-fc522880-3c4a-11e9-9994-c05bfe52a0ad.png)
