### PR TITLE
Hide Coupons if No Coupons

### DIFF
--- a/js/templates/modals/purchase/purchase.html
+++ b/js/templates/modals/purchase/purchase.html
@@ -196,6 +196,7 @@
             </div>
           </div>
           <div class="col6">
+            <% if (ob.hasCoupons) { %>
             <div class="rowTn">
               <label for="couponCode" class="tx5">
                 <%= ob.polyT('purchase.couponCode') %>
@@ -215,6 +216,7 @@
             <div class="js-couponsWrapper">
               <% // coupons are inserted here after they are added by the user. %>
             </div>
+            <% } %>
           </div>
         </div>
         <hr class="clrBr row">

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -661,7 +661,8 @@ export default class extends BaseModal {
         cryptoAmountCurrency: this.cryptoAmountCurrency,
         isCrypto: this.listing.isCrypto,
         phaseClass: `phase${capitalize(state.phase)}`,
-        hasCoupons: this.listing.get('coupons').length,
+        hasCoupons: this.listing.get('coupons').length &&
+          this.listing.get('metadata').get('contractType') !== 'CRYPTOCURRENCY',
       }));
 
       super.render();

--- a/js/views/modals/purchase/Purchase.js
+++ b/js/views/modals/purchase/Purchase.js
@@ -661,6 +661,7 @@ export default class extends BaseModal {
         cryptoAmountCurrency: this.cryptoAmountCurrency,
         isCrypto: this.listing.isCrypto,
         phaseClass: `phase${capitalize(state.phase)}`,
+        hasCoupons: this.listing.get('coupons').length,
       }));
 
       super.render();


### PR DESCRIPTION
If a listing doesn't have any coupons, there isn't a point in showing the coupon input. It also shouldn't be shown in crypto listings, which don't have coupons.

This will check if coupons are in the listing and if the listing is a non-cryptocurrency contract type, the coupons input will only render if both are true.

Closes #1770