### PR TITLE
add btnFlx classes to update modal

### DIFF
--- a/js/utils/autoUpdate.js
+++ b/js/utils/autoUpdate.js
@@ -49,11 +49,11 @@ export function updateReady(opts = {}) {
     buttons: [{
       text: app.polyglot.t('update.cancel'),
       fragment: 'cancelInstall',
-      className: 'txU',
+      className: 'txU btnFlx',
     }, {
       text: app.polyglot.t('update.install'),
       fragment: 'installUpdate',
-      className: 'btn clrP clrBAttGrad clrBrDec1 clrTOnEmph',
+      className: 'btnFlx clrP clrBAttGrad clrBrDec1 clrTOnEmph',
     }],
   }).on('click-installUpdate', () => ipcRenderer.send('installUpdate'))
     .on('click-cancelInstall', () => updateReadyDialog.close())


### PR DESCRIPTION
This fixes the update dialog to have the new button styles we added a while ago.

The screenshot below doesn't include the normal update text, since I was just manually triggering the modal.

![image](https://user-images.githubusercontent.com/1584275/54636607-369a3300-4a5d-11e9-9ffe-462f8192c7de.png)
