### PR TITLE
don't wipe out query params

### DIFF
--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -112,7 +112,7 @@ export default class extends baseVw {
       // If the query had a providerQ parameter, use that as the provider URL instead.
       if (queryParams.get('providerQ')) {
         const subURL = new URL(queryParams.get('providerQ'));
-        queryParams.delete('providerQ')
+        queryParams.delete('providerQ');
         // The first parameter after the ? will be part of the providerQ, transfer it over.
         for (const param of subURL.searchParams.entries()) {
           queryParams.append(param[0], param[1]);

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -107,12 +107,16 @@ export default class extends baseVw {
       recordEvent('Discover_SearchFromAddressBar');
       recordEvent('Discover_Search', { type: 'addressBar' });
 
-      let queryParams = (new URL(`${this.currentBaseUrl}?${options.query}`)).searchParams;
+      const queryParams = (new URL(`${this.currentBaseUrl}?${options.query}`)).searchParams;
 
       // If the query had a providerQ parameter, use that as the provider URL instead.
       if (queryParams.get('providerQ')) {
         const subURL = new URL(queryParams.get('providerQ'));
-        queryParams = subURL.searchParams;
+        queryParams.delete('providerQ')
+        // The first parameter after the ? will be part of the providerQ, transfer it over.
+        for (const param of subURL.searchParams.entries()) {
+          queryParams.append(param[0], param[1]);
+        }
         const base = `${subURL.origin}${subURL.pathname}`;
         /*
          If the query provider model doesn't already exist, create a new provider model for it.


### PR DESCRIPTION
When a providerQ was passed in, the query parameters were being replaced with only the first parameter in the providerQ. None of the parameters after it were maintained.

This PR fixes that so the old parameters are kept, and the one attached to the providerQ is also kept (ie: `providerQ=https%3A%2F%2Fsearch.ob1.io%2Flistings%2Fsearch%3Fq%3DMusic` is providerQ=https://search.ob1.io/listings/search?q=Music, the q=music is part of the providerQ parameter and is extracted and added to the other parameters).