### PR TITLE
Only Translate Known Conditions

### DIFF
--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -175,7 +175,7 @@
             </div>
           <% } else if (ob.metadata.contractType === 'PHYSICAL_GOOD') { %>
             <div>
-              <%= ob.polyT('listingDetail.condition', { condition: `<b>${ob.item.condition}</b>` }) %>
+              <%= ob.polyT('listingDetail.condition', { condition: `<b>${ob.polyT(`conditionTypes.${ob.item.condition.toUpperCase()}`, { _: ob.item.condition })}</b>` }) %>
             </div>
           <% } %>
         </div>

--- a/js/templates/modals/listingDetail/listing.html
+++ b/js/templates/modals/listingDetail/listing.html
@@ -175,7 +175,7 @@
             </div>
           <% } else if (ob.metadata.contractType === 'PHYSICAL_GOOD') { %>
             <div>
-              <%= ob.polyT('listingDetail.condition', { condition: `<b>${ob.polyT(`conditionTypes.${ob.item.condition.toUpperCase()}`)}</b>` }) %>
+              <%= ob.polyT('listingDetail.condition', { condition: `<b>${ob.item.condition}</b>` }) %>
             </div>
           <% } %>
         </div>

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -742,12 +742,6 @@ export default class extends BaseModal {
     loadTemplate('modals/listingDetail/listing.html', t => {
       const flatModel = this.model.toJSON();
 
-      // translate recognised conditions, leave unknown conditions as-is.
-      if (this.model.get('item').conditionTypes.includes(flatModel.item.condition)) {
-        flatModel.item.condition =
-          app.polyglot.t(`conditionTypes.${flatModel.item.condition.toUpperCase()}`);
-      }
-
       this.$el.html(t({
         ...flatModel,
         shipsFreeToMe: this.shipsFreeToMe,

--- a/js/views/modals/listingDetail/Listing.js
+++ b/js/views/modals/listingDetail/Listing.js
@@ -742,6 +742,12 @@ export default class extends BaseModal {
     loadTemplate('modals/listingDetail/listing.html', t => {
       const flatModel = this.model.toJSON();
 
+      // translate recognised conditions, leave unknown conditions as-is.
+      if (this.model.get('item').conditionTypes.includes(flatModel.item.condition)) {
+        flatModel.item.condition =
+          app.polyglot.t(`conditionTypes.${flatModel.item.condition.toUpperCase()}`);
+      }
+
       this.$el.html(t({
         ...flatModel,
         shipsFreeToMe: this.shipsFreeToMe,


### PR DESCRIPTION
This PR changes the listing details view so the condition is translated in the render function, and unknown conditions are not translated. That allows it to handle listings with conditions that don't match our expected list. I think it's better for users to see the value directly from the data vs. "conditionTypes.SOMETHINGINCAPS".

Closes #1785