### PR TITLE
fix capitalization of tor template

### DIFF
--- a/js/views/modals/TorExternalLinkWarning.js
+++ b/js/views/modals/TorExternalLinkWarning.js
@@ -46,7 +46,7 @@ export default class extends BaseModal {
   }
 
   render() {
-    loadTemplate('modals/TorExternalLinkWarning.html', t => {
+    loadTemplate('modals/torExternalLinkWarning.html', t => {
       this.$el.html(t({
         url: this.url,
       }));


### PR DESCRIPTION
On some OSes the Tor External Warning modal won't load because the file isn't capitalized. This fixes that.