### PR TITLE
Wallet updates based on ethereum precision schema changes

### DIFF
--- a/js/templates/modals/wallet/transactions/transaction.html
+++ b/js/templates/modals/wallet/transactions/transaction.html
@@ -70,7 +70,7 @@
     <div class="flexHRight">
       <div class="btnStrip">
         <a class="btn clrP clrBr clrSh2" href="<%= ob.walletCur.getBlockChainTxUrl(ob.txid, ob.isTestnet) %>"><%= ob.polyT('wallet.transactions.transaction.viewDetailsBtn') %></a>
-        <% if (ob.allowFeeBump || true) { %>
+        <% if (ob.allowFeeBump) { %>
           <%= ob.processingButton({
             className: `btn clrP clrBr clrSh2 js-retryPmt ${ob.retryConfirmOn ? 'disabled' : ''} ${ob.retryInProgress ? 'processing' : ''}`,
             btnText: ob.polyT('wallet.transactions.transaction.retryTransactionBtn')

--- a/js/templates/modals/wallet/transactions/transaction.html
+++ b/js/templates/modals/wallet/transactions/transaction.html
@@ -70,7 +70,7 @@
     <div class="flexHRight">
       <div class="btnStrip">
         <a class="btn clrP clrBr clrSh2" href="<%= ob.walletCur.getBlockChainTxUrl(ob.txid, ob.isTestnet) %>"><%= ob.polyT('wallet.transactions.transaction.viewDetailsBtn') %></a>
-        <% if (ob.allowFeeBump) { %>
+        <% if (ob.allowFeeBump || true) { %>
           <%= ob.processingButton({
             className: `btn clrP clrBr clrSh2 js-retryPmt ${ob.retryConfirmOn ? 'disabled' : ''} ${ob.retryInProgress ? 'processing' : ''}`,
             btnText: ob.polyT('wallet.transactions.transaction.retryTransactionBtn')

--- a/js/utils/currency.js
+++ b/js/utils/currency.js
@@ -718,14 +718,6 @@ export function renderPairedCurrency(price, fromCur, toCur) {
   return result;
 }
 
-// {
-//     \"amount\": \"535021\",
-//     \"currency\": {
-//       \"code\": \"TLTC\",
-//       \"divisibility\": 8
-//     }
-//   }
-
 /**
  * Will create an object representation of an amount based on how the server is
  * representing it, notably including the currency code and divisibility.

--- a/js/utils/currency.js
+++ b/js/utils/currency.js
@@ -719,8 +719,7 @@ export function renderPairedCurrency(price, fromCur, toCur) {
 }
 
 /**
- * Will create an object representation of an amount based on how the server is
- * representing it, notably including the currency code and divisibility.
+ * Will return a string based amount along with a currency definition.
  * @param {number|string} amount - If providing the amount in base units, it should
  *   be provided as a string (as returned by decimalToInteger), otherwise if providing
  *   a number, it will be assumed that it needs to be converted to base units.
@@ -728,7 +727,8 @@ export function renderPairedCurrency(price, fromCur, toCur) {
  * @param {object} [options={}] - Function options
  * @param {boolean} [options.divisibility] - The divisibility of the amount. If not
  *   provided, it will be obtained from getCoinDivisibility().
- * @returns {string} - An object representation of the number with meta.
+ * @returns {string} - An object containing a string based amount along with a
+ *   currency definition.
  */
 export function createAmount(amount, curCode, options = {}) {
   if (

--- a/js/utils/fees.js
+++ b/js/utils/fees.js
@@ -121,8 +121,8 @@ export function estimateFee(coinType, feeLevel, amount, options = {}) {
 
           try {
             convertedAmount = integerToDecimal(
-              args[0].estimatedFee.amount,
-              args[0].estimatedFee.currency.divisibility,
+              args[0].amount,
+              args[0].currency.divisibility,
               { returnUndefinedOnError: false }
             );
           } catch (e) {

--- a/js/utils/fees.js
+++ b/js/utils/fees.js
@@ -186,9 +186,39 @@ export function getFees(coinType) {
     };
 
     $.get(app.getServerUrl(`wallet/fees/${coinType}`))
-      .done((...args) => deferred.resolve(...args))
-      .fail((...args) => {
-        deferred.reject(...args);
+      .done(data => {
+        let economic;
+        let normal;
+        let priority;
+
+        try {
+          economic = integerToDecimal(
+            data.economic.amount,
+            data.economic.currency.divisibility
+          );
+          normal = integerToDecimal(
+            data.normal.amount,
+            data.normal.currency.divisibility
+          );
+          priority = integerToDecimal(
+            data.priority.amount,
+            data.priority.currency.divisibility
+          );
+        } catch (e) {
+          deferred.reject(`There was an error processing the reponse: ${e.message}`);
+          return;
+        }
+
+        deferred.resolve({
+          economic,
+          normal,
+          priority,
+        });
+      })
+      .fail(xhr => {
+        const reason =
+          xhr && xhr.responseJSON && xhr.responseJSON.reason || '';
+        deferred.reject(reason);
         delete getFeesCache[coinType];
       });
   }

--- a/js/views/modals/wallet/transactions/Transaction.js
+++ b/js/views/modals/wallet/transactions/Transaction.js
@@ -182,15 +182,14 @@ export default class extends BaseVw {
       this.setState({
         fetchingEstimatedFee: false,
         // server doubles the fee when bumping
-        estimatedFee: (this.walletCur.feeBumpTransactionSize * fees.priority * 2) /
-          this.walletCur.baseUnit,
+        estimatedFee: this.walletCur.feeBumpTransactionSize * fees.priority * 2,
       });
-    }).fail(xhr => {
+    }).fail(reason => {
       if (this.isRemoved()) return;
       this.setState({
         fetchingEstimatedFee: false,
         fetchFeeFailed: true,
-        fetchFeeError: xhr && xhr.responseJSON && xhr.responseJSON.reason || '',
+        fetchFeeError: reason || '',
       });
     });
   }


### PR DESCRIPTION
This covers just the wallet with the exception of:

- There is a socket which comes on an interval to let us know the wallet balance. I'm ignoring that for now pending an upcoming server change to update the schema of the socket. Th only impact for testing is just that the wallet balance won't update on incoming transactions unless you hard refresh the app. Once it's ready on the server, I'll wire it in - should be quick.

Keep in mind this branch merges into the `eth-precision` branch. Eventually, I'll put that one up for review to get it into `master`.