### PR TITLE
Fix case crypto quantity

### DIFF
--- a/js/models/order/Case.js
+++ b/js/models/order/Case.js
@@ -81,6 +81,10 @@ export default class extends BaseOrder {
     contract.buyerOrder.items.forEach((item, index) => {
       const listing = contract.vendorListings[index];
 
+      // standardize the quantity field
+      item.quantity = item.quantity === 0 ?
+        item.quantity64 : item.quantity;
+
       if (listing.metadata.contractType === 'CRYPTOCURRENCY') {
         const coinDivisibility = listing.metadata
           .coinDivisibility;

--- a/js/models/order/Case.js
+++ b/js/models/order/Case.js
@@ -77,15 +77,19 @@ export default class extends BaseOrder {
     return false;
   }
 
-  convertCryptoQuantity(contract = {}) {
+  convertQuantity(contract = {}) {
     contract.buyerOrder.items.forEach((item, index) => {
       const listing = contract.vendorListings[index];
+
+      // standardize the quantity field
+      item.quantity = item.quantity === 0 ?
+        item.quantity64 : item.quantity;
 
       if (listing.metadata.contractType === 'CRYPTOCURRENCY') {
         const coinDivisibility = listing.metadata
           .coinDivisibility;
 
-        item.quantity = item.quantity64 / coinDivisibility;
+        item.quantity = item.quantity / coinDivisibility;
       }
     });
 
@@ -120,7 +124,7 @@ export default class extends BaseOrder {
         integerToDecimal(response.buyerContract.buyerOrder.payment.amount,
           paymentCoin);
 
-      response.buyerContract = this.convertCryptoQuantity(response.buyerContract);
+      response.buyerContract = this.convertQuantity(response.buyerContract);
     }
 
     if (response.vendorContract) {
@@ -133,6 +137,8 @@ export default class extends BaseOrder {
       response.vendorContract.buyerOrder.payment.amount =
         integerToDecimal(response.vendorContract.buyerOrder.payment.amount,
           paymentCoin);
+
+      response.vendorContract = this.convertQuantity(response.vendorContract);
     }
 
     if (response.resolution) {

--- a/js/models/order/Case.js
+++ b/js/models/order/Case.js
@@ -81,15 +81,11 @@ export default class extends BaseOrder {
     contract.buyerOrder.items.forEach((item, index) => {
       const listing = contract.vendorListings[index];
 
-      // standardize the quantity field
-      item.quantity = item.quantity === 0 ?
-        item.quantity64 : item.quantity;
-
       if (listing.metadata.contractType === 'CRYPTOCURRENCY') {
         const coinDivisibility = listing.metadata
           .coinDivisibility;
 
-        item.quantity = item.quantity / coinDivisibility;
+        item.quantity = item.quantity64 / coinDivisibility;
       }
     });
 


### PR DESCRIPTION
It looks like there was a typo where cases for cryptocurrency orders were dividing the wrong quantity field, which always resulted in a quantity of zero.

Closes #1723