### PR TITLE
remove block booth from default providers

### DIFF
--- a/js/data/defaultSearchProviders.js
+++ b/js/data/defaultSearchProviders.js
@@ -11,17 +11,6 @@ const defaultSearchProviders = [
     torlistings: 'http://my7nrnmkscxr32zo.onion/listings/search',
     locked: true,
   },
-  {
-    id: 'blockbooth',
-    name: 'Block Booth',
-    logo: '../imgs/blockboothLogo.png',
-    localLogo: '../imgs/blockboothLogo.png',
-    search: '',
-    listings: 'https://search.blockbooth.com/api/',
-    torsearch: 'http://vnjzhvm5gkctyldn.onion/api/',
-    torlistings: 'http://vnjzhvm5gkctyldn.onion/api/',
-    locked: true,
-  },
 ];
 
 export default defaultSearchProviders;


### PR DESCRIPTION
This removes Blockbooth from the list of default search providers, due to their API being down, along with issues outlined in #1569.

Closes #1569 