### PR TITLE
Prevent External Link Warning in Selectize

### DIFF
--- a/js/utils/dom.js
+++ b/js/utils/dom.js
@@ -112,6 +112,9 @@ export function handleLinks(el) {
     // Anchor without href is likely being handled programmatically.
     if (!href) return;
 
+    // Ignore javascript:void(0) links such as in selectize's close buttons.
+    if (href.startsWith('javascript')) return;
+
     const link = document.createElement('a');
     link.setAttribute('href', href);
 


### PR DESCRIPTION
Selectize puts a javascript:void(0) href in it's close buttons, which was triggering the Tor external link warning.

This will disregard links that start with javascript.

Closes #1790