### PR TITLE
Css updates for235

### DIFF
--- a/js/templates/modals/settings/store.html
+++ b/js/templates/modals/settings/store.html
@@ -88,16 +88,18 @@
                 <div class="rowLg"><% // just a spacer %></div>
               </div>
               <div class="row">
-                <div class="flexVCentClearMarg tx5 rowTn">
-                  <h5 class="flexExpand"><%= ob.polyT('settings.storeTab.availableModerators') %></h5>
-                  <input type="checkbox" id="storeVerifiedOnly" class="js-storeVerifiedOnly"<% if (ob.showVerifiedOnly) print('checked') %>>
-                  <label class="tx5b" for="storeVerifiedOnly"><%= ob.polyT('settings.storeTab.verifiedOnly') %></label>
+                <div class="tx5 rowTn">
+                  <div class="flexVCentClearMarg">
+                    <h5 class="flexExpand"><%= ob.polyT('settings.storeTab.availableModerators') %></h5>
+                    <input type="checkbox" id="storeVerifiedOnly" class="js-storeVerifiedOnly"<% if (ob.showVerifiedOnly) print('checked') %>>
+                    <label class="tx5b" for="storeVerifiedOnly"><%= ob.polyT('settings.storeTab.verifiedOnly') %></label>
+                  </div>
                 </div>
                 <ul class="unstyled errorList hide js-modListAvailableError">
                   <li><i class="ion-alert-circled"></i><span class="js-modListAvailableErrorText"></span> </li>
                 </ul>
                 <div class="js-modListAvailable"></div>
-                <div class="noModsAdded clrBr flexCent <% if (ob.modsAvailable.length) print('hide') %> js-noModsAdded">
+                <div class="noModsAdded flex clrBr <% if (ob.modsAvailable.length) print('hide') %> js-noModsAdded">
                   <button class="btn clrP clrBr browseMods js-browseMods">
                      <%= ob.polyT('settings.storeTab.browseModerators') %>
                   </button>

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -236,7 +236,7 @@ svg {
     height: calc(100% - #{$bar + $barLg});
     box-sizing: border-box;
     z-index: 2; // chat needs to be on top of modals
-    @include chatOpeningTransition(width, background-color, border-color, height);
+    @include chatOpeningTransition(width, background-color, height);
     overflow-y: auto;
     overflow-x: hidden;
     background-color: transparent;

--- a/styles/modules/modals/_settings.scss
+++ b/styles/modules/modals/_settings.scss
@@ -120,6 +120,8 @@
        min-height: 175px;
        border-width: 1px;
        border-style: solid;
+       align-items: center;
+       justify-content: center;
      }
 
     .bulkCoinUpdateBtn .confirmBox {


### PR DESCRIPTION
This fixes three visual bugs:

1. the vertical spacing on the load moderators section of settings.store was way too big. A div inside a flex container was set to 100% height, which picked up the height of the entire container. That was an error, my guess is it worked before due to a bug in Chromium that was fixed in an Electron update.

2. the placeholder box with the load mods button was getting a height that pushed it outside the bottom of its container into the next div, probably due to the same change in Chromium. It was tweaked and no longer overlaps the text below it.

3. when the app was loading, the chat container would briefly have a black border. This was happening because the container border color was set to transparent, with a transition, so it could become grey when it opened. 

Again, probably due to a Chromium update, the browser behavior changed and the transition was being applied to the default border color of black. I'm not sure why it would do that, it might be a Chromium bug. Removing the transition (which is barely noticeable when it changes from transparent to grey) was the simplest solution.