### PR TITLE
Always use OB1 for Categories

### DIFF
--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -82,11 +82,12 @@ export default class extends baseVw {
 
     this._categorySearch = {
       ...this._search,
+      provider: app.searchProviders.at(0),
       ps: 8,
     };
 
     this._cryptoSearch = {
-      ...this._search,
+      ...this._categorySearch,
       ps: 5,
       filters: {
         type: 'cryptocurrency',


### PR DESCRIPTION
This makes sure the OB1 endpoint is always used for category fetches.

It was possible to set a different endpoint as the default, which would then put it into the search object used by the categories in the constructor. If that non-OB1 endpoint didn't use the same search parameters (and the one I ran into didn't), the results can be ugly, in this case the page size was ignored so each category had 50 results.

Closes #1767 
