### PR TITLE
Use Grid for Mixed Results

### DIFF
--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -418,8 +418,8 @@ export default class extends baseVw {
       data.options.type.options &&
       data.options.type.options.length) {
       if (data.options.type.options.find(
-        op => op.value === 'cryptocurrency' && op.checked
-      )) {
+          op => op.value === 'cryptocurrency' && op.checked) &&
+        data.options.type.options.filter(op => op.checked).length === 1) {
         viewType = 'cryptoList';
       }
     }


### PR DESCRIPTION
This fixes an issue where if you select cryptocurrency and another listing type in the type filter of the search page all the results will be formatted as cryptocurrencies (a list). 

If more than one type is selected, the results will be shown as a grid instead.

My assumption is this was missed when we changed the listing type filter from a radio group where only one could be selected at a time to a set of checkboxes.