### PR TITLE
Handle Missing Avatar Images

### DIFF
--- a/js/utils/responsive.js
+++ b/js/utils/responsive.js
@@ -18,9 +18,9 @@ function getBackgroundImage(imageHashes = {}, standardSize, responsiveSize, defa
   let imageHash = '';
   let bgImageProperty = '';
 
-  if (isHiRez() && imageHashes[responsiveSize]) {
+  if (isHiRez() && imageHashes && imageHashes[responsiveSize]) {
     imageHash = imageHashes[responsiveSize];
-  } else if (imageHashes[standardSize]) {
+  } else if (imageHashes && imageHashes[standardSize]) {
     imageHash = imageHashes[standardSize];
   }
 


### PR DESCRIPTION
In some cases search results were passing "null" as the `avatarHashes` value to the loading and listing views, which would cause an unhandled exception in responsive.js.

This adds a check, so the default image will be used if null is passed in for the avatarHashes object.