### PR TITLE
Improve discover

### DIFF
--- a/js/collections/search/SearchProviders.js
+++ b/js/collections/search/SearchProviders.js
@@ -3,7 +3,6 @@ import is from 'is_js';
 import app from '../../app';
 import Provider from '../../models/search/SearchProvider';
 import LocalStorageSync from '../../utils/lib/backboneLocalStorage';
-import { sanitizeResults } from '../../utils/search';
 import { getCurrentConnection } from '../../utils/serverConnect';
 
 /**
@@ -98,11 +97,5 @@ export default class extends Collection {
       this[idString] = md.id;
       localStorage[storageString] = md.id;
     }
-  }
-
-  fetch(options = {}) {
-    return super.fetch({
-      data: sanitizeResults(options.data || {}),
-    });
   }
 }

--- a/js/collections/search/SearchProviders.js
+++ b/js/collections/search/SearchProviders.js
@@ -59,7 +59,7 @@ export default class extends Collection {
   }
 
   /**
-   * This will retrieve the first provider that has the given URL for one of it's endpoints.
+   * This will retrieve the first provider that has the given URL for one of its endpoints.
    * @param {string} url - The endpoint URL being looked for.
    * @returns {object} - A search provider model.
    */

--- a/js/collections/search/SearchProviders.js
+++ b/js/collections/search/SearchProviders.js
@@ -61,6 +61,8 @@ export default class extends Collection {
    * @returns {object} - A search provider model.
    */
   getProviderByURL(url) {
+    if (!url || is.not.url(url)) throw new Error('Please provide a valid URL.');
+
     return this.models.find(md => {
       let match = false;
       ['listings', 'torListings', 'vendors', 'torVendors'].forEach(type => {

--- a/js/collections/search/SearchProviders.js
+++ b/js/collections/search/SearchProviders.js
@@ -1,8 +1,20 @@
 import { Collection } from 'backbone';
+import is from 'is_js';
 import LocalStorageSync from '../../utils/lib/backboneLocalStorage';
-import { baseUrl } from '../../utils';
 import { sanitizeResults } from '../../utils/search';
 import Provider from '../../models/search/SearchProvider';
+
+/**
+ * Returns the URL minus any query parameters.
+ * @param {string} url - A URL.
+ * @returns {string} - The URL domain and pathname.
+ */
+function baseUrl(url) {
+  if (!url || is.not.url(url)) throw new Error('Please provide a valid URL.');
+
+  const tempUrl = new URL(url);
+  return (`${tempUrl.host}${tempUrl.pathname}`).replace(/\/$/, '');
+}
 
 export default class extends Collection {
   localStorage() {
@@ -47,8 +59,8 @@ export default class extends Collection {
     return this.models.find(md => {
       let match = false;
       ['listings', 'torListings', 'vendors', 'torVendors'].forEach(type => {
-        const typeUrl = md.get(type) && baseUrl(md.get(type), true);
-        if (typeUrl && baseUrl(url, true) === typeUrl) match = true;
+        const typeUrl = md.get(type) && baseUrl(md.get(type));
+        if (typeUrl && baseUrl(url) === typeUrl) match = true;
       });
       return match;
     });

--- a/js/collections/search/SearchProviders.js
+++ b/js/collections/search/SearchProviders.js
@@ -48,13 +48,18 @@ export default class extends Collection {
   }
 
   set defaultProvider(md) {
-    this.setProvider(md);
+    this.setDefaultProvider(md);
   }
 
   set defaultTorProvider(md) {
-    this.setProvider(md, true);
+    this.setDefaultProvider(md, true);
   }
 
+  /**
+   * This will retrieve the first provider that has the given URL for one of it's endpoints.
+   * @param {string} url - The endpoint URL being looked for.
+   * @returns {object} - A search provider model.
+   */
   getProviderByURL(url) {
     return this.models.find(md => {
       let match = false;
@@ -67,7 +72,12 @@ export default class extends Collection {
     });
   }
 
-  setProvider(md, tor = false) {
+  /**
+   * This will set the default provider for clear or Tor mode.
+   * @param {object} md - A provider model.
+   * @param {boolean} tor - Whether to save the default for clear or Tor mode.
+   */
+  setDefaultProvider(md, tor = false) {
     if (!md instanceof Provider) {
       throw new Error('Please provide a model as a Provider instance.');
     }

--- a/js/collections/search/SearchProviders.js
+++ b/js/collections/search/SearchProviders.js
@@ -1,9 +1,8 @@
 import { Collection } from 'backbone';
 import is from 'is_js';
-import app from '../../app';
 import Provider from '../../models/search/SearchProvider';
 import LocalStorageSync from '../../utils/lib/backboneLocalStorage';
-import { getCurrentConnection } from '../../utils/serverConnect';
+import { getCurConnTor } from '../../utils/serverConnect';
 
 /**
  * Returns the URL minus any query parameters.
@@ -41,7 +40,7 @@ export default class extends Collection {
   }
 
   get tor() {
-    return app.serverConfig.tor && getCurrentConnection().server.get('useTor') ? 'Tor' : '';
+    return getCurConnTor() ? 'Tor' : '';
   }
 
   get defaultProvider() {

--- a/js/collections/search/SearchProviders.js
+++ b/js/collections/search/SearchProviders.js
@@ -2,7 +2,7 @@ import { Collection } from 'backbone';
 import is from 'is_js';
 import Provider from '../../models/search/SearchProvider';
 import LocalStorageSync from '../../utils/lib/backboneLocalStorage';
-import { getCurConnTor } from '../../utils/serverConnect';
+import { curConnOnTor } from '../../utils/serverConnect';
 
 /**
  * Returns the URL minus any query parameters.
@@ -40,7 +40,7 @@ export default class extends Collection {
   }
 
   get tor() {
-    return getCurConnTor() ? 'Tor' : '';
+    return curConnOnTor() ? 'Tor' : '';
   }
 
   get defaultProvider() {

--- a/js/collections/search/SearchProviders.js
+++ b/js/collections/search/SearchProviders.js
@@ -1,8 +1,10 @@
 import { Collection } from 'backbone';
 import is from 'is_js';
+import app from '../../app';
+import Provider from '../../models/search/SearchProvider';
 import LocalStorageSync from '../../utils/lib/backboneLocalStorage';
 import { sanitizeResults } from '../../utils/search';
-import Provider from '../../models/search/SearchProvider';
+import { getCurrentConnection } from '../../utils/serverConnect';
 
 /**
  * Returns the URL minus any query parameters.
@@ -39,12 +41,13 @@ export default class extends Collection {
     return 8;
   }
 
-  get defaultProvider() {
-    return this.get(this._defaultId);
+  get tor() {
+    return app.serverConfig.tor && getCurrentConnection().server.get('useTor') ? 'Tor' : '';
   }
 
-  get defaultTorProvider() {
-    return this.get(this._defaultTorId);
+  get defaultProvider() {
+    // Fall back to the clearnet endpoint if no Tor endpoint exists.
+    return this.get(this[`_default${this.tor}Id`]) || this.get(this._defaultId);
   }
 
   set defaultProvider(md) {

--- a/js/collections/search/SearchProviders.js
+++ b/js/collections/search/SearchProviders.js
@@ -7,7 +7,7 @@ import Provider from '../../models/search/SearchProvider';
 /**
  * Returns the URL minus any query parameters.
  * @param {string} url - A URL.
- * @returns {string} - The URL domain and pathname.
+ * @returns {string} - The URL domain and pathname without any trailing slashes.
  */
 function baseUrl(url) {
   if (!url || is.not.url(url)) throw new Error('Please provide a valid URL.');
@@ -62,6 +62,7 @@ export default class extends Collection {
         const typeUrl = md.get(type) && baseUrl(md.get(type));
         if (typeUrl && baseUrl(url) === typeUrl) match = true;
       });
+
       return match;
     });
   }

--- a/js/data/defaultSearchProviders.js
+++ b/js/data/defaultSearchProviders.js
@@ -7,7 +7,9 @@ const defaultSearchProviders = [
     listings: 'https://search.ob1.io/listings/search',
     torlistings: 'http://my7nrnmkscxr32zo.onion/listings/search',
     vendors: 'https://search.ob1.io/profiles/search?type=vendor',
+    torVendors: 'http://my7nrnmkscxr32zo.onion/profiles/search?type=vendor',
     reports: 'https://search.ob1.io/reports',
+    torReports: 'http://my7nrnmkscxr32zo.onion/reports',
   },
 ];
 

--- a/js/data/defaultSearchProviders.js
+++ b/js/data/defaultSearchProviders.js
@@ -1,5 +1,6 @@
 const defaultSearchProviders = [
   {
+    id: 'ob1',
     name: 'OB1',
     logo: '../imgs/ob1searchLogo.png',
     localLogo: '../imgs/ob1searchLogo.png',

--- a/js/data/defaultSearchProviders.js
+++ b/js/data/defaultSearchProviders.js
@@ -1,6 +1,5 @@
 const defaultSearchProviders = [
   {
-    id: 'ob1',
     name: 'OB1',
     logo: '../imgs/ob1searchLogo.png',
     localLogo: '../imgs/ob1searchLogo.png',

--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -1347,6 +1347,7 @@
       "connection": "You are no longer connected to your node. Reconnect to continue searching",
       "addError": "This provider cannot be added. Check your data and try again.",
       "existsError": "This provider has already been added.",
+      "invalidUrl":"The provided URL not valid. The default search provider has been used instead.",
       "locked": "Default search providers can't be deleted.",
       "resetToOriginal": "Your search provider's URL is invalid. We'll use the original default provider instead."
     }

--- a/js/models/search/SearchProvider.js
+++ b/js/models/search/SearchProvider.js
@@ -18,6 +18,10 @@ export default class extends BaseModel {
     };
   }
 
+  get idAttribute() {
+    return 'name';
+  }
+
   localStorage() {
     return new LocalStorageSync('__searchProviders');
   }

--- a/js/models/search/SearchProvider.js
+++ b/js/models/search/SearchProvider.js
@@ -26,20 +26,23 @@ export default class extends BaseModel {
     return LocalStorageSync.sync.apply(this, args);
   }
 
-  get usingTor() {
-    return app.serverConfig.tor && getCurrentConnection().server.get('useTor');
+  get tor() {
+    return app.serverConfig.tor && getCurrentConnection().server.get('useTor') ? 'tor' : '';
   }
 
   get listingsUrl() {
-    return this.get(`${this.usingTor ? 'tor' : ''}listings`);
+    // Fall back to clear endpoint on tor if no tor endpoint exists.
+    return this.get(`${this.tor}listings`) || this.get('listings');
   }
 
   get vendorsUrl() {
-    return this.get(`${this.usingTor ? 'tor' : ''}vendors`);
+    // Fall back to clear endpoint on tor if no tor endpoint exists.
+    return this.get(`${this.tor}vendors`) || this.get('vendors');
   }
 
   get reportsUrl() {
-    return this.get(`${this.usingTor ? 'tor' : ''}reports`);
+    // Fall back to clear endpoint on tor if no tor endpoint exists.
+    return this.get(`${this.tor}reports`) || this.get('reports');
   }
 
   validate(attrs, options) {
@@ -48,7 +51,8 @@ export default class extends BaseModel {
       errObj[fieldName] = errObj[fieldName] || [];
       errObj[fieldName].push(error);
     };
-    const urlTypes = options.urlTypes || ['vendors', 'listings', 'torvendors', 'torlistings'];
+    const urlTypes = options.urlTypes ||
+      ['listings', 'torlistings', 'vendors', 'torvendors', 'reports', 'torReports'];
 
     if (attrs.name && is.not.string(attrs.name)) {
       addError('name', app.polyglot.t('searchProviderModelErrors.invalidName'));

--- a/js/models/search/SearchProvider.js
+++ b/js/models/search/SearchProvider.js
@@ -12,9 +12,9 @@ export default class extends BaseModel {
       listings: '',
       torlistings: '',
       vendors: '',
-      torVendors: '',
+      torvendors: '',
       reports: '',
-      torReports: '',
+      torreports: '',
     };
   }
 
@@ -52,7 +52,7 @@ export default class extends BaseModel {
       errObj[fieldName].push(error);
     };
     const urlTypes = options.urlTypes ||
-      ['listings', 'torlistings', 'vendors', 'torvendors', 'reports', 'torReports'];
+      ['listings', 'torlistings', 'vendors', 'torvendors', 'reports', 'torreports'];
 
     if (attrs.name && is.not.string(attrs.name)) {
       addError('name', app.polyglot.t('searchProviderModelErrors.invalidName'));

--- a/js/models/search/SearchProvider.js
+++ b/js/models/search/SearchProvider.js
@@ -48,7 +48,7 @@ export default class extends BaseModel {
       errObj[fieldName] = errObj[fieldName] || [];
       errObj[fieldName].push(error);
     };
-    const urlTypes = options.urlTypes || ['search', 'listings', 'torsearch', 'torlistings'];
+    const urlTypes = options.urlTypes || ['vendors', 'listings', 'torvendors', 'torlistings'];
 
     if (attrs.name && is.not.string(attrs.name)) {
       addError('name', app.polyglot.t('searchProviderModelErrors.invalidName'));

--- a/js/models/search/SearchProvider.js
+++ b/js/models/search/SearchProvider.js
@@ -18,10 +18,6 @@ export default class extends BaseModel {
     };
   }
 
-  get idAttribute() {
-    return 'name';
-  }
-
   localStorage() {
     return new LocalStorageSync('__searchProviders');
   }

--- a/js/models/search/SearchProvider.js
+++ b/js/models/search/SearchProvider.js
@@ -1,7 +1,7 @@
 import app from '../../app';
 import is from 'is_js';
 import LocalStorageSync from '../../utils/lib/backboneLocalStorage';
-import { getCurrentConnection } from '../../utils/serverConnect';
+import { getCurConnTor } from '../../utils/serverConnect';
 import BaseModel from '../BaseModel';
 
 export default class extends BaseModel {
@@ -27,7 +27,7 @@ export default class extends BaseModel {
   }
 
   get tor() {
-    return app.serverConfig.tor && getCurrentConnection().server.get('useTor') ? 'tor' : '';
+    return getCurConnTor() ? 'tor' : '';
   }
 
   get listingsUrl() {

--- a/js/models/search/SearchProvider.js
+++ b/js/models/search/SearchProvider.js
@@ -1,7 +1,7 @@
 import app from '../../app';
 import is from 'is_js';
 import LocalStorageSync from '../../utils/lib/backboneLocalStorage';
-import { getCurConnTor } from '../../utils/serverConnect';
+import { curConnOnTor } from '../../utils/serverConnect';
 import BaseModel from '../BaseModel';
 
 export default class extends BaseModel {
@@ -27,7 +27,7 @@ export default class extends BaseModel {
   }
 
   get tor() {
-    return getCurConnTor() ? 'tor' : '';
+    return curConnOnTor() ? 'tor' : '';
   }
 
   get listingsUrl() {

--- a/js/router.js
+++ b/js/router.js
@@ -43,6 +43,7 @@ export default class ObRouter extends Router {
       ['(ob://)transactions/:tab(/)', 'transactions'],
       ['(ob://)connected-peers(/)', 'connectedPeers'],
       ['(ob://)search(?query)', 'search'],
+      ['(ob://)search/home', 'searchHome'],
       ['(ob://)*path', 'pageNotFound'],
     ];
 
@@ -632,6 +633,12 @@ export default class ObRouter extends Router {
   search(query) {
     this.loadPage(
       new Search({ query })
+    );
+  }
+
+  searchHome() {
+    this.loadPage(
+      new Search({ initialState:{ showHome: true } })
     );
   }
 

--- a/js/router.js
+++ b/js/router.js
@@ -42,8 +42,7 @@ export default class ObRouter extends Router {
       ['(ob://)transactions(/)', 'transactions'],
       ['(ob://)transactions/:tab(/)', 'transactions'],
       ['(ob://)connected-peers(/)', 'connectedPeers'],
-      ['(ob://)search(?query)', 'search'],
-      ['(ob://)search/home', 'searchHome'],
+      ['(ob://)search(/:tab)(?query)', 'search'],
       ['(ob://)*path', 'pageNotFound'],
     ];
 
@@ -630,15 +629,9 @@ export default class ObRouter extends Router {
     this.once('will-route', () => (peerFetch.abort()));
   }
 
-  search(query) {
+  search(tab = 'listings', query) {
     this.loadPage(
-      new Search({ query })
-    );
-  }
-
-  searchHome() {
-    this.loadPage(
-      new Search({ initialState:{ showHome: true } })
+      new Search({ query, initialState: { tab } })
     );
   }
 

--- a/js/templates/components/listingCard.html
+++ b/js/templates/components/listingCard.html
@@ -285,6 +285,7 @@
         })
       %>
     </div>
+    <% /* This is being commented out until inventory is functional. %>
     <%
       let inventory = ob.polyT('cryptoAmountIconPairing', {
         amount: `<i class="clrT2">${ob.polyT('inventoryDisplay.unknownInventory')}</i>`,
@@ -313,6 +314,7 @@
       }
     %>
     <div class="inventoryCol flexExpand flexVCent flexHRight gutterHSm <%= inventoryTxClass %>"><%= inventory %></div>
+    <% */ %>
   </div>
 <% } %>
 

--- a/js/templates/pageNav.html
+++ b/js/templates/pageNav.html
@@ -45,7 +45,7 @@
       <div class="rowDivV clrBrBk"></div>
       <div>
         <div class="flexVCent box margLSm posR">
-          <a href="#search" class="toolTipNoWrap js-discover" data-tip="<%= ob.polyT('pageNav.toolTip.discover') %>" id="Nav_Discover">
+          <a href="#search/home" class="toolTipNoWrap js-discover" data-tip="<%= ob.polyT('pageNav.toolTip.discover') %>" id="Nav_Discover">
             <div class="discoverBtn navBtn" style="background-image: url('../imgs/obVectorIconSmall.svg')"></div>
           </a>
           <% if (ob.showDiscoverCallout) { %>

--- a/js/templates/pageNav.html
+++ b/js/templates/pageNav.html
@@ -45,7 +45,7 @@
       <div class="rowDivV clrBrBk"></div>
       <div>
         <div class="flexVCent box margLSm posR">
-          <a href="#search/home" class="toolTipNoWrap js-discover" data-tip="<%= ob.polyT('pageNav.toolTip.discover') %>" id="Nav_Discover">
+          <a href="#search" class="toolTipNoWrap js-discover" data-tip="<%= ob.polyT('pageNav.toolTip.discover') %>" id="Nav_Discover">
             <div class="discoverBtn navBtn" style="background-image: url('../imgs/obVectorIconSmall.svg')"></div>
           </a>
           <% if (ob.showDiscoverCallout) { %>

--- a/js/templates/search/category.html
+++ b/js/templates/search/category.html
@@ -1,4 +1,4 @@
-<a class="btnTxtOnly js-seeAll"><h2><%= ob.title %></h2></a>
+<a class="clrT js-seeAll"><h2><%= ob.title %></h2></a>
 <% if (ob.viewType === 'cryptoList') { %>
 <div class="flexVCent txB clrBr clrP gutterH cryptoListViewHeader">
   <div class="tradeFromCol"><%= ob.polyT('search.cryptoListViewHeader.colTradeFrom') %></div>

--- a/js/templates/search/category.html
+++ b/js/templates/search/category.html
@@ -9,9 +9,11 @@
     <%= ob.polyT('search.cryptoListViewHeader.colPrice',
     { subText: `<span class="subText clrT2">${ob.polyT('search.cryptoListViewHeader.colPriceSubText')}</span>` }) %>
   </div>
+  <% /* This is being commented out until inventory is functional. %>
   <div class="inventoryCol flexExpand">
     <%= ob.polyT('search.cryptoListViewHeader.colInventory') %> <span class="toolTip txCtr" data-tip="<%= ob.polyT('search.cryptoListViewHeader.tipInventory') %>"><i class="ion-information-circled clrT2"></i></span>
   </div>
+  <% */ %>
 </div>
 <% } %>
 <div class="listingsGrid <%= ob.viewTypeClass %> flex js-resultsGrid"></div>

--- a/js/templates/search/category.html
+++ b/js/templates/search/category.html
@@ -21,4 +21,6 @@
   <button class="btn clrP clrT clrBr clrSh1 js-seeAll"><%= ob.polyT('search.categories.seeAllBtn') %></button>
 </div>
 <hr class="clrBr row categoryRow">
-<div class="flexCent loadingSearch clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
+<% if (ob.loading) { %>
+  <div class="flexCent loadingSearch clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
+<% } %>

--- a/js/templates/search/category.html
+++ b/js/templates/search/category.html
@@ -1,4 +1,4 @@
-<h2><%= ob.title %></h2>
+<a class="btnTxtOnly js-seeAll"><h2><%= ob.title %></h2></a>
 <% if (ob.viewType === 'cryptoList') { %>
 <div class="flexVCent txB clrBr clrP gutterH cryptoListViewHeader">
   <div class="tradeFromCol"><%= ob.polyT('search.cryptoListViewHeader.colTradeFrom') %></div>

--- a/js/templates/search/category.html
+++ b/js/templates/search/category.html
@@ -18,5 +18,5 @@
 <div class="flexCent rowLg">
   <button class="btn clrP clrT clrBr clrSh1 js-seeAll"><%= ob.polyT('search.categories.seeAllBtn') %></button>
 </div>
-<hr class="clrBr row">
+<hr class="clrBr row categoryRow">
 <div class="flexCent loadingSearch clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>

--- a/js/templates/search/provider.html
+++ b/js/templates/search/provider.html
@@ -5,7 +5,7 @@
 %>
 
 <button
-    class="clrP clrBr clrSh2 providerBtn <% if (ob.selecting) print('selecting') %> <% if (ob.name) print('toolTipNoWrap') %> js-provider" data-tip="<%= ob.name %>">
+    class="clrP clrBr clrSh2 providerBtn <% if (ob.showSelectDefault) print('showSelectDefault') %> <% if (ob.name) print('toolTipNoWrap') %> js-provider" data-tip="<%= ob.name %>">
   <div class="thumb providerInner" style="background-image: <%= bkg %>"></div>
 </button>
 

--- a/js/templates/search/providers.html
+++ b/js/templates/search/providers.html
@@ -8,8 +8,8 @@
   </div>
 </div>
 <div class="providersBar flexExpand">
-  <div class="providerWrapper gutterH <% if(!ob.selecting) print('margR') %> js-providerWrapper">
-    <% if (ob.selecting) { %>
+  <div class="providerWrapper gutterH <% if(!ob.showSelectDefault) print('margR') %> js-providerWrapper">
+    <% if (ob.showSelectDefault) { %>
       <div class="selectingBox confirmBox arrowBoxTop clrP clrBr clrSh1">
         <h2><%= ob.polyT('search.chooseDefaultTitle') %></h2>
         <p class="tx5"><%= ob.polyT('search.chooseDefaultMsg') %></p>

--- a/js/templates/search/results.html
+++ b/js/templates/search/results.html
@@ -24,4 +24,6 @@
 <div class="listingsGrid <%= ob.viewTypeClass %> flex js-resultsGrid"></div>
 <div class="pageControls js-pageControlsContainer"></div>
 <hr class="clrBr">
-<div class="flexCent loadingSearch clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
+<% if (ob.loading) { %>
+  <div class="flexCent loadingSearch clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
+<% } %>

--- a/js/templates/search/results.html
+++ b/js/templates/search/results.html
@@ -8,7 +8,9 @@
       <%= ob.polyT('search.cryptoListViewHeader.colPrice',
         { subText: `<span class="subText clrT2">${ob.polyT('search.cryptoListViewHeader.colPriceSubText')}</span>` }) %>
     </div>
+    <% /* This is being commented out until inventory is functional. %>
     <div class="inventoryCol flexExpand"><%= ob.polyT('search.cryptoListViewHeader.colInventory') %> <span class="toolTip txCtr" data-tip="<%= ob.polyT('search.cryptoListViewHeader.tipInventory') %>"><i class="ion-information-circled clrT2"></i></span></div>
+    <% */ %>
   </div>
 <% } %>
 <div class="noResultsMessage contentBox clrP clrBr clrSh3">

--- a/js/templates/search/search.html
+++ b/js/templates/search/search.html
@@ -4,7 +4,7 @@
 
 <% if (!ob.fetching) { %>
   <div class="pageContent">
-    <% if (!ob.emptyData) { %>
+    <% if (!ob.showDataError) { %>
       <div class="flexColRows row">
         <div class="flexVBase gutterH">
           <h3 class="txUnl rowSm"><%= ob.name %></h3>

--- a/js/templates/search/search.html
+++ b/js/templates/search/search.html
@@ -43,7 +43,7 @@
       </div>
       <div class="js-categoryWrapper"></div>
       <div class="flexRow gutterHLg">
-        <% if (ob.showFilters) { %>
+        <% if (ob.hasFilters) { %>
         <div class="col3 filterWrapper js-filterWrapper"></div>
         <div class="col9">
         <% } else { %>

--- a/js/utils/dom.js
+++ b/js/utils/dom.js
@@ -1,8 +1,10 @@
+import $ from 'jquery';
 import app from '../app';
 import { shell } from 'electron';
 import Backbone from 'backbone';
+import { getPageContainer } from './selectors';
 import TorExternalLinkWarning from '../views/modals/TorExternalLinkWarning';
-import $ from 'jquery';
+
 
 // todo: check args and write unit test
 // http://stackoverflow.com/a/21627295/632806
@@ -136,5 +138,5 @@ export function handleLinks(el) {
  * scrollIntoView on a page view's root element doesn't scroll the pageContainer to zero.
  */
 export function scrollPageIntoView() {
-  document.getElementById('pageContainer').scrollIntoView();
+  getPageContainer()[0].scrollIntoView();
 }

--- a/js/utils/index.js
+++ b/js/utils/index.js
@@ -208,18 +208,3 @@ export function deparam(queryStr = '') {
 
   return parsed;
 }
-
-/**
- * Returns the URL minus any query parameters.
- * @param {string} url - A URL.
- * @returns {string}
- */
-export function baseUrl(url, removePrefix) {
-  if (!url || is.not.url(url)) throw new Error('Please provide a valid URL.');
-
-  const tempUrl = new URL(url);
-
-  if (removePrefix) return (`${tempUrl.host}${tempUrl.pathname}`).replace(/\/$/, '');
-
-  return (`${tempUrl.origin}${tempUrl.pathname}`).replace(/\/$/, '');
-}

--- a/js/utils/index.js
+++ b/js/utils/index.js
@@ -3,7 +3,6 @@
 
 import $ from 'jquery';
 import _ from 'underscore';
-import is from 'is_js';
 import app from '../app';
 import multihashes from 'multihashes';
 import twemoji from 'twemoji';

--- a/js/utils/search.js
+++ b/js/utils/search.js
@@ -2,13 +2,13 @@ import _ from 'underscore';
 import app from '../app';
 import $ from 'jquery';
 import sanitizeHtml from 'sanitize-html';
-import is from 'is_js';
 import ProviderMd from '../models/search/SearchProvider';
+
+export const searchTypes = ['listings', 'vendors'];
 
 /**
  * Create a search query URL.
  * @param {object} options.provider - The provider model.
- * @param {string} options.urlType - The type of endpoint to use.
  * @param {string} options.term - The term(s) to search for.
  * @param {string} options.page - The page to returns results for.
  * @param {string} options.pageSize - The number of results per page.
@@ -21,8 +21,8 @@ export function createSearchURL(options = {}) {
   if (!options.provider || !(options.provider instanceof ProviderMd)) {
     throw new Error('Please provide a provider model.');
   }
-  if (!options.urlType || is.not.string(options.urlType)) {
-    throw new Error('Please provide an urlType for the search endpoint.');
+  if (!searchTypes.includes(options.searchType)) {
+    throw new Error('Please provide a valid search type.');
   }
 
   const opts = {
@@ -36,7 +36,7 @@ export function createSearchURL(options = {}) {
   const query = { ..._.pick(opts, ['q', 'p', 'ps', 'sortBy', 'network']), ...opts.filters };
   query.q = query.q || '*';
 
-  return new URL(`${opts.provider[opts.urlType]}?${$.param(query, true)}`);
+  return new URL(`${opts.provider[`${options.searchType}Url`]}?${$.param(query, true)}`);
 }
 
 /**

--- a/js/utils/search.js
+++ b/js/utils/search.js
@@ -3,12 +3,7 @@ import app from '../app';
 import $ from 'jquery';
 import sanitizeHtml from 'sanitize-html';
 import is from 'is_js';
-import { Events } from 'backbone';
 import ProviderMd from '../models/search/SearchProvider';
-
-const events = {
-  ...Events,
-};
 
 /**
  * Create a search query URL.
@@ -20,7 +15,7 @@ const events = {
  * @param {string} options.sortBy - The parameter to sort the results by.
  * @param {object} options.filters - A set of filter keys and values in formData format.
  *
- * @returns {xhr}
+ * @returns {string} - a search URL with query parameters.
  */
 export function createSearchURL(options = {}) {
   if (!options.provider || !(options.provider instanceof ProviderMd)) {
@@ -38,29 +33,10 @@ export function createSearchURL(options = {}) {
     ...options,
   };
 
-  const baseUrl = opts.provider[opts.urlType];
-
-  const query = { ..._.pick(opts, ['q', 'p', 'ps', 'sortBy', 'network']) };
+  const query = { ..._.pick(opts, ['q', 'p', 'ps', 'sortBy', 'network']), ...opts.filters };
   query.q = query.q || '*';
 
-  return new URL(`${baseUrl}?${$.param(query, true)}&${$.param(opts.filters, true)}`);
-}
-
-/**
- * Create a search query and return the results.
- * @param {string} url - The url endpoint to use.
- *
- * @returns {xhr}
- */
-export function fetchSearchResults(url) {
-  const xhr = $.get({
-    url,
-    dataType: 'json',
-  });
-
-  events.trigger('fetchingSearchResults', { xhr });
-
-  return xhr;
+  return new URL(`${opts.provider[opts.urlType]}?${$.param(query, true)}`);
 }
 
 /**
@@ -80,50 +56,4 @@ export function sanitizeResults(data) {
     }
     return val;
   });
-}
-
-/**
- * Creates an object for updating search providers with new data returned from a query.
- * @param {object} data - Provider object from a search query.
- * @returns {{data: *, urlTypes: Array}}
- */
-export function buildProviderUpdate(data) {
-  const update = {};
-  const urlTypes = [];
-
-  if (data.name && is.string(data.name)) update.name = data.name;
-  if (data.logo && is.url(data.logo)) update.logo = data.logo;
-  if (data.links) {
-    if (is.url(data.links.vendors)) {
-      update.vendors = data.links.vendors;
-      urlTypes.push('vendors');
-    }
-    if (is.url(data.links.listings)) {
-      update.listings = data.links.listings;
-      urlTypes.push('listings');
-    }
-    if (is.url(data.links.reports)) {
-      update.reports = data.links.reports;
-      urlTypes.push('reports');
-    }
-    if (data.links.tor) {
-      if (is.url(data.links.tor.listings)) {
-        update.torListings = data.links.tor.listings;
-        urlTypes.push('torlistings');
-      }
-      if (is.url(data.links.tor.vendors)) {
-        update.torVendors = data.links.tor.vendors;
-        urlTypes.push('torVendors');
-      }
-      if (is.url(data.links.tor.reports)) {
-        update.torReports = data.links.tor.reports;
-        urlTypes.push('torReports');
-      }
-    }
-  }
-
-  return {
-    update,
-    urlTypes,
-  };
 }

--- a/js/utils/search.js
+++ b/js/utils/search.js
@@ -38,22 +38,3 @@ export function createSearchURL(options = {}) {
 
   return new URL(`${opts.provider[`${options.searchType}Url`]}?${$.param(query, true)}`);
 }
-
-/**
- * Sanitize search results.
- * @param {object} data - Data object returned from a search query.
- *
- * @returns {object} - The same object, but with sanitized strings.
- */
-export function sanitizeResults(data) {
-  return JSON.stringify(data, (key, val) => {
-    // sanitize the data from any dangerous characters
-    if (typeof val === 'string') {
-      return sanitizeHtml(val, {
-        allowedTags: [],
-        allowedAttributes: [],
-      });
-    }
-    return val;
-  });
-}

--- a/js/utils/search.js
+++ b/js/utils/search.js
@@ -1,7 +1,6 @@
 import _ from 'underscore';
 import app from '../app';
 import $ from 'jquery';
-import sanitizeHtml from 'sanitize-html';
 import ProviderMd from '../models/search/SearchProvider';
 
 export const searchTypes = ['listings', 'vendors'];

--- a/js/utils/search.js
+++ b/js/utils/search.js
@@ -28,13 +28,13 @@ export function createSearchURL(options = {}) {
   const opts = {
     p: 0,
     ps: 66,
-    network: !!app.serverConfig.testnet ? 'testnet' : 'mainnet',
     filters: {},
     ...options,
   };
 
-  const query = { ..._.pick(opts, ['q', 'p', 'ps', 'sortBy', 'network']), ...opts.filters };
+  const query = { ..._.pick(opts, ['q', 'p', 'ps', 'sortBy']), ...opts.filters };
   query.q = query.q || '*';
+  query.network = !!app.serverConfig.testnet ? 'testnet' : 'mainnet';
 
   return new URL(`${opts.provider[`${options.searchType}Url`]}?${$.param(query, true)}`);
 }

--- a/js/utils/serverConnect.js
+++ b/js/utils/serverConnect.js
@@ -75,8 +75,9 @@ export function getServer() {
   return curCon.server;
 }
 
-export function getCurConnTor() {
-  return getServer().get('useTor') && app.serverConfig.tor;
+export function curConnOnTor() {
+  const server = getServer();
+  return !!server && getServer().get('useTor') && app.serverConfig.tor;
 }
 
 /**

--- a/js/utils/serverConnect.js
+++ b/js/utils/serverConnect.js
@@ -75,6 +75,11 @@ export function getServer() {
   return curCon.server;
 }
 
+/**
+ * Returns a boolean indicating whether the server is currently using Tor or not. If no server is
+ * available will return false.
+ * @returns {boolean}
+ */
 export function curConnOnTor() {
   const server = getServer();
   return !!server && getServer().get('useTor') && app.serverConfig.tor;

--- a/js/utils/serverConnect.js
+++ b/js/utils/serverConnect.js
@@ -76,8 +76,9 @@ export function getServer() {
 }
 
 /**
- * Returns a boolean indicating whether the server is currently using Tor or not. If no server is
- * available will return false.
+ * Returns a boolean indicating whether the server is currently using Tor and the client connection
+ * is configured to use Tor. This means all server and client traffic should be running through a
+ * Tor proxy. If no server is available, will return false, take that into account.
  * @returns {boolean}
  */
 export function curConnOnTor() {

--- a/js/utils/serverConnect.js
+++ b/js/utils/serverConnect.js
@@ -75,6 +75,10 @@ export function getServer() {
   return curCon.server;
 }
 
+export function getCurConnTor() {
+  return getServer().get('useTor') && app.serverConfig.tor;
+}
+
 /**
  * Call this method to obtain the socket instance in order to bind socket events.
  * If we are not currently connected to a server, this method will return false.

--- a/js/views/search/AddProvider.js
+++ b/js/views/search/AddProvider.js
@@ -54,6 +54,12 @@ export default class extends BaseView {
       URL = `http://${URL}`;
     }
 
+    /*
+       If the exact same path as an existing provider is added, don't save. Note that if a base URL
+       is added, like search.ob1.io, it won't be matched to provider URLs, since they include the
+       full paths. This is to allow multiple providers on the same domain such as one at
+       foo.com/shoeSearch and another at foo.com/hatSearch.
+     */
     if (app.searchProviders.getProviderByURL(URL)) {
       this.setState({ showExistsError: true });
       return;

--- a/js/views/search/AddProvider.js
+++ b/js/views/search/AddProvider.js
@@ -58,7 +58,10 @@ export default class extends BaseView {
        If the exact same path as an existing provider is added, don't save. Note that if a base URL
        is added, like search.ob1.io, it won't be matched to provider URLs, since they include the
        full paths. This is to allow multiple providers on the same domain such as one at
-       foo.com/shoeSearch and another at foo.com/hatSearch.
+       foo.com/shoeSearch and another at foo.com/hatSearch. This can be a little confusing, due to
+       the self-healing mechanism where the endpoint returns search urls and those replace the urls
+       the user enters, ie: entering "search.ob1.io" creates a provider that updates to use the
+       returned listing endpoint, which is the same as the default OB1 search.
      */
     if (app.searchProviders.getProviderByURL(URL)) {
       this.setState({ showExistsError: true });

--- a/js/views/search/AddProvider.js
+++ b/js/views/search/AddProvider.js
@@ -24,7 +24,7 @@ export default class extends BaseView {
     };
 
     super(opts);
-    this.options = options;
+    this.options = opts;
 
     this.model = new ProviderMd();
 

--- a/js/views/search/AddProvider.js
+++ b/js/views/search/AddProvider.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import app from '../../app';
 import loadTemplate from '../../utils/loadTemplate';
 import { recordEvent } from '../../utils/metrics';
-import { getCurConnTor } from '../../utils/serverConnect';
+import { curConnOnTor } from '../../utils/serverConnect';
 import { searchTypes } from '../../utils/search';
 import BaseView from '../baseVw';
 import { openSimpleMessage } from '../modals/SimpleMessage';
@@ -72,7 +72,7 @@ export default class extends BaseView {
     }
 
     const opts = {};
-    const urlType = `${getCurConnTor() ? 'tor' : ''}${this.options.searchType}`;
+    const urlType = `${curConnOnTor() ? 'tor' : ''}${this.options.searchType}`;
     opts[urlType] = URL;
 
     // pass the type of url to validate to the model

--- a/js/views/search/AddProvider.js
+++ b/js/views/search/AddProvider.js
@@ -1,18 +1,21 @@
 import $ from 'jquery';
-import loadTemplate from '../../utils/loadTemplate';
-import BaseView from '../baseVw';
 import app from '../../app';
-import ProviderMd from '../../models/search/SearchProvider';
-import { openSimpleMessage } from '../modals/SimpleMessage';
+import loadTemplate from '../../utils/loadTemplate';
 import { recordEvent } from '../../utils/metrics';
-
+import { getCurrentConnection } from '../../utils/serverConnect';
+import { searchTypes } from '../../utils/search';
+import BaseView from '../baseVw';
+import { openSimpleMessage } from '../modals/SimpleMessage';
+import ProviderMd from '../../models/search/SearchProvider';
 
 export default class extends BaseView {
   constructor(options = {}) {
-    if (!options.urlType) throw new Error('Please provide an urlType.');
+    if (!searchTypes.includes(options.searchType)) {
+      throw new Error('Please provide a valid search type.');
+    }
 
     const opts = {
-      urlType: '',
+      searchType: '',
       initialState: {
         showExistsError: false,
         ...options.initialState,
@@ -69,7 +72,8 @@ export default class extends BaseView {
     }
 
     const opts = {};
-    const urlType = this.options.urlType;
+    const usingTor = app.serverConfig.tor && getCurrentConnection().server.get('useTor');
+    const urlType = `${usingTor ? 'tor' : ''}${this.options.searchType}`;
     opts[urlType] = URL;
 
     // pass the type of url to validate to the model

--- a/js/views/search/AddProvider.js
+++ b/js/views/search/AddProvider.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import app from '../../app';
 import loadTemplate from '../../utils/loadTemplate';
 import { recordEvent } from '../../utils/metrics';
-import { getCurrentConnection } from '../../utils/serverConnect';
+import { getCurConnTor } from '../../utils/serverConnect';
 import { searchTypes } from '../../utils/search';
 import BaseView from '../baseVw';
 import { openSimpleMessage } from '../modals/SimpleMessage';
@@ -72,8 +72,7 @@ export default class extends BaseView {
     }
 
     const opts = {};
-    const usingTor = app.serverConfig.tor && getCurrentConnection().server.get('useTor');
-    const urlType = `${usingTor ? 'tor' : ''}${this.options.searchType}`;
+    const urlType = `${getCurConnTor() ? 'tor' : ''}${this.options.searchType}`;
     opts[urlType] = URL;
 
     // pass the type of url to validate to the model

--- a/js/views/search/Category.js
+++ b/js/views/search/Category.js
@@ -14,9 +14,6 @@ export default class extends baseVw {
     if (!options.search.provider || !(options.search.provider instanceof ProviderMd)) {
       throw new Error('Please provide a provider model.');
     }
-    if (!options.search.urlType || is.not.string(options.search.urlType)) {
-      throw new Error('Please provide an urlType for the search endpoint.');
-    }
 
     super(options);
 
@@ -54,7 +51,7 @@ export default class extends baseVw {
     const options = {
       listingBaseUrl: `${base}/store/`,
       reportsUrl: this._search.provider.reportsUrl || '',
-      searchUrl: this._search.provider[this._search.urlType],
+      searchUrl: this._search.provider.listingsUrl,
       model,
       vendor,
       onStore: false,

--- a/js/views/search/Category.js
+++ b/js/views/search/Category.js
@@ -74,8 +74,6 @@ export default class extends baseVw {
     });
 
     this.getCachedEl('.js-resultsGrid').html(resultsFrag);
-
-    this.$el.removeClass('loading');
   }
 
   loadCategory(options) {
@@ -92,8 +90,11 @@ export default class extends baseVw {
         this.trigger('fetchComplete');
         this.renderCards(catCol);
       })
-      .fail((xhr) => {
+      .fail(xhr => {
         if (xhr.statusText !== 'abort') this.trigger('searchError', xhr);
+      })
+      .always(() => {
+        this.$el.removeClass('loading');
       });
   }
 
@@ -118,7 +119,6 @@ export default class extends baseVw {
         title: this.cryptoTitle || this._search.q,
       }));
 
-      this.removeCardViews();
       this.loadCategory(this._search);
     });
 

--- a/js/views/search/Category.js
+++ b/js/views/search/Category.js
@@ -35,6 +35,7 @@ export default class extends baseVw {
     }
 
     this.cardViews = [];
+    this.catCol = new ResultsCol();
     this.loadCategory();
   }
 
@@ -93,10 +94,8 @@ export default class extends baseVw {
       ...options,
     };
 
-    if (this.catCol) this.catCol.reset();
-    else this.catCol = new ResultsCol();
-
     if (this.categoryFetch) this.categoryFetch.abort();
+    if (this.catCol.length) this.catCol.reset();
 
     this.categoryFetch = this.catCol.fetch({
       url: createSearchURL(opts),

--- a/js/views/search/Category.js
+++ b/js/views/search/Category.js
@@ -1,4 +1,3 @@
-import is from 'is_js';
 import baseVw from '../baseVw';
 import loadTemplate from '../../utils/loadTemplate';
 import { capitalize } from '../../utils/string';

--- a/js/views/search/Category.js
+++ b/js/views/search/Category.js
@@ -131,6 +131,7 @@ export default class extends baseVw {
           '' : `listingsGrid${capitalize(this.options.viewType)}View`,
         viewType: this.options.viewType,
         title: this.cryptoTitle || this._search.q,
+        ...this.getState(),
       }));
       if (this.catCol && this.catCol.length) this.renderCards(this.catCol);
     });

--- a/js/views/search/Category.js
+++ b/js/views/search/Category.js
@@ -18,7 +18,7 @@ export default class extends baseVw {
       ...options,
       initialState: {
         loading: false,
-        ...options,
+        ...options.initialState,
       },
     };
 

--- a/js/views/search/Filters.js
+++ b/js/views/search/Filters.js
@@ -63,12 +63,11 @@ export default class extends baseVw {
 
     loadTemplate('search/filters.html', (t) => {
       this.$el.html(t({
-        formOverrides: this.formOverrides,
         ...this.getState(),
       }));
     });
 
-    this.$el.find('select').select2({
+    this.$('select').select2({
       minimumResultsForSearch: 10,
       templateResult: selectEmojis,
       templateSelection: selectEmojis,

--- a/js/views/search/Results.js
+++ b/js/views/search/Results.js
@@ -142,15 +142,15 @@ export default class extends baseVw {
   }
 
   clickPagePrev() {
+    recordEvent('Discover_PrevPage', { fromPage: this._search.p });
     this._search.p--;
     this.loadPage();
-    recordEvent('Discover_PrevPage', { fromPage: this._search.p });
   }
 
   clickPageNext() {
+    recordEvent('Discover_NextPage', { fromPage: this._search.p });
     this._search.p++;
     this.loadPage();
-    recordEvent('Discover_NextPage', { fromPage: this._search.p });
   }
 
   removeCardViews() {

--- a/js/views/search/Results.js
+++ b/js/views/search/Results.js
@@ -20,15 +20,17 @@ export default class extends baseVw {
 
     const opts = {
       viewType: 'grid',
+      setHistory: true,
       ...options,
       initialState: {
         loading: false,
-        ...options,
+        ...options.initialState,
       },
     };
 
     super(opts);
     this.options = opts;
+    this._setHistory = opts.setHistory;
     this._search = {
       p: 0,
       ps: 66,
@@ -106,7 +108,9 @@ export default class extends baseVw {
 
     // if page exists, reuse it
     if (this.pageCols[opts.p]) {
-      app.router.navigate(`search/listings?providerQ=${encodeURIComponent(newUrl)}`);
+      if (this._setHistory) {
+        app.router.navigate(`search/listings?providerQ=${encodeURIComponent(newUrl)}`);
+      }
       this.setState({ loading: false });
     } else {
       const newPageCol = new ResultsCol();
@@ -118,7 +122,9 @@ export default class extends baseVw {
         url: newUrl,
       })
         .done(() => {
-          app.router.navigate(`search/listings?providerQ=${encodeURIComponent(newUrl)}`);
+          if (this._setHistory) {
+            app.router.navigate(`search/listings?providerQ=${encodeURIComponent(newUrl)}`);
+          }
         })
         .fail((xhr) => {
           if (xhr.statusText !== 'abort') this.trigger('searchError', xhr);
@@ -132,12 +138,14 @@ export default class extends baseVw {
   clickPagePrev() {
     recordEvent('Discover_PrevPage', { fromPage: this._search.p });
     this._search.p--;
+    this._setHistory = true;
     this.loadPage();
   }
 
   clickPageNext() {
     recordEvent('Discover_NextPage', { fromPage: this._search.p });
     this._search.p++;
+    this._setHistory = true;
     this.loadPage();
   }
 

--- a/js/views/search/Results.js
+++ b/js/views/search/Results.js
@@ -106,7 +106,7 @@ export default class extends baseVw {
 
     // if page exists, reuse it
     if (this.pageCols[opts.p]) {
-      app.router.navigate(`search?providerQ=${encodeURIComponent(newUrl)}`);
+      app.router.navigate(`search/listings?providerQ=${encodeURIComponent(newUrl)}`);
       this.setState({ loading: false });
     } else {
       const newPageCol = new ResultsCol();
@@ -118,7 +118,7 @@ export default class extends baseVw {
         url: newUrl,
       })
         .done(() => {
-          app.router.navigate(`search?providerQ=${encodeURIComponent(newUrl)}`);
+          app.router.navigate(`search/listings?providerQ=${encodeURIComponent(newUrl)}`);
         })
         .fail((xhr) => {
           if (xhr.statusText !== 'abort') this.trigger('searchError', xhr);

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -199,7 +199,7 @@ export default class extends baseVw {
     return !!_.findWhere(defaultSearchProviders, { id });
   }
 
-  /** Handles updates to the search.
+  /** Updates the search object. If updated, triggers a search fetch.
    *
    * @param {object} search - The new state.
    */
@@ -262,8 +262,6 @@ export default class extends baseVw {
   }
 
   fetchSearch(opts = {}) {
-    opts.baseUrl = opts.baseUrl || this.currentBaseUrl;
-
     this.removeFetches();
 
     this.setState({

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -180,7 +180,7 @@ export default class extends baseVw {
   }
 
   get currentDefaultProvider() {
-    return app.searchProviders[`default${this.onTor ? 'Tor' : ''}Provider`];
+    return app.searchProviders.defaultProvider;
   }
 
   set currentDefaultProvider(md) {

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -21,6 +21,7 @@ import { recordEvent } from '../../utils/metrics';
 import { getCurrentConnection } from '../../utils/serverConnect';
 import { scrollPageIntoView } from '../../utils/dom';
 import {
+  searchTypes,
   createSearchURL,
   sanitizeResults,
 } from '../../utils/search';
@@ -40,11 +41,15 @@ export default class extends baseVw {
     super(opts);
     const queryKeys = ['q', 'p', 'ps', 'sortBy'];
 
+    // Allow router to pass in a search type for future use with vendor searches.
+    const searchType = searchTypes.includes(opts.initialState.tab) ?
+      opts.initialState.tab : 'listings';
+
     this._defaultSearch = {
       q: '*',
       p: 0,
       ps: 66,
-      searchType: 'listings',
+      searchType,
       filters: {
         nsfw: String(app.settings.get('showNsfw')),
         acceptedCurrencies: supportedWalletCurs(),

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -494,6 +494,7 @@ export default class extends baseVw {
     const state = this.getState();
     const data = state.data || {};
     const term = this._search.q === '*' ? '' : this._search.q;
+    const hasFilters = data.options && !$.isEmptyObject(data);
 
     let errTitle;
     let errMsg;
@@ -516,7 +517,7 @@ export default class extends baseVw {
         isExistingProvider: this.isExistingProvider(this._search.provider),
         showMakeDefault: this._search.provider !== this.currentDefaultProvider,
         showDataError: $.isEmptyObject(data) && !state.showHome,
-        showFilters: data.options && !$.isEmptyObject(data),
+        hasFilters,
         ...state,
         ...data,
       }));
@@ -551,7 +552,7 @@ export default class extends baseVw {
       this.addNextCategory();
     } else {
       if (this.filters) this.filters.remove();
-      if (data.options) {
+      if (hasFilters) {
         this.filters = this.createChild(Filters, { initialState: { filters: data.options } });
         this.listenTo(this.filters, 'filterChanged', opts => this.onFilterChanged(opts));
         $filterWrapper.append(this.filters.render().el);

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -196,10 +196,8 @@ export default class extends baseVw {
   }
 
   providerIsADefault(id) {
-    if (!id || !(typeof id === 'string')) {
-      throw new Error('Please provide a valid provider ID.');
-    }
-    return !!_.findWhere(defaultSearchProviders, { id });
+    // Non-default providers probably don't have an id, especially if they don't return a name.
+    return id && !!_.findWhere(defaultSearchProviders, { id });
   }
 
   /** Updates the search object. If updated, triggers a search fetch.

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -475,7 +475,7 @@ export default class extends baseVw {
   }
 
   onClickSuggestion(opts) {
-    this.setSearch({ q: opts.suggestion });
+    this.setSearch({ q: opts.suggestion, p: 0 });
     recordEvent('Discover_ClickSuggestion');
     recordEvent('Discover_Search', { type: 'suggestion' });
   }

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -518,7 +518,6 @@ export default class extends baseVw {
         showDataError: $.isEmptyObject(data) && !state.showHome,
         showFilters: data.options,
         ...state,
-        ...this._search.provider,
         ...data,
       }));
     });

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -439,7 +439,7 @@ export default class extends baseVw {
 
     this.getCachedEl('.js-resultsWrapper').html(this.resultsView.render().el);
 
-    this.listenTo(this.resultsView, 'searchError', (xhr) => {
+    this.listenTo(this.resultsView, 'searchError', xhr => {
       this.setState({
         fetching: false,
         data: '',
@@ -515,7 +515,7 @@ export default class extends baseVw {
         providerLocked: this.providerIsADefault(this._search.provider.id),
         isExistingProvider: this.isExistingProvider(this._search.provider),
         showMakeDefault: this._search.provider !== this.currentDefaultProvider,
-        emptyData: $.isEmptyObject(data) && !state.showHome,
+        showDataError: $.isEmptyObject(data) && !state.showHome,
         showFilters: data.options,
         ...state,
         ...this._search.provider,

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -450,14 +450,14 @@ export default class extends baseVw {
   }
 
   clickSearchBtn() {
-    this.setSearch({ q: this.getCachedEl('.js-searchInput').val(), p: 0 });
+    this.setSearch({ q: this.getCachedEl('.js-searchInput').val(), p: 0 }, { force: true });
     recordEvent('Discover_ClickSearch');
     recordEvent('Discover_Search', { type: 'click' });
   }
 
   onKeyupSearchInput(e) {
     if (e.which === 13) {
-      this.setSearch({ q: this.getCachedEl('.js-searchInput').val(), p: 0 });
+      this.setSearch({ q: this.getCachedEl('.js-searchInput').val(), p: 0 }, { force: true });
       recordEvent('Discover_EnterKeySearch');
       recordEvent('Discover_Search', { type: 'enterKey' });
     }

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -545,13 +545,14 @@ export default class extends baseVw {
     this.$('.js-suggestions').append(this.suggestions.render().el);
 
     this.categoryViews.forEach(cat => cat.remove());
+    if (this.filters) this.filters.remove();
+    if (this.sortBy) this.sortBy.remove();
 
     if (state.showHome) {
       // Create a disposable copy to be shifted by the addNextCategory function.
       this._categorySearchesToAdd = [...this._categorySearches];
       this.addNextCategory();
     } else {
-      if (this.filters) this.filters.remove();
       if (hasFilters) {
         this.filters = this.createChild(Filters, { initialState: { filters: data.options } });
         this.listenTo(this.filters, 'filterChanged', opts => this.onFilterChanged(opts));
@@ -564,7 +565,6 @@ export default class extends baseVw {
         });
       }
 
-      if (this.sortBy) this.sortBy.remove();
       if (data.sortBy) {
         this.sortBy = this.createChild(SortBy, {
           initialState: {

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -395,6 +395,7 @@ export default class extends baseVw {
     if (this.categoryViews.length === this._categorySearches.length) {
       app.router.navigate('search/home');
       this._search.provider = app.searchProviders.at(0);
+      scrollPageIntoView();
       // The state may not be changed here, so always fire a render.
       this.setState({ tab: 'home' }, { renderOnChange: false });
       this.render();

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -211,6 +211,7 @@ export default class extends baseVw {
 
     if (!_.isEqual(this._search, newSearch)) {
       this._search = newSearch;
+      scrollPageIntoView();
       this.fetchSearch(this._search);
     }
   }
@@ -397,7 +398,6 @@ export default class extends baseVw {
     this.getCachedEl('.js-categoryWrapper').append(categoryVw.render().el);
 
     this.listenTo(categoryVw, 'seeAllCategory', (opts) => {
-      scrollPageIntoView();
       this.setSearch(opts);
     });
     this.listenTo(categoryVw, 'fetchComplete', () => this.addNextCategory());

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -516,7 +516,7 @@ export default class extends baseVw {
         isExistingProvider: this.isExistingProvider(this._search.provider),
         showMakeDefault: this._search.provider !== this.currentDefaultProvider,
         showDataError: $.isEmptyObject(data) && !state.showHome,
-        showFilters: data.options,
+        showFilters: data.options && !$.isEmptyObject(data),
         ...state,
         ...data,
       }));

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -123,11 +123,12 @@ export default class extends baseVw {
           this._search.provider = new ProviderMd();
           /*
              We don't actually know what type of search the url is for, we'll assume for example a
-             tor user is only pasting in a tor url. If there is a mismatch, the correct values
-             will be saved after the endpoint returns them.
+             user in tor mode is only pasting in a tor url. If there is a mismatch, the correct
+             values will be saved after the endpoint returns them.
            */
           this._search.provider.set(`${this.onTor ? 'tor' : ''}${this._search.searchType}`, base);
           if (!this._search.provider.isValid()) {
+            // TODO show a message to the user.
             this._search.provider = app.searchProviders.at(0);
             recordEvent('Discover_InvalidQueryProvider', { url: base });
           }
@@ -330,7 +331,7 @@ export default class extends baseVw {
   /**
    * This will activate a provider. If no default is set, the activated provider will be set as the
    * the default. If the user is currently in Tor mode, the default Tor provider will be set.
-   * @param md the search provider model
+   * @param {object} md - the search provider model
    */
   activateProvider(md) {
     if (!md || !(md instanceof ProviderMd)) {
@@ -551,7 +552,7 @@ export default class extends baseVw {
     this.searchProviders = this.createChild(Providers, {
       searchType: this._search.searchType,
       currentID: this._search.provider.id,
-      selecting: !this.currentDefaultProvider,
+      showSelectDefault: !this.currentDefaultProvider,
     });
     this.listenTo(this.searchProviders, 'activateProvider', pOpts => this.activateProvider(pOpts));
     this.$('.js-searchProviders').append(this.searchProviders.render().el);

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -196,8 +196,7 @@ export default class extends baseVw {
   }
 
   providerIsADefault(id) {
-    // Non-default providers probably don't have an id, especially if they don't return a name.
-    return id && !!_.findWhere(defaultSearchProviders, { id });
+    return !!_.findWhere(defaultSearchProviders, { id });
   }
 
   /** Updates the search object. If updated, triggers a search fetch.

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -31,6 +31,7 @@ export default class extends baseVw {
       initialState: {
         fetching: false,
         showHome: false,
+        xhr: null,
         ...options.initialState,
       },
       ...options,
@@ -270,7 +271,7 @@ export default class extends baseVw {
     this.setState({
       showHome: false,
       fetching: true,
-      xhr: '',
+      xhr: null,
     });
 
     const searchFetch = $.get({
@@ -298,7 +299,7 @@ export default class extends baseVw {
         } else {
           this.setState({
             fetching: false,
-            data: '',
+            data: {},
             xhr,
           });
         }
@@ -307,7 +308,7 @@ export default class extends baseVw {
         if (xhr.statusText !== 'abort') {
           this.setState({
             fetching: false,
-            data: '',
+            data: {},
             xhr,
           });
         }
@@ -441,7 +442,7 @@ export default class extends baseVw {
     this.listenTo(this.resultsView, 'searchError', xhr => {
       this.setState({
         fetching: false,
-        data: '',
+        data: {},
         xhr,
       });
     });

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -37,7 +37,6 @@ export default class extends baseVw {
     };
 
     super(opts);
-    this.options = opts;
     const queryKeys = ['q', 'p', 'ps', 'sortBy', 'network'];
 
     this._defaultSearch = {

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -196,6 +196,9 @@ export default class extends baseVw {
   }
 
   providerIsADefault(id) {
+    if (!id || !(typeof id === 'string')) {
+      throw new Error('Please provide a valid provider ID.');
+    }
     return !!_.findWhere(defaultSearchProviders, { id });
   }
 

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -127,7 +127,8 @@ export default class extends baseVw {
            user in tor mode is only pasting in a tor url. If there is a mismatch, the correct
            values will be saved after the endpoint returns them.
            */
-          this._search.provider.set(`${getCurConnTor() ? 'tor' : ''}${this._search.searchType}`, base);
+          const searchAttribute = `${getCurConnTor() ? 'tor' : ''}${this._search.searchType}`;
+          this._search.provider.set(searchAttribute, base);
           if (!this._search.provider.isValid()) {
             openSimpleMessage(app.polyglot.t('search.errors.invalidUrl'));
             this._search.provider = app.searchProviders.at(0);

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -150,7 +150,7 @@ export default class extends baseVw {
     } else {
       // If the user has OB1 set as default, show the Discover default UX. If they don't, show a
       // default search using their default provider.
-      if (this.usingOriginal) {
+      if (this._search.provider.id === defaultSearchProviders[0].id) {
         this.setState({ showHome: true });
       } else {
         this.fetchSearch(this._search);
@@ -193,10 +193,6 @@ export default class extends baseVw {
 
   get currentBaseUrl() {
     return this._search.provider[`${this._search.searchType}Url`];
-  }
-
-  get usingOriginal() {
-    return this._search.provider.id === defaultSearchProviders[0].id;
   }
 
   providerIsADefault(id) {

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -18,7 +18,7 @@ import defaultSearchProviders from '../../data/defaultSearchProviders';
 import { selectEmojis } from '../../utils';
 import loadTemplate from '../../utils/loadTemplate';
 import { recordEvent } from '../../utils/metrics';
-import { getCurrentConnection } from '../../utils/serverConnect';
+import { getCurConnTor } from '../../utils/serverConnect';
 import { scrollPageIntoView } from '../../utils/dom';
 import {
   searchTypes,
@@ -100,7 +100,6 @@ export default class extends baseVw {
 
     this.categoryViews = [];
     this.searchFetches = [];
-    this.onTor = app.serverConfig.tor && getCurrentConnection().server.get('useTor');
 
     // If a query was passed in from the router, extract the data from it.
     if (options.query) {
@@ -128,7 +127,7 @@ export default class extends baseVw {
            user in tor mode is only pasting in a tor url. If there is a mismatch, the correct
            values will be saved after the endpoint returns them.
            */
-          this._search.provider.set(`${this.onTor ? 'tor' : ''}${this._search.searchType}`, base);
+          this._search.provider.set(`${getCurConnTor() ? 'tor' : ''}${this._search.searchType}`, base);
           if (!this._search.provider.isValid()) {
             openSimpleMessage(app.polyglot.t('search.errors.invalidUrl'));
             this._search.provider = app.searchProviders.at(0);
@@ -192,7 +191,7 @@ export default class extends baseVw {
       throw new Error('Please provide a search provider model.');
     }
 
-    app.searchProviders[`default${this.onTor ? 'Tor' : ''}Provider`] = md;
+    app.searchProviders[`default${getCurConnTor() ? 'Tor' : ''}Provider`] = md;
   }
 
   get currentBaseUrl() {

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -23,7 +23,6 @@ import { scrollPageIntoView } from '../../utils/dom';
 import {
   searchTypes,
   createSearchURL,
-  sanitizeResults,
 } from '../../utils/search';
 
 export default class extends baseVw {
@@ -281,9 +280,7 @@ export default class extends baseVw {
       url: createSearchURL(opts),
       dataType: 'json',
     })
-      .done((pData, status, xhr) => {
-        const data = JSON.parse(sanitizeResults(pData));
-
+      .done((data, status, xhr) => {
         // make sure minimal data is present. If it isn't, it's probably an invalid endpoint.
         if (data.name && data.links) {
           const dataUpdate = this.buildProviderUpdate(data);

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -340,10 +340,6 @@ export default class extends baseVw {
     }
   }
 
-  resetSearch() {
-    this.setSearch(this._defaultSearch);
-  }
-
   clickDeleteProvider() {
     recordEvent('Discover_DeleteProvider', {
       provider: this._search.provider.get('name') || 'unknown',
@@ -448,7 +444,7 @@ export default class extends baseVw {
       });
     });
     this.listenTo(this.resultsView, 'loadingPage', () => scrollPageIntoView());
-    this.listenTo(this.resultsView, 'resetSearch', () => this.resetSearch());
+    this.listenTo(this.resultsView, 'resetSearch', () => this.setSearch(this._defaultSearch));
   }
 
   clickSearchBtn() {

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -333,13 +333,8 @@ export default class extends baseVw {
   }
 
   deleteProvider(md = this._search.provider) {
-    if (this.providerIsADefault(md.id)) {
-      openSimpleMessage(app.polyglot.t('search.errors.locked'));
-      recordEvent('Discover_DeleteLocked', {
-        provider: md.get('name') || 'unknown',
-        url: md.listingsUrl,
-      });
-    } else {
+    // Default providers shouldn't show an option to trigger this.
+    if (!this.providerIsADefault(md.id)) {
       md.destroy();
       if (app.searchProviders.length) this.activateProvider(app.searchProviders.at(0));
     }

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -434,7 +434,7 @@ export default class extends baseVw {
       total: data.results ? data.results.total : 0,
       provider: this._search.provider.get('name') || 'unknown',
       url: this.currentBaseUrl,
-      page: this._search.page + 1,
+      page: this._search.p + 1,
     });
 
     this.getCachedEl('.js-resultsWrapper').html(this.resultsView.render().el);

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -399,7 +399,7 @@ export default class extends baseVw {
 
     if (this.categoryViews.length === this._categorySearches.length) {
       app.router.navigate('search/home');
-      this._search.provider = app.searchProviders.at(0);
+      this._search = { ...this._defaultSearch, provider: app.searchProviders.at(0) };
       scrollPageIntoView();
       // The state may not be changed here, so always fire a render.
       this.setState({ tab: 'home' }, { renderOnChange: false });

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -565,18 +565,16 @@ export default class extends baseVw {
         });
       }
 
-      if (data.sortBy) {
-        this.sortBy = this.createChild(SortBy, {
-          initialState: {
-            term,
-            results: data.results,
-            sortBy: data.sortBy,
-            sortBySelected: this._search.sortBy,
-          },
-        });
-        this.listenTo(this.sortBy, 'changeSortBy', opts => this.changeSortBy(opts));
-        this.$('.js-sortByWrapper').append(this.sortBy.render().el);
-      }
+      this.sortBy = this.createChild(SortBy, {
+        initialState: {
+          term,
+          results: data.results,
+          sortBy: data.sortBy,
+          sortBySelected: this._search.sortBy,
+        },
+      });
+      this.listenTo(this.sortBy, 'changeSortBy', opts => this.changeSortBy(opts));
+      this.$('.js-sortByWrapper').append(this.sortBy.render().el);
 
       // use the initial set of results data to create the results view
       this.createResults(data, this._search);

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -37,7 +37,7 @@ export default class extends baseVw {
     };
 
     super(opts);
-    const queryKeys = ['q', 'p', 'ps', 'sortBy', 'network'];
+    const queryKeys = ['q', 'p', 'ps', 'sortBy'];
 
     this._defaultSearch = {
       q: '*',

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -144,13 +144,7 @@ export default class extends baseVw {
       }
 
       // set the params in the search object
-      const filters = _.omit(params, [...queryKeys]);
-
-      // if the  provider returns a bad URL, change to a known good default provider
-      if (is.not.url(this.currentBaseUrl)) {
-        this._search.provider = app.searchProviders.at(0);
-        recordEvent('Discover_InvalidDefaultProvider', { url: this.currentBaseUrl });
-      }
+      const filters = { ...this._search.filters, ..._.omit(params, [...queryKeys]) };
 
       this.setSearch({ ..._.pick(params, ...queryKeys), filters });
     } else {

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -59,7 +59,7 @@ export default class extends baseVw {
     if (!this.currentDefaultProvider && app.searchProviders.length === 1) {
       this.currentDefaultProvider = app.searchProviders.at(0);
     }
-    this._search.provider = this.currentDefaultProvider;
+    this._search.provider = this.currentDefaultProvider || app.searchProviders.at(0);
 
     this._categoryTerms = [
       'Art',

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -30,7 +30,7 @@ export default class extends baseVw {
     const opts = {
       initialState: {
         fetching: false,
-        showHome: false,
+        tab: 'listings',
         xhr: null,
         ...options.initialState,
       },
@@ -149,7 +149,8 @@ export default class extends baseVw {
 
       this.setSearch({ ..._.pick(params, ...queryKeys), filters }, { force: true });
     } else {
-      if (this._search.provider.id === defaultSearchProviders[0].id && this.getState().showHome) {
+      if (this._search.provider.id === defaultSearchProviders[0].id &&
+        this.getState().tab === 'home') {
         this.buildCategories();
       } else {
         this.setSearch({}, { force: true });
@@ -266,7 +267,7 @@ export default class extends baseVw {
     this.removeFetches();
 
     this.setState({
-      showHome: false,
+      tab: 'listings',
       fetching: true,
       xhr: null,
     });
@@ -395,7 +396,7 @@ export default class extends baseVw {
       app.router.navigate('search/home');
       this._search.provider = app.searchProviders.at(0);
       // The state may not be changed here, so always fire a render.
-      this.setState({ showHome: true }, { renderOnChange: false });
+      this.setState({ tab: 'home' }, { renderOnChange: false });
       this.render();
       return;
     }
@@ -539,7 +540,7 @@ export default class extends baseVw {
         providerLocked: this.providerIsADefault(this._search.provider.id),
         isExistingProvider: this.isExistingProvider(this._search.provider),
         showMakeDefault: this._search.provider !== this.currentDefaultProvider,
-        showDataError: $.isEmptyObject(data) && !state.showHome,
+        showDataError: $.isEmptyObject(data) && state.tab === 'listings',
         hasFilters,
         ...state,
         ...data,
@@ -570,9 +571,9 @@ export default class extends baseVw {
     if (this.filters) this.filters.remove();
     if (this.sortBy) this.sortBy.remove();
 
-    if (state.showHome) {
+    if (state.tab === 'home') {
       this.renderCategories();
-    } else {
+    } else if (state.tab === 'listings') {
       if (hasFilters) {
         this.filters = this.createChild(Filters, { initialState: { filters: data.options } });
         this.listenTo(this.filters, 'filterChanged', opts => this.onFilterChanged(opts));

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -168,7 +168,7 @@ export default class extends baseVw {
       'keyup .js-searchInput': 'onKeyupSearchInput',
       'click .js-deleteProvider': 'clickDeleteProvider',
       'click .js-makeDefaultProvider': 'clickMakeDefaultProvider',
-      'click .js-addQueryProvider': 'clickAddProvider',
+      'click .js-addQueryProvider': 'clickAddQueryProvider',
     };
   }
 
@@ -349,6 +349,9 @@ export default class extends baseVw {
   }
 
   makeDefaultProvider(md) {
+    if (!md || !(md instanceof ProviderMd)) {
+      throw new Error('Please provide a search provider model.');
+    }
     if (app.searchProviders.indexOf(md) === -1) {
       throw new Error('The provider to be made the default must be in the collection.');
     }
@@ -358,22 +361,22 @@ export default class extends baseVw {
   }
 
   clickMakeDefaultProvider() {
-    this.makeDefaultProvider(this._search.provider);
     recordEvent('Discover_MakeDefaultProvider', {
       provider: this._search.provider.get('name') || 'unknown',
       url: this.currentBaseUrl,
     });
+    this.makeDefaultProvider(this._search.provider);
   }
 
-  addProvider() {
+  addQueryProvider() {
     if (!this.isExistingProvider(this._search.provider)) {
       app.searchProviders.add(this._search.provider);
       this.render();
     }
   }
 
-  clickAddProvider() {
-    this.addProvider();
+  clickAddQueryProvider() {
+    this.addQueryProvider();
   }
 
   /**

--- a/js/views/search/SearchProviders.js
+++ b/js/views/search/SearchProviders.js
@@ -62,7 +62,7 @@ export default class extends BaseView {
     const view = this.createChild(Provider, {
       model,
       active: this.options.currentID === model.id,
-      selecting: this.options.selecting,
+      showSelectDefault: this.options.showSelectDefault,
     });
 
     this.listenTo(view, 'click', (md) => {

--- a/js/views/search/SearchProviders.js
+++ b/js/views/search/SearchProviders.js
@@ -1,7 +1,6 @@
 import app from '../../app';
 import loadTemplate from '../../utils/loadTemplate';
 import { recordEvent } from '../../utils/metrics';
-import { getCurrentConnection } from '../../utils/serverConnect';
 import { searchTypes } from '../../utils/search';
 import BaseView from '../baseVw';
 import Provider from './SearchProvider';
@@ -86,14 +85,11 @@ export default class extends BaseView {
 
       const providerFrag = document.createDocumentFragment();
 
-      const usingTor = app.serverConfig.tor && getCurrentConnection().server.get('useTor');
-
       app.searchProviders.forEach(provider => {
         const view = this.createProviderView(provider);
         if (view) {
           this.providerViews.push(view);
-          if (provider.get(`${usingTor ? 'tor' : ''}${this.options.searchType}`)) {
-            // if the provider is the wrong type, don't add it to the DOM
+          if (provider.get(this.options.searchType)) {
             view.render().$el.appendTo(providerFrag);
           }
         }

--- a/js/views/search/SortBy.js
+++ b/js/views/search/SortBy.js
@@ -37,8 +37,7 @@ export default class extends baseVw {
         ...this.getState(),
       }));
 
-      this.$sortBy = this.$('#sortBy');
-      this.$sortBy.select2({
+      this.$('#sortBy').select2({
         minimumResultsForSearch: Infinity, // disables the search box
         templateResult: selectEmojis,
         templateSelection: selectEmojis,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6643,7 +6643,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -6663,7 +6663,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {

--- a/styles/components/_listingsGrid.scss
+++ b/styles/components/_listingsGrid.scss
@@ -2,12 +2,20 @@
    the store and search results views. Make sure to check both when making changes to this file.
  */
 
+/* These are the values to use if the inventory column is turned back on.
 $crytoListViewTradeFromWidth: 9%;
 $crytoListViewTradeToWidth: 16%;
 $crytoListViewTradeArrowWidth: 7%;
 $crytoListViewVendorWidth: 28%;
 $crytoListViewPriceWidth: 19%;
 $crytoListViewInventoryMaxWidth: 21%;
+*/
+
+$crytoListViewTradeFromWidth: 10%;
+$crytoListViewTradeArrowWidth: 5%;
+$crytoListViewTradeToWidth: 15%;
+$crytoListViewVendorWidth: 38%;
+$crytoListViewPriceWidth: 32%;
 
 .listingsGrid {
   flex-wrap: wrap;
@@ -137,9 +145,11 @@ $crytoListViewInventoryMaxWidth: 21%;
       width: $crytoListViewPriceWidth;
     }
 
+    /* Commented out until inventory is working again.
     .inventoryCol {
       width: $crytoListViewInventoryMaxWidth;
     }
+    */
   }
 
   &:empty {
@@ -187,10 +197,12 @@ $crytoListViewInventoryMaxWidth: 21%;
     }
   }
 
+  /* Commented out until inventory is working again.
   .inventoryCol {
     text-align: right;
     max-width: $crytoListViewInventoryMaxWidth;
   }
+  */
 
   .toolTip {
     text-transform: none;

--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -239,6 +239,7 @@
 
     &.searchCategory {
       position: relative;
+      margin-top: 50px;
 
       .cryptoListViewHeader {
         padding: 15px 30px;
@@ -248,6 +249,14 @@
       .listingsGrid.listingsGridCryptoListView  .listingCard {
         padding: 6px 30px;
         font-size: 1.6rem;
+      }
+
+      &:first-child {
+        margin-top: 20px;
+      }
+
+      &:last-child .categoryRow {
+        display: none;
       }
     }
   }

--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -50,7 +50,7 @@
 
           .providerBtn {
             padding: 0;
-            
+
             &:focus, &:hover {
               outline: none;
             }
@@ -206,15 +206,11 @@
     }
 
     .loadingSearch {
-      display: none;
-    }
-
-    &.loading .loadingSearch {
       display: flex;
 
       .spinner {
         position: absolute;
-        top: calc(50% - #{$spinnerLg/2});
+        top: calc(25% - #{$spinnerLg/2});
       }
 
       .listingsGrid {

--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -50,6 +50,10 @@
 
           .providerBtn {
             padding: 0;
+            
+            &:focus, &:hover {
+              outline: none;
+            }
 
             .providerInner {
               opacity: .35;

--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -55,7 +55,7 @@
               opacity: .35;
             }
 
-            &.selecting .providerInner {
+            &.showSelectDefault .providerInner {
               opacity: 1;
             }
           }


### PR DESCRIPTION
This is a pretty extensive rework and refactor of the discover section. The main change was to create a category-based initial experience similar to the one on openbazaar.com.

To see the category view, click on the discover button. If OB1 is your default provider, you will see a set of categories. If a different provider is your default, you're shown a blank search, since we can't know if they support the same search parameters (for instance, a type filter for cryptocurrency listings, which is needed for the Trade category).

The filters and sortBy bar have been broken out into their own views/templates, to make it easier to add them conditionally. If a provider doesn't provide filters, the filter column won't be shown and the results will fill the space instead (the last row will have 2 results instead of 4, but we have to send the page size parameter before we find out the endpoint doesn't return filters).

A simple search object was added that holds all the data needed to make a search call, to make it easier to keep the data passed to different modules consistent. It works similarly to a state object when it's in the main search view, updating it will trigger a search fetch.

Closes #1730
Closes #1728