### PR TITLE
Update explorers

### DIFF
--- a/js/data/walletCurrencies.js
+++ b/js/data/walletCurrencies.js
@@ -20,12 +20,12 @@ const currencies = [
     url: 'https://bitcoin.org/',
     getBlockChainAddressUrl: (address, isTestnet) => (
       isTestnet ?
-        `https://www.blocktrail.com/tBTC/address/${address}` :
+        `https://chain.so/address/BTCTEST/${address}` :
         `https://blockchair.com/bitcoin/address/${address}`
     ),
     getBlockChainTxUrl: (txid, isTestnet) => (
       isTestnet ?
-        `https://www.blocktrail.com/tBTC/tx/${txid}` :
+        `https://chain.so/tx/BTCTEST/${txid}` :
         `https://blockchair.com/bitcoin/transaction/${txid}`
     ),
     isValidAddress: address => {
@@ -67,12 +67,12 @@ const currencies = [
     url: 'https://bitcoincash.org/',
     getBlockChainAddressUrl: (address, isTestnet) => (
       isTestnet ?
-        `https://www.blocktrail.com/tBCC/address/${address}` :
+        `https://explorer.bitcoin.com/tbch/address/bchtest:${address}` :
         `https://blockchair.com/bitcoin-cash/address/${address}`
     ),
     getBlockChainTxUrl: (txid, isTestnet) => (
       isTestnet ?
-        `https://www.blocktrail.com/tBCC/tx/${txid}` :
+        `https://explorer.bitcoin.com/tbch/tx/${txid}` :
         `https://blockchair.com/bitcoin-cash/transaction/${txid}`
     ),
     supportsEscrowTimeout: true,
@@ -89,7 +89,7 @@ const currencies = [
     url: 'https://litecoin.org/',
     getBlockChainAddressUrl: (address, isTestnet) => (
       isTestnet ?
-        `https://www.blocktrail.com/tLTC/address/${address}` :
+        `https://chain.so/address/LTCTEST/${address}` :
         `https://blockchair.com/litecoin/address/${address}`
     ),
     getBlockChainTxUrl: (txid, isTestnet) => (

--- a/js/data/walletCurrencies.js
+++ b/js/data/walletCurrencies.js
@@ -68,12 +68,12 @@ const currencies = [
     getBlockChainAddressUrl: (address, isTestnet) => (
       isTestnet ?
         `https://www.blocktrail.com/tBCC/address/${address}` :
-        `https://blockdozer.com/address/${address}`
+        `https://blockchair.com/bitcoin-cash/address/${address}`
     ),
     getBlockChainTxUrl: (txid, isTestnet) => (
       isTestnet ?
         `https://www.blocktrail.com/tBCC/tx/${txid}` :
-        `https://blockdozer.com/tx/${txid}`
+        `https://blockchair.com/bitcoin-cash/transaction/${txid}`
     ),
     supportsEscrowTimeout: true,
     blockTime: 1000 * 60 * 10,
@@ -90,12 +90,12 @@ const currencies = [
     getBlockChainAddressUrl: (address, isTestnet) => (
       isTestnet ?
         `https://www.blocktrail.com/tLTC/address/${address}` :
-        `https://live.blockcypher.com/ltc/address/${address}`
+        `https://blockchair.com/litecoin/address/${address}`
     ),
     getBlockChainTxUrl: (txid, isTestnet) => (
       isTestnet ?
         `https://chain.so/tx/LTCTEST/${txid}` :
-        `https://live.blockcypher.com/ltc/tx/${txid}`
+        `https://blockchair.com/litecoin/transaction/${txid}`
     ),
     supportsEscrowTimeout: true,
     blockTime: 1000 * 60 * 2.5,


### PR DESCRIPTION
This replaces blocktrail with other explorers for testnet, now that block trail is no longer available, and updates BTC, BCH, and LTC to use blockchair.

Closes #1718
Closes #1732 