### PR TITLE
Tweak to BtnFlex

### DIFF
--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -550,7 +550,6 @@ input[type=range][class~="clrS"] {
 
   &:hover, &:focus {
     @include borderColor($border, $border3);
-    z-index: 1;
   }
 
   &.underlineOnly:hover,

--- a/styles/components/_buttons.scss
+++ b/styles/components/_buttons.scss
@@ -336,10 +336,15 @@
     border-width: 1px;
     border-style: solid;
     flex-grow: 1;
+    flex-basis: 0; // calculate the width independent of the content
     margin: 0 -1px -1px -1px;
 
     & + .btnFlx {
       margin-left: 0;
+    }
+
+    &:hover, &:focus {
+      z-index: 1; // make sure the themed border between buttons is stacked to be visible
     }
   }
 


### PR DESCRIPTION
Makes sure btnFlx buttons are actually equal width by ignoring the content size.

Also moves the z-index out of the theme.