### PR TITLE
Non tor search fallback

### DIFF
--- a/js/collections/search/SearchProviders.js
+++ b/js/collections/search/SearchProviders.js
@@ -1,8 +1,10 @@
 import { Collection } from 'backbone';
 import is from 'is_js';
+import app from '../../app';
+import Provider from '../../models/search/SearchProvider';
 import LocalStorageSync from '../../utils/lib/backboneLocalStorage';
 import { sanitizeResults } from '../../utils/search';
-import Provider from '../../models/search/SearchProvider';
+import { getCurrentConnection } from '../../utils/serverConnect';
 
 /**
  * Returns the URL minus any query parameters.
@@ -39,12 +41,13 @@ export default class extends Collection {
     return 8;
   }
 
-  get defaultProvider() {
-    return this.get(this._defaultId);
+  get tor() {
+    return app.serverConfig.tor && getCurrentConnection().server.get('useTor') ? 'Tor' : '';
   }
 
-  get defaultTorProvider() {
-    return this.get(this._defaultTorId);
+  get defaultProvider() {
+    // Fall back to the clearnet endpoint if no Tor endpoint exists.
+    return this.get(this[`_default${this.tor}Id`]) || this.get(this._defaultId);
   }
 
   set defaultProvider(md) {

--- a/js/models/search/SearchProvider.js
+++ b/js/models/search/SearchProvider.js
@@ -56,7 +56,7 @@ export default class extends BaseModel {
       errObj[fieldName].push(error);
     };
     const urlTypes = options.urlTypes ||
-      ['vendors', 'listings', 'torvendors', 'torlistings', 'reports', 'torReports'];
+      ['listings', 'torlistings', 'vendors', 'torvendors', 'reports', 'torReports'];
 
     if (attrs.name && is.not.string(attrs.name)) {
       addError('name', app.polyglot.t('searchProviderModelErrors.invalidName'));

--- a/js/models/search/SearchProvider.js
+++ b/js/models/search/SearchProvider.js
@@ -26,20 +26,23 @@ export default class extends BaseModel {
     return LocalStorageSync.sync.apply(this, args);
   }
 
-  get usingTor() {
-    return app.serverConfig.tor && getCurrentConnection().server.get('useTor');
+  get tor() {
+    return app.serverConfig.tor && getCurrentConnection().server.get('useTor') ? 'tor' : '';
   }
 
   get listingsUrl() {
-    return this.get(`${this.usingTor ? 'tor' : ''}listings`);
+    // Fall back to clear endpoint on tor if no tor endpoint exists.
+    return this.get(`${this.tor}listings`) || this.get('listings');
   }
 
   get vendorsUrl() {
-    return this.get(`${this.usingTor ? 'tor' : ''}vendors`);
+    // Fall back to clear endpoint on tor if no tor endpoint exists.
+    return this.get(`${this.tor}vendors`) || this.get('vendors');
   }
 
   get reportsUrl() {
-    return this.get(`${this.usingTor ? 'tor' : ''}reports`);
+    // Fall back to clear endpoint on tor if no tor endpoint exists.
+    return this.get(`${this.tor}reports`) || this.get('reports');
   }
 
   validate(attrs, options) {
@@ -48,7 +51,8 @@ export default class extends BaseModel {
       errObj[fieldName] = errObj[fieldName] || [];
       errObj[fieldName].push(error);
     };
-    const urlTypes = options.urlTypes || ['vendors', 'listings', 'torvendors', 'torlistings'];
+    const urlTypes = options.urlTypes ||
+      ['vendors', 'listings', 'torvendors', 'torlistings', 'reports', 'torReports'];
 
     if (attrs.name && is.not.string(attrs.name)) {
       addError('name', app.polyglot.t('searchProviderModelErrors.invalidName'));

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -180,7 +180,7 @@ export default class extends baseVw {
   }
 
   get currentDefaultProvider() {
-    return app.searchProviders[`default${this.onTor ? 'Tor' : ''}Provider`];
+    return app.searchProviders.defaultProvider;
   }
 
   set currentDefaultProvider(md) {

--- a/js/views/search/SearchProviders.js
+++ b/js/views/search/SearchProviders.js
@@ -1,7 +1,6 @@
 import app from '../../app';
 import loadTemplate from '../../utils/loadTemplate';
 import { recordEvent } from '../../utils/metrics';
-import { getCurrentConnection } from '../../utils/serverConnect';
 import { searchTypes } from '../../utils/search';
 import BaseView from '../baseVw';
 import Provider from './SearchProvider';
@@ -86,14 +85,11 @@ export default class extends BaseView {
 
       const providerFrag = document.createDocumentFragment();
 
-      const usingTor = app.serverConfig.tor && getCurrentConnection().server.get('useTor');
-
       app.searchProviders.forEach(provider => {
         const view = this.createProviderView(provider);
         if (view) {
           this.providerViews.push(view);
-          if (provider.get(`${usingTor ? 'tor' : ''}${this.options.searchType}`)) {
-            // if the provider is the wrong type, don't add it to the DOM
+          if (provider.get(this.options.searchType)) {
             view.render().$el.appendTo(providerFrag);
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6643,7 +6643,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -6663,7 +6663,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {


### PR DESCRIPTION
This allows the search to fall back to the clear endpoint of a search provider when in Tor mode if no specific Tor endpoint exists.

This is still secure, since the traffic is sent through Tor, the Tor endpoints are only for providers behind Cloudflare or simile CDNs that require a special endpoint for Tor requests.