### PR TITLE
Fix Mismatch with Notification Types

### DIFF
--- a/js/collections/Notifications.js
+++ b/js/collections/Notifications.js
@@ -77,7 +77,8 @@ export function getNotifDisplayData(attrs, options = {}) {
     text = app.polyglot.t('notifications.text.orderConfirmation', {
       vendorName,
     });
-  } else if (attrs.type === 'orderDeclined') {
+    // Check for the new 'orderDeclined' value, but maintain compatibility with older notifications.
+  } else if (attrs.type === 'orderDeclined' || attrs.type === 'declined') {
     const vendorName = opts.native ?
       getName(attrs.vendorHandle, attrs.vendorId) :
       `<a class="clrTEm" href="#${attrs.vendorId}">` +
@@ -86,7 +87,8 @@ export function getNotifDisplayData(attrs, options = {}) {
     text = app.polyglot.t('notifications.text.declined', {
       vendorName,
     });
-  } else if (attrs.type === 'cancel') {
+    // Check for the new 'cancel' value, but maintain compatibility with older notifications.
+  } else if (attrs.type === 'cancel' || attrs.type === 'cancelled') {
     const buyerName = opts.native ?
       getName(attrs.buyerHandle, attrs.buyerId) :
       `<a class="clrTEm" href="#${attrs.buyerId}">` +

--- a/js/collections/Notifications.js
+++ b/js/collections/Notifications.js
@@ -77,7 +77,7 @@ export function getNotifDisplayData(attrs, options = {}) {
     text = app.polyglot.t('notifications.text.orderConfirmation', {
       vendorName,
     });
-  } else if (attrs.type === 'declined') {
+  } else if (attrs.type === 'orderDeclined') {
     const vendorName = opts.native ?
       getName(attrs.vendorHandle, attrs.vendorId) :
       `<a class="clrTEm" href="#${attrs.vendorId}">` +
@@ -86,7 +86,7 @@ export function getNotifDisplayData(attrs, options = {}) {
     text = app.polyglot.t('notifications.text.declined', {
       vendorName,
     });
-  } else if (attrs.type === 'canceled') {
+  } else if (attrs.type === 'cancel') {
     const buyerName = opts.native ?
       getName(attrs.buyerHandle, attrs.buyerId) :
       `<a class="clrTEm" href="#${attrs.buyerId}">` +


### PR DESCRIPTION
I'm not sure how we missed this, but the notification types we were expecting don't match the ones the server sends for orderDeclined and cancel.

This resulted in notifications for a declined offline order or a cancelled offline order not showing any text in the notifications list, and not being clickable.

 https://github.com/OpenBazaar/openbazaar-go/blob/6eca0f933482c206aee7b124137baa76532faad3/repo/constants.go