### PR TITLE
Don't Show Shipping Options If There Are No Addresses

### DIFF
--- a/js/views/modals/purchase/Shipping.js
+++ b/js/views/modals/purchase/Shipping.js
@@ -161,7 +161,9 @@ export default class extends baseView {
     this.listenTo(this.shippingOptions, 'shippingOptionSelected',
         opts => (this.selectedOption = opts));
 
-    this.$('.js-shippingOptionsWrapper').append(this.shippingOptions.render().el);
+    if (userAddresses.length) {
+      this.$('.js-shippingOptionsWrapper').append(this.shippingOptions.render().el);
+    }
 
     return this;
   }


### PR DESCRIPTION
If a user doesn't have any shipping addresses, don't show the shipping option selector, since it's not usable and would just show a warning until after they add at least one address.

Closes #1709