### PR TITLE
Show All Short Desc In Home

### DIFF
--- a/styles/modules/_userPage.scss
+++ b/styles/modules/_userPage.scss
@@ -83,8 +83,31 @@
       }
     }
 
-    .userPageHome .aboutBox img {
-      max-width: 100%;
+    .userPageHome {
+
+      .aboutBox img {
+        max-width: 100%;
+      }
+
+      .userCard {
+
+        .contentBox {
+
+          .content {
+            height: auto;
+
+            .contentTop {
+              height: auto;
+              margin-bottom: 10px;
+
+              .userDescription {
+                max-height: none;
+                -webkit-line-clamp: unset;
+              }
+            }
+          }
+        }
+      }
     }
 
     .userPageFollow {


### PR DESCRIPTION
This is a simple tweak to not truncate the height of the user card on the user page home tab, so short descriptions will be shown without being cut off.

Closes #1472 
