### PR TITLE
Fix Test Failing Because of Space

### DIFF
--- a/test/utils/currency.js
+++ b/test/utils/currency.js
@@ -108,7 +108,7 @@ describe('the currency utility module', () => {
         'the resulting value', () => {
         expect(cur.convertAndFormatCurrency(500, 'USD', 'PLN', { locale: 'en-US' }))
           .to
-          .equal('PLN2,097.31');
+          .equal('PLN\xa02,097.31');
       });
 
       it('which will convert between a fiat currency and BTC and properly localize ' +


### PR DESCRIPTION
The international formatting is adding a non-breaking space, which breaks a test. This will fix it by checking against the non-breaking space character code.

See https://stackoverflow.com/questions/54242039/intl-numberformat-space-character-does-not-match