### PR TITLE
Reset Type Filter on Suggestion Click

### DIFF
--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -504,7 +504,7 @@ export default class extends baseVw {
   }
 
   onClickSuggestion(opts) {
-    this.setSearch({ q: opts.suggestion, p: 0 });
+    this.setSearch({ q: opts.suggestion, p: 0, filters: { type: 'all' } });
     recordEvent('Discover_ClickSuggestion');
     recordEvent('Discover_Search', { type: 'suggestion' });
   }


### PR DESCRIPTION
This will reset the type filter when a suggestion is clicked. Previously if you clicked the See All button for the Cryptocurrency category, it would set the filter to Cryptocurrency, and that filter would remain in place when you clicked a suggestion.

(filters not changing is intended, so if you have filtered to show only listings that accept ZEC, for instance, that remains true when you click a suggestion. But if you have filtered for a type, like digital goods, it's reasonable to reset that if you click a suggestion like clothing)

Closes #1782 
