### PR TITLE
Center Button Elements in btnFlx Class

### DIFF
--- a/styles/components/_buttons.scss
+++ b/styles/components/_buttons.scss
@@ -330,7 +330,8 @@
     // see styleSheet.html for example usage.
     // use for buttons in the new 'flex' style with more padding and use css flex.
     @extend .btn;
-    padding: 25px;
+    min-height: 48px;
+    height: auto;
     border-radius: 0px;
     border-width: 1px;
     border-style: solid;
@@ -355,8 +356,6 @@
     .btnFlx {
       border-radius: 0;
       border-top: none;
-      padding: 0;
-      height: 48px;
       display: inline-flex;
       align-items: center;
       font-weight: 400;


### PR DESCRIPTION
This solves a potential issue with how the text inside a Button element was vertically centered when a btnFlx class was applied to it.

The Button element was starting the top of the text line-height at the bottom of the top padding, which is different from how a link element positioned the text, resulting in a link and a button side by side not having the same vertical text position. By removing the padding and setting a min-height, both elements position their text the same, and can expand vertically while remaining centered.

If a button has 3 or more lines of text, the text gets pretty close to the top and bottom borders of the button, but that's a situation we should always avoid.