### PR TITLE
In fixLinuxZoomIssue, checks for screen since we've had a report of it…

### DIFF
--- a/js/startup/index.js
+++ b/js/startup/index.js
@@ -10,14 +10,19 @@ import app from '../app';
 
 export function fixLinuxZoomIssue() {
   // fix zoom issue on Linux hiDPI
-  if (screen && process.platform === 'linux') {
-    let scaleFactor = screen.getPrimaryDisplay().scaleFactor;
+  if (process.platform === 'linux') {
+    try {
+      let scaleFactor = screen.getPrimaryDisplay().scaleFactor;
 
-    if (scaleFactor === 0) {
-      scaleFactor = 1;
+      if (scaleFactor === 0) {
+        scaleFactor = 1;
+      }
+
+      getBody().css('zoom', 1 / scaleFactor);
+    } catch (e) {
+      console.error('Unable to fix the linux zoom issue due to an error.');
+      console.error(e);
     }
-
-    getBody().css('zoom', 1 / scaleFactor);
   }
 }
 

--- a/js/startup/index.js
+++ b/js/startup/index.js
@@ -10,7 +10,7 @@ import app from '../app';
 
 export function fixLinuxZoomIssue() {
   // fix zoom issue on Linux hiDPI
-  if (process.platform === 'linux') {
+  if (screen && process.platform === 'linux') {
     let scaleFactor = screen.getPrimaryDisplay().scaleFactor;
 
     if (scaleFactor === 0) {


### PR DESCRIPTION
… not being available on Ubuntu. And if it's not available it cause the client to "bomb" - blank screen on startup with the inability to proceed further.

