### PR TITLE
Updated Build Script for OS X Notarization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: node_js
 sudo: true
+before_cache:
+  - brew cleanup
 cache:
   directories:
   - node_modules
   - "/usr/local/Cellar"
+  - $HOME/Library/Caches/Homebrew
+
 node_js:
 - '8'
 addons:
@@ -18,15 +22,15 @@ before_script:
 - if [[ -n "$TRAVIS_TAG" ]]; then if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then "./.travis/add-key.sh"; fi ; fi
 jobs:
   include:
-      - os: linux
-      - os: osx
-        env: BINARY=win
       - os: osx
         osx_image: xcode11
         env: BINARY=osx
       - os: osx
         osx_image: xcode11
         env: BINARY=osxclient
+      - os: linux
+      - os: osx
+        env: BINARY=win
 script:
 - npm run lint
 - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 sudo: true
-os:
-- linux
-- osx
 cache:
   directories:
   - node_modules
@@ -21,18 +18,17 @@ before_script:
 - if [[ -n "$TRAVIS_TAG" ]]; then if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then "./.travis/add-key.sh"; fi ; fi
 jobs:
   include:
-    - stage: prepare
-      script: npm run lint
-#      script: npm run test
-    - stage: build
-      os: osx
-      script: if [ -n "$TRAVIS_TAG" ]; then ./build.sh; fi
-      os: linux
-      script: if [ -n "$TRAVIS_TAG" ]; then ./build.sh; fi
-#script:
-#- npm run lint
-#- npm run test
-#- if [ -n "$TRAVIS_TAG" ]; then ./build.sh; fi
+      - os: linux
+      - os: osx
+        env: BINARY=win
+      - os: osx
+        env: BINARY=osx
+      - os: osx
+        env: BINARY=osxclient
+script:
+- npm run lint
+- npm run test
+- if [ -n "$TRAVIS_TAG" ]; then ./build.sh; fi
 deploy:
   provider: releases
   api_key: "$GITHUB_TOKEN"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ jobs:
       - os: osx
         env: BINARY=win
       - os: osx
+        osx_image: xcode11
         env: BINARY=osx
       - os: osx
+        osx_image: xcode11
         env: BINARY=osxclient
 script:
 - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,20 @@ before_script:
 - if [[ -n "$TRAVIS_TAG" ]]; then openssl aes-256-cbc -k "$OB1_SECRET" -in .travis/ob1.cert.spc.enc -d -a -out ./.travis/ob1.cert.spc; fi
 - if [[ -n "$TRAVIS_TAG" ]]; then openssl aes-256-cbc -k "$OB1_SECRET" -in .travis/ob1.cert.spc.enc -d -a -out ./.travis/ob1.pvk; fi
 - if [[ -n "$TRAVIS_TAG" ]]; then if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then "./.travis/add-key.sh"; fi ; fi
-script:
-- npm run lint
-- npm run test
-- if [ -n "$TRAVIS_TAG" ]; then ./build.sh; fi
+jobs:
+  include:
+    - stage: prepare
+      script: npm run lint
+#      script: npm run test
+    - stage: build
+      os: osx
+      script: if [ -n "$TRAVIS_TAG" ]; then ./build.sh; fi
+      os: linux
+      script: if [ -n "$TRAVIS_TAG" ]; then ./build.sh; fi
+#script:
+#- npm run lint
+#- npm run test
+#- if [ -n "$TRAVIS_TAG" ]; then ./build.sh; fi
 deploy:
   provider: releases
   api_key: "$GITHUB_TOKEN"

--- a/build.sh
+++ b/build.sh
@@ -48,117 +48,111 @@ npm run build
 echo 'Copying transpiled files into js folder...'
 cp -rf prod/* js/
 
+echo "We are building: ${BINARY}"
 
 case "$TRAVIS_OS_NAME" in
-#  "linux")
-#
-#    echo 'Linux builds'
-#
-#    echo 'Building Linux 32-bit Installer....'
-#
-#    echo 'Making dist directories'
-#    mkdir dist/linux32
-#    mkdir dist/linux64
-#
-#    echo 'Install npm packages for Linux'
-#    npm install -g --save-dev electron-installer-debian --silent
-#    npm install -g --save-dev electron-installer-redhat --silent
-#
-#    # Install libgconf2-4
-#    sudo apt-get install libgconf2-4 libgconf-2-4
-#
-#    # Install rpmbuild
-#    sudo apt-get install rpm
-#
-#    # Ensure fakeroot is installed
-#    sudo apt-get install fakeroot
-#
-#    # Retrieve Latest Server Binaries
-#    sudo apt-get install jq
-#    cd OPENBAZAAR_TEMP/
-#    curl -u $GITHUB_USER:$GITHUB_TOKEN -s https://api.github.com/repos/OpenBazaar/openbazaar-go/releases/$SERVERTAG > release.txt
-#    cat release.txt | jq -r ".assets[].browser_download_url" | xargs -n 1 curl -L -O
-#    cd ..
-#
-#    APPNAME="openbazaar2"
-#
-#    echo "Packaging Electron application"
-#    electron-packager . ${APPNAME} --platform=linux --arch=ia32 --electronVersion=${ELECTRONVER} --ignore="OPENBAZAAR_TEMP" --overwrite --prune --out=dist
-#
-#    echo 'Move go server to electron app'
-#    mkdir dist/${APPNAME}-linux-ia32/resources/openbazaar-go/
-#    cp -rf OPENBAZAAR_TEMP/openbazaar-go-linux-386 dist/${APPNAME}-linux-ia32/resources/openbazaar-go
-#    mv dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaar-go-linux-386 dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaard
-#    rm -rf dist/${APPNAME}-linux-ia32/resources/app/.travis
-#    chmod +x dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaard
-#
-#    echo 'Create debian archive'
-#    electron-installer-debian --config .travis/config_ia32.json
-#
-#    echo 'Create RPM archive'
-#    electron-installer-redhat --config .travis/config_ia32.json
-#
-#    echo 'Building Linux 64-bit Installer....'
-#
-#    echo "Packaging Electron application"
-#    electron-packager . ${APPNAME} --platform=linux --arch=x64 --electronVersion=${ELECTRONVER} --overwrite --ignore="OPENBAZAAR_TEMP" --prune --out=dist
-#
-#    echo 'Move go server to electron app'
-#    mkdir dist/${APPNAME}-linux-x64/resources/openbazaar-go/
-#    cp -rf OPENBAZAAR_TEMP/openbazaar-go-linux-amd64 dist/${APPNAME}-linux-x64/resources/openbazaar-go
-#    rm -rf OPENBAZAAR_TEMP/*
-#    mv dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaar-go-linux-amd64 dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaard
-#    rm -rf dist/${APPNAME}-linux-x64/resources/app/.travis
-#    chmod +x dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaard
-#
-#    echo 'Create debian archive'
-#    electron-installer-debian --config .travis/config_amd64.json
-#
-#    echo 'Create RPM archive'
-#    electron-installer-redhat --config .travis/config_x86_64.json
-#
-#    APPNAME="openbazaar2client"
-#
-#    echo "Packaging Electron application"
-#    electron-packager . ${APPNAME} --platform=linux --arch=ia32 --ignore="OPENBAZAAR_TEMP" --electronVersion=${ELECTRONVER} --overwrite --prune --out=dist
-#
-#    echo 'Create debian archive'
-#    electron-installer-debian --config .travis/config_ia32.client.json
-#
-#    echo 'Create RPM archive'
-#    electron-installer-redhat --config .travis/config_ia32.client.json
-#
-#    echo 'Building Linux 64-bit Installer....'
-#
-#    echo "Packaging Electron application"
-#    electron-packager . ${APPNAME} --platform=linux --arch=x64 --ignore="OPENBAZAAR_TEMP" --electronVersion=${ELECTRONVER} --overwrite --prune --out=dist
-#
-#    echo 'Create debian archive'
-#    electron-installer-debian --config .travis/config_amd64.client.json
-#
-#    echo 'Create RPM archive'
-#    electron-installer-redhat --config .travis/config_x86_64.client.json
-#
-#    ;;
-#
+  "linux")
+
+    echo 'Linux builds'
+
+    echo 'Building Linux 32-bit Installer....'
+
+    echo 'Making dist directories'
+    mkdir dist/linux32
+    mkdir dist/linux64
+
+    echo 'Install npm packages for Linux'
+    npm install -g --save-dev electron-installer-debian --silent
+    npm install -g --save-dev electron-installer-redhat --silent
+
+    # Install libgconf2-4
+    sudo apt-get install libgconf2-4 libgconf-2-4
+
+    # Install rpmbuild
+    sudo apt-get install rpm
+
+    # Ensure fakeroot is installed
+    sudo apt-get install fakeroot
+
+    # Retrieve Latest Server Binaries
+    sudo apt-get install jq
+    cd OPENBAZAAR_TEMP/
+    curl -u $GITHUB_USER:$GITHUB_TOKEN -s https://api.github.com/repos/OpenBazaar/openbazaar-go/releases/$SERVERTAG > release.txt
+    cat release.txt | jq -r ".assets[].browser_download_url" | xargs -n 1 curl -L -O
+    cd ..
+
+    APPNAME="openbazaar2"
+
+    echo "Packaging Electron application"
+    electron-packager . ${APPNAME} --platform=linux --arch=ia32 --electronVersion=${ELECTRONVER} --ignore="OPENBAZAAR_TEMP" --overwrite --prune --out=dist
+
+    echo 'Move go server to electron app'
+    mkdir dist/${APPNAME}-linux-ia32/resources/openbazaar-go/
+    cp -rf OPENBAZAAR_TEMP/openbazaar-go-linux-386 dist/${APPNAME}-linux-ia32/resources/openbazaar-go
+    mv dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaar-go-linux-386 dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaard
+    rm -rf dist/${APPNAME}-linux-ia32/resources/app/.travis
+    chmod +x dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaard
+
+    echo 'Create debian archive'
+    electron-installer-debian --config .travis/config_ia32.json
+
+    echo 'Create RPM archive'
+    electron-installer-redhat --config .travis/config_ia32.json
+
+    echo 'Building Linux 64-bit Installer....'
+
+    echo "Packaging Electron application"
+    electron-packager . ${APPNAME} --platform=linux --arch=x64 --electronVersion=${ELECTRONVER} --overwrite --ignore="OPENBAZAAR_TEMP" --prune --out=dist
+
+    echo 'Move go server to electron app'
+    mkdir dist/${APPNAME}-linux-x64/resources/openbazaar-go/
+    cp -rf OPENBAZAAR_TEMP/openbazaar-go-linux-amd64 dist/${APPNAME}-linux-x64/resources/openbazaar-go
+    rm -rf OPENBAZAAR_TEMP/*
+    mv dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaar-go-linux-amd64 dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaard
+    rm -rf dist/${APPNAME}-linux-x64/resources/app/.travis
+    chmod +x dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaard
+
+    echo 'Create debian archive'
+    electron-installer-debian --config .travis/config_amd64.json
+
+    echo 'Create RPM archive'
+    electron-installer-redhat --config .travis/config_x86_64.json
+
+    APPNAME="openbazaar2client"
+
+    echo "Packaging Electron application"
+    electron-packager . ${APPNAME} --platform=linux --arch=ia32 --ignore="OPENBAZAAR_TEMP" --electronVersion=${ELECTRONVER} --overwrite --prune --out=dist
+
+    echo 'Create debian archive'
+    electron-installer-debian --config .travis/config_ia32.client.json
+
+    echo 'Create RPM archive'
+    electron-installer-redhat --config .travis/config_ia32.client.json
+
+    echo 'Building Linux 64-bit Installer....'
+
+    echo "Packaging Electron application"
+    electron-packager . ${APPNAME} --platform=linux --arch=x64 --ignore="OPENBAZAAR_TEMP" --electronVersion=${ELECTRONVER} --overwrite --prune --out=dist
+
+    echo 'Create debian archive'
+    electron-installer-debian --config .travis/config_amd64.client.json
+
+    echo 'Create RPM archive'
+    electron-installer-redhat --config .travis/config_x86_64.client.json
+
+    ;;
+
   "osx")
 
     brew update
     brew remove jq
     brew link oniguruma
     brew install jq
-    curl -L https://dl.bintray.com/develar/bin/7za -o /tmp/7za
-    chmod +x /tmp/7za
-    curl -L https://dl.bintray.com/develar/bin/wine.7z -o /tmp/wine.7z
-    /tmp/7za x -o/usr/local/Cellar -y /tmp/wine.7z
-
     brew link --overwrite fontconfig gd gnutls jasper libgphoto2 libicns libtasn1 libusb libusb-compat little-cms2 nettle openssl sane-backends webp wine git-lfs gnu-tar dpkg xz
     brew install freetype graphicsmagick
     brew link xz
     brew remove openssl
     brew install openssl
-    brew remove osslsigncode
-    brew install mono osslsigncode
     brew link freetype graphicsmagick mono
 
     # Retrieve Latest Server Binaries
@@ -167,179 +161,202 @@ case "$TRAVIS_OS_NAME" in
     cat release.txt | jq -r ".assets[].browser_download_url" | xargs -n 1 curl -L -O
     cd ..
 
-##    # WINDOWS 32
-##    echo 'Building Windows 32-bit Installer...'
-##    mkdir dist/win32
-##
-##    echo 'Running Electron Packager...'
-##    electron-packager . OpenBazaar2 --asar --out=dist --ignore="OPENBAZAAR_TEMP" --protocol-name=OpenBazaar --win32metadata.ProductName="OpenBazaar2" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2.exe --protocol=ob --platform=win32 --arch=ia32 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
-##
-##    echo 'Copying server binary into application folder...'
-##    cp -rf OPENBAZAAR_TEMP/openbazaar-go-windows-4.0-386.exe dist/OpenBazaar2-win32-ia32/resources/
-##    cp -rf OPENBAZAAR_TEMP/libwinpthread-1.win32.dll dist/OpenBazaar2-win32-ia32/resources/libwinpthread-1.dll
-##    mkdir dist/OpenBazaar2-win32-ia32/resources/openbazaar-go
-##    mv dist/OpenBazaar2-win32-ia32/resources/openbazaar-go-windows-4.0-386.exe dist/OpenBazaar2-win32-ia32/resources/openbazaar-go/openbazaard.exe
-##    mv dist/OpenBazaar2-win32-ia32/resources/libwinpthread-1.dll dist/OpenBazaar2-win32-ia32/resources/openbazaar-go/libwinpthread-1.dll
-##    rm -rf dist/OPENBAZAAR_TEMP
-##
-##    echo 'Building Installer...'
-##    grunt create-windows-installer --appname=OpenBazaar2 --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2-win32-ia32 --outdir=dist/win32
-##    mv dist/win32/OpenBazaar2Setup.exe dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe
-##    mv dist/win32/RELEASES dist/RELEASES
-##
-##    #### CLIENT ONLY
-##    echo 'Running Electron Packager...'
-##    electron-packager . OpenBazaar2Client --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2Client" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2Client.exe --protocol=ob --platform=win32 --arch=ia32 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
-##
-##    echo 'Building Installer...'
-##    grunt create-windows-installer --appname=OpenBazaar2Client --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2Client-win32-ia32 --outdir=dist/win32
-##    mv dist/win32/OpenBazaar2ClientSetup.exe dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe
-##
-##    echo 'Sign the installer'
-##    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe -out dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe
-##    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe -out dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe
-##
-##    rm dist/win32/RELEASES
-##
-##    # WINDOWS 64
-##    echo 'Building Windows 64-bit Installer...'
-##    mkdir dist/win64
-##
-##    echo 'Running Electron Packager...'
-##    electron-packager . OpenBazaar2 --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2.exe --protocol=ob --platform=win32 --arch=x64 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
-##
-##    echo 'Copying server binary into application folder...'
-##    cp -rf OPENBAZAAR_TEMP/openbazaar-go-windows-4.0-amd64.exe dist/OpenBazaar2-win32-x64/resources/
-##    cp -rf OPENBAZAAR_TEMP/libwinpthread-1.win64.dll dist/OpenBazaar2-win32-x64/resources/libwinpthread-1.dll
-##    mkdir dist/OpenBazaar2-win32-x64/resources/openbazaar-go
-##    mv dist/OpenBazaar2-win32-x64/resources/openbazaar-go-windows-4.0-amd64.exe dist/OpenBazaar2-win32-x64/resources/openbazaar-go/openbazaard.exe
-##    mv dist/OpenBazaar2-win32-x64/resources/libwinpthread-1.dll dist/OpenBazaar2-win32-x64/resources/openbazaar-go/libwinpthread-1.dll
-##
-##    echo 'Building Installer...'
-##    grunt create-windows-installer --appname=OpenBazaar2 --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2-win32-x64 --outdir=dist/win64
-##    mv dist/win64/OpenBazaar2Setup.exe dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe
-##    mv dist/win64/RELEASES dist/win64/RELEASES-x64
-##
-##    #### CLIENT ONLY
-##    echo 'Running Electron Packager...'
-##    electron-packager . OpenBazaar2Client --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2Client" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2Client.exe --protocol=ob --platform=win32 --arch=x64 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
-##
-##    echo 'Building Installer...'
-##    grunt create-windows-installer --appname=OpenBazaar2Client --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2Client-win32-x64 --outdir=dist/win64
-##    mv dist/win64/OpenBazaar2ClientSetup.exe dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe
-##
-##    echo 'Sign the installer'
-##    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe -out dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe
-##    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe -out dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe
-##
-##    mv dist/RELEASES dist/win32/RELEASES
-#
-    # OSX
-    echo 'Building OSX Installer'
-    mkdir dist/osx
+    if [[ $BINARY == 'win' ]]; then
 
-    # Install the DMG packager
-    echo 'Installing electron-installer-dmg'
-    npm install -g electron-installer-dmg
+        curl -L https://dl.bintray.com/develar/bin/7za -o /tmp/7za
+        chmod +x /tmp/7za
+        curl -L https://dl.bintray.com/develar/bin/wine.7z -o /tmp/wine.7z
+        /tmp/7za x -o/usr/local/Cellar -y /tmp/wine.7z
 
-    # Sign openbazaar-go binary
-    echo 'Signing Go binary'
-    mv OPENBAZAAR_TEMP/openbazaar-go-darwin-10.6-amd64 dist/osx/openbazaard
-    rm -rf OPENBAZAAR_TEMP/*
-    codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime dist/osx/openbazaard
+        brew link --overwrite fontconfig gd gnutls jasper libgphoto2 libicns libtasn1 libusb libusb-compat little-cms2 nettle openssl sane-backends webp wine git-lfs gnu-tar dpkg xz
 
-    echo 'Running Electron Packager...'
-    electron-packager . OpenBazaar2 --out=dist -app-category-type=public.app-category.business --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --protocol=ob --platform=darwin --arch=x64 --icon=imgs/openbazaar2.icns --electron-version=${ELECTRONVER} --overwrite --app-version=$PACKAGE_VERSION
-    # Client Only
-    electron-packager . OpenBazaar2Client --out=dist -app-category-type=public.app-category.business --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --protocol=ob --platform=darwin --arch=x64 --icon=imgs/openbazaar2.icns --electron-version=${ELECTRONVER} --overwrite --app-version=$PACKAGE_VERSION
+        brew remove osslsigncode
+        brew install mono osslsigncode
 
-    echo 'Creating openbazaar-go folder in the OS X .app'
-    mkdir dist/OpenBazaar2-darwin-x64/OpenBazaar2.app/Contents/Resources/openbazaar-go
+        # WINDOWS 32
+        echo 'Building Windows 32-bit Installer...'
+        mkdir dist/win32
 
-    echo 'Moving binary to correct folder'
-    mv dist/osx/openbazaard dist/OpenBazaar2-darwin-x64/OpenBazaar2.app/Contents/Resources/openbazaar-go/openbazaard
-    chmod +x dist/OpenBazaar2-darwin-x64/OpenBazaar2.app/Contents/Resources/openbazaar-go/openbazaard
+        echo 'Running Electron Packager...'
+        electron-packager . OpenBazaar2 --asar --out=dist --ignore="OPENBAZAAR_TEMP" --protocol-name=OpenBazaar --win32metadata.ProductName="OpenBazaar2" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2.exe --protocol=ob --platform=win32 --arch=ia32 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
 
-    echo 'Codesign the .app'
-    codesign --force --deep --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2-darwin-x64/OpenBazaar2.app
-    electron-installer-dmg dist/OpenBazaar2-darwin-x64/OpenBazaar2.app OpenBazaar2-$PACKAGE_VERSION --icon ./imgs/openbazaar2.icns --out=dist/OpenBazaar2-darwin-x64 --overwrite --background=./imgs/osx-finder_background.png --debug
-    # Client Only
-    codesign --force --deep --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client.app
-    electron-installer-dmg dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client.app OpenBazaar2Client-$PACKAGE_VERSION --icon ./imgs/openbazaar2.icns --out=dist/OpenBazaar2Client-darwin-x64 --overwrite --background=./imgs/osx-finder_background.png --debug
+        echo 'Copying server binary into application folder...'
+        cp -rf OPENBAZAAR_TEMP/openbazaar-go-windows-4.0-386.exe dist/OpenBazaar2-win32-ia32/resources/
+        cp -rf OPENBAZAAR_TEMP/libwinpthread-1.win32.dll dist/OpenBazaar2-win32-ia32/resources/libwinpthread-1.dll
+        mkdir dist/OpenBazaar2-win32-ia32/resources/openbazaar-go
+        mv dist/OpenBazaar2-win32-ia32/resources/openbazaar-go-windows-4.0-386.exe dist/OpenBazaar2-win32-ia32/resources/openbazaar-go/openbazaard.exe
+        mv dist/OpenBazaar2-win32-ia32/resources/libwinpthread-1.dll dist/OpenBazaar2-win32-ia32/resources/openbazaar-go/libwinpthread-1.dll
+        rm -rf dist/OPENBAZAAR_TEMP
 
-    echo 'Codesign the DMG and zip'
-    codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2-darwin-x64/OpenBazaar2-$PACKAGE_VERSION.dmg
-    cd dist/OpenBazaar2-darwin-x64/
-    zip -q -r OpenBazaar2-mac-$PACKAGE_VERSION.zip OpenBazaar2.app
-    cp -r OpenBazaar2.app ../osx/
-    cp OpenBazaar2-mac-$PACKAGE_VERSION.zip ../osx/
-    cp OpenBazaar2-$PACKAGE_VERSION.dmg ../osx/
+        echo 'Building Installer...'
+        grunt create-windows-installer --appname=OpenBazaar2 --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2-win32-ia32 --outdir=dist/win32
+        mv dist/win32/OpenBazaar2Setup.exe dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe
+        mv dist/win32/RELEASES dist/RELEASES
 
-    # Client Only
-    cd ../../
-    codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client-$PACKAGE_VERSION.dmg
-    cd dist/OpenBazaar2Client-darwin-x64/
-    zip -q -r OpenBazaar2Client-mac-$PACKAGE_VERSION.zip OpenBazaar2Client.app
-    cp -r OpenBazaar2Client.app ../osx/
-    cp OpenBazaar2Client-mac-$PACKAGE_VERSION.zip ../osx/
-    cp OpenBazaar2Client-$PACKAGE_VERSION.dmg ../osx/
+        #### CLIENT ONLY
+        echo 'Running Electron Packager...'
+        electron-packager . OpenBazaar2Client --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2Client" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2Client.exe --protocol=ob --platform=win32 --arch=ia32 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
 
-    cd ../..
+        echo 'Building Installer...'
+        grunt create-windows-installer --appname=OpenBazaar2Client --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2Client-win32-ia32 --outdir=dist/win32
+        mv dist/win32/OpenBazaar2ClientSetup.exe dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe
 
-    # Notarize the zip files
-    UPLOAD_INFO_PLIST="uploadinfo.plist"
-    REQUEST_INFO_PLIST="request.plist"
-    touch $UPLOAD_INFO_PLIST
+        echo 'Sign the installer'
+        osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe -out dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe
+        osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe -out dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe
 
-    # Zip up .dmg files for notarization
-    zip -q -r dist/osx/OpenBazaar2.zip dist/OpenBazaar2-darwin-x64/OpenBazaar2-$PACKAGE_VERSION.dmg
-    zip -q -r dist/osx/OpenBazaar2Client.zip dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client-$PACKAGE_VERSION.dmg
+        rm dist/win32/RELEASES
 
-    wait_for_notarization() {
-      while true; do \
+        # WINDOWS 64
+        echo 'Building Windows 64-bit Installer...'
+        mkdir dist/win64
 
-        echo "Checking Apple for notarization status..."; \
-        /usr/bin/xcrun altool --notarization-info `/usr/libexec/PlistBuddy -c "Print :notarization-upload:RequestUUID" $UPLOAD_INFO_PLIST` -u $APPLE_ID -p $APPLE_PASS --output-format xml > "$REQUEST_INFO_PLIST" ;\
+        echo 'Running Electron Packager...'
+        electron-packager . OpenBazaar2 --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2.exe --protocol=ob --platform=win32 --arch=x64 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
 
-        if [[ `/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" ${REQUEST_INFO_PLIST}` != "in progress" ]] || [[ "$requestUUID" == "" ]] ; then \
+        echo 'Copying server binary into application folder...'
+        cp -rf OPENBAZAAR_TEMP/openbazaar-go-windows-4.0-amd64.exe dist/OpenBazaar2-win32-x64/resources/
+        cp -rf OPENBAZAAR_TEMP/libwinpthread-1.win64.dll dist/OpenBazaar2-win32-x64/resources/libwinpthread-1.dll
+        mkdir dist/OpenBazaar2-win32-x64/resources/openbazaar-go
+        mv dist/OpenBazaar2-win32-x64/resources/openbazaar-go-windows-4.0-amd64.exe dist/OpenBazaar2-win32-x64/resources/openbazaar-go/openbazaard.exe
+        mv dist/OpenBazaar2-win32-x64/resources/libwinpthread-1.dll dist/OpenBazaar2-win32-x64/resources/openbazaar-go/libwinpthread-1.dll
 
-           # check if it has been uploaded already and get the RequestUUID from the error message
-           echo "Checking if binary has already been uploaded..."; \
-           message=`/usr/libexec/PlistBuddy -c "Print :product-errors:0:message" $UPLOAD_INFO_PLIST`;\
-           if [[ ${message} =~ ^ERROR\ ITMS-90732* ]]; then \
-               prefix="ERROR ITMS-90732: \"The software asset has already been uploaded. The upload ID is "; \
-               suffix="\" at SoftwareAssets\/EnigmaSoftwareAsset"; \
-               requestUUID=`echo "${message}" | sed -e "s/^$prefix//" -e "s/$suffix$//"`; \
+        echo 'Building Installer...'
+        grunt create-windows-installer --appname=OpenBazaar2 --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2-win32-x64 --outdir=dist/win64
+        mv dist/win64/OpenBazaar2Setup.exe dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe
+        mv dist/win64/RELEASES dist/win64/RELEASES-x64
 
-               echo "Binary has already been uploaded. Checking Apple status for request ${requestUUID}..."; \
-               /usr/bin/xcrun altool --notarization-info ${requestUUID} -u $APPLE_ID -p $APPLE_PASS --output-format xml > "$REQUEST_INFO_PLIST" ;\
-           fi ;\
+        #### CLIENT ONLY
+        echo 'Running Electron Packager...'
+        electron-packager . OpenBazaar2Client --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2Client" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2Client.exe --protocol=ob --platform=win32 --arch=x64 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
 
-           if [[ `/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" ${REQUEST_INFO_PLIST}` != "in progress" ]]; then \
-            echo "Binary has been notarized"; \
-            break; \
-           fi; \
-        fi ;\
-        echo "Waiting 60 seconds to check status again..."; \
-        sleep 60 ;\
-      done
-    }
+        echo 'Building Installer...'
+        grunt create-windows-installer --appname=OpenBazaar2Client --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2Client-win32-x64 --outdir=dist/win64
+        mv dist/win64/OpenBazaar2ClientSetup.exe dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe
 
-    # Upload to apple and notarize
-    echo "Uploading binary to Apple Notarization server..."
-    xcrun altool --notarize-app --primary-bundle-id "org.openbazaar.desktop-${PACKAGE_VERSION}" --username "$APPLE_ID" --password "$APPLE_PASS" --file dist/osx/OpenBazaar2.zip --output-format xml > ${UPLOAD_INFO_PLIST}
-    wait_for_notarization
+        echo 'Sign the installer'
+        osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe -out dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe
+        osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe -out dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe
 
-    # Staple ticket to .app file
-    echo "Stapling ticket to the app..."
-    xcrun stapler staple dist/osx/OpenBazaar2-2.3.6.dmg
+        mv dist/RELEASES dist/win32/RELEASES
 
-    # Re-zip it up for distribution
+    else
 
-    echo "Uploading client only binary to Apple Notarization server..."
-    xcrun altool --notarize-app --primary-bundle-id "org.openbazaar.desktopclient-$PACKAGE_VERSION" --username "$APPLE_ID" --password "$APPLE_PASS" --file dist/osx/OpenBazaar2Client.zip --output-format xml > $UPLOAD_INFO_PLIST
-    wait_for_notarization
-    xcrun stapler staple dist/osx/OpenBazaar2Client-2.3.6.dmg
+        # OSX
+        echo 'Building OSX Installer'
+        mkdir dist/osx
 
-    ;;
+        # Install the DMG packager
+        echo 'Installing electron-installer-dmg'
+        npm install -g electron-installer-dmg
+
+        # Sign openbazaar-go binary
+        echo 'Signing Go binary'
+        mv OPENBAZAAR_TEMP/openbazaar-go-darwin-10.6-amd64 dist/osx/openbazaard
+        rm -rf OPENBAZAAR_TEMP/*
+        codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime dist/osx/openbazaard
+
+        # Notarize the zip files
+        UPLOAD_INFO_PLIST="uploadinfo.plist"
+        REQUEST_INFO_PLIST="request.plist"
+        touch $UPLOAD_INFO_PLIST
+
+        wait_for_notarization() {
+          while true; do \
+
+            echo "Checking Apple for notarization status..."; \
+            /usr/bin/xcrun altool --notarization-info `/usr/libexec/PlistBuddy -c "Print :notarization-upload:RequestUUID" $UPLOAD_INFO_PLIST` -u $APPLE_ID -p $APPLE_PASS --output-format xml > "$REQUEST_INFO_PLIST" ;\
+
+            if [[ `/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" ${REQUEST_INFO_PLIST}` != "in progress" ]] || [[ "$requestUUID" == "" ]] ; then \
+
+               # check if it has been uploaded already and get the RequestUUID from the error message
+               echo "Checking if binary has already been uploaded..."; \
+               message=`/usr/libexec/PlistBuddy -c "Print :product-errors:0:message" $UPLOAD_INFO_PLIST`;\
+               if [[ ${message} =~ ^ERROR\ ITMS-90732* ]]; then \
+                   prefix="ERROR ITMS-90732: \"The software asset has already been uploaded. The upload ID is "; \
+                   suffix="\" at SoftwareAssets\/EnigmaSoftwareAsset"; \
+                   requestUUID=`echo "${message}" | sed -e "s/^$prefix//" -e "s/$suffix$//"`; \
+
+                   echo "Binary has already been uploaded. Checking Apple status for request ${requestUUID}..."; \
+                   /usr/bin/xcrun altool --notarization-info ${requestUUID} -u $APPLE_ID -p $APPLE_PASS --output-format xml > "$REQUEST_INFO_PLIST" ;\
+               fi ;\
+
+               if [[ `/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" ${REQUEST_INFO_PLIST}` != "in progress" ]]; then \
+                echo "Binary has been notarized"; \
+                break; \
+               fi; \
+            fi ;\
+            echo "Waiting 30 seconds to check status again..."; \
+            sleep 30 ;\
+          done
+        }
+
+        if [[ ${BINARY} == 'osx' ]]; then
+
+            echo 'Running Electron Packager...'
+            electron-packager . OpenBazaar2 --out=dist -app-category-type=public.app-category.business --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --protocol=ob --platform=darwin --arch=x64 --icon=imgs/openbazaar2.icns --electron-version=${ELECTRONVER} --overwrite --app-version=$PACKAGE_VERSION
+
+            echo 'Creating openbazaar-go folder in the OS X .app'
+            mkdir dist/OpenBazaar2-darwin-x64/OpenBazaar2.app/Contents/Resources/openbazaar-go
+
+            echo 'Moving binary to correct folder'
+            mv dist/osx/openbazaard dist/OpenBazaar2-darwin-x64/OpenBazaar2.app/Contents/Resources/openbazaar-go/openbazaard
+            chmod +x dist/OpenBazaar2-darwin-x64/OpenBazaar2.app/Contents/Resources/openbazaar-go/openbazaard
+
+            echo 'Codesign the .app'
+            codesign --force --deep --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2-darwin-x64/OpenBazaar2.app
+            electron-installer-dmg dist/OpenBazaar2-darwin-x64/OpenBazaar2.app OpenBazaar2-$PACKAGE_VERSION --icon ./imgs/openbazaar2.icns --out=dist/OpenBazaar2-darwin-x64 --overwrite --background=./imgs/osx-finder_background.png --debug
+
+            echo 'Codesign the DMG and zip'
+            codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2-darwin-x64/OpenBazaar2-$PACKAGE_VERSION.dmg
+            cd dist/OpenBazaar2-darwin-x64/
+            zip -q -r OpenBazaar2-mac-$PACKAGE_VERSION.zip OpenBazaar2.app
+            cp -r OpenBazaar2.app ../osx/
+            cp OpenBazaar2-mac-$PACKAGE_VERSION.zip ../osx/
+            cp OpenBazaar2-$PACKAGE_VERSION.dmg ../osx/
+
+            cd ../..
+
+            zip -q -r dist/osx/OpenBazaar2.zip dist/OpenBazaar2-darwin-x64/OpenBazaar2-$PACKAGE_VERSION.dmg
+
+            # Upload to apple and notarize
+            echo "Uploading binary to Apple Notarization server..."
+            xcrun altool --notarize-app --primary-bundle-id "org.openbazaar.desktop-${PACKAGE_VERSION}" --username "$APPLE_ID" --password "$APPLE_PASS" --file dist/osx/OpenBazaar2.zip --output-format xml > ${UPLOAD_INFO_PLIST}
+            wait_for_notarization
+
+            echo "Stapling ticket to the DMG..."
+            xcrun stapler staple dist/osx/OpenBazaar2-2.3.6.dmg
+
+        else
+
+            # Client Only
+            electron-packager . OpenBazaar2Client --out=dist -app-category-type=public.app-category.business --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --protocol=ob --platform=darwin --arch=x64 --icon=imgs/openbazaar2.icns --electron-version=${ELECTRONVER} --overwrite --app-version=$PACKAGE_VERSION
+
+            codesign --force --deep --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client.app
+            electron-installer-dmg dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client.app OpenBazaar2Client-$PACKAGE_VERSION --icon ./imgs/openbazaar2.icns --out=dist/OpenBazaar2Client-darwin-x64 --overwrite --background=./imgs/osx-finder_background.png --debug
+
+            # Client Only
+            cd ../../
+            codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client-$PACKAGE_VERSION.dmg
+            cd dist/OpenBazaar2Client-darwin-x64/
+            zip -q -r OpenBazaar2Client-mac-$PACKAGE_VERSION.zip OpenBazaar2Client.app
+            cp -r OpenBazaar2Client.app ../osx/
+            cp OpenBazaar2Client-mac-$PACKAGE_VERSION.zip ../osx/
+            cp OpenBazaar2Client-$PACKAGE_VERSION.dmg ../osx/
+
+            cd ../..
+
+            zip -q -r dist/osx/OpenBazaar2Client.zip dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client-$PACKAGE_VERSION.dmg
+
+            echo "Uploading client only binary to Apple Notarization server..."
+            xcrun altool --notarize-app --primary-bundle-id "org.openbazaar.desktopclient-$PACKAGE_VERSION" --username "$APPLE_ID" --password "$APPLE_PASS" --file dist/osx/OpenBazaar2Client.zip --output-format xml > $UPLOAD_INFO_PLIST
+            wait_for_notarization
+
+            echo "Stapling ticket to the DMG..."
+            xcrun stapler staple dist/osx/OpenBazaar2Client-2.3.6.dmg
+        fi
+
+    fi
+
+  ;;
 esac

--- a/build.sh
+++ b/build.sh
@@ -50,97 +50,97 @@ cp -rf prod/* js/
 
 
 case "$TRAVIS_OS_NAME" in
-  "linux")
-
-    echo 'Linux builds'
-
-    echo 'Building Linux 32-bit Installer....'
-
-    echo 'Making dist directories'
-    mkdir dist/linux32
-    mkdir dist/linux64
-
-    echo 'Install npm packages for Linux'
-    npm install -g --save-dev electron-installer-debian --silent
-    npm install -g --save-dev electron-installer-redhat --silent
-
-    # Install libgconf2-4
-    sudo apt-get install libgconf2-4 libgconf-2-4
-
-    # Install rpmbuild
-    sudo apt-get install rpm
-
-    # Ensure fakeroot is installed
-    sudo apt-get install fakeroot
-
-    # Retrieve Latest Server Binaries
-    sudo apt-get install jq
-    cd OPENBAZAAR_TEMP/
-    curl -u $GITHUB_USER:$GITHUB_TOKEN -s https://api.github.com/repos/OpenBazaar/openbazaar-go/releases/$SERVERTAG > release.txt
-    cat release.txt | jq -r ".assets[].browser_download_url" | xargs -n 1 curl -L -O
-    cd ..
-
-    APPNAME="openbazaar2"
-
-    echo "Packaging Electron application"
-    electron-packager . ${APPNAME} --platform=linux --arch=ia32 --electronVersion=${ELECTRONVER} --ignore="OPENBAZAAR_TEMP" --overwrite --prune --out=dist
-
-    echo 'Move go server to electron app'
-    mkdir dist/${APPNAME}-linux-ia32/resources/openbazaar-go/
-    cp -rf OPENBAZAAR_TEMP/openbazaar-go-linux-386 dist/${APPNAME}-linux-ia32/resources/openbazaar-go
-    mv dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaar-go-linux-386 dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaard
-    rm -rf dist/${APPNAME}-linux-ia32/resources/app/.travis
-    chmod +x dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaard
-
-    echo 'Create debian archive'
-    electron-installer-debian --config .travis/config_ia32.json
-
-    echo 'Create RPM archive'
-    electron-installer-redhat --config .travis/config_ia32.json
-
-    echo 'Building Linux 64-bit Installer....'
-
-    echo "Packaging Electron application"
-    electron-packager . ${APPNAME} --platform=linux --arch=x64 --electronVersion=${ELECTRONVER} --overwrite --ignore="OPENBAZAAR_TEMP" --prune --out=dist
-
-    echo 'Move go server to electron app'
-    mkdir dist/${APPNAME}-linux-x64/resources/openbazaar-go/
-    cp -rf OPENBAZAAR_TEMP/openbazaar-go-linux-amd64 dist/${APPNAME}-linux-x64/resources/openbazaar-go
-    rm -rf OPENBAZAAR_TEMP/*
-    mv dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaar-go-linux-amd64 dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaard
-    rm -rf dist/${APPNAME}-linux-x64/resources/app/.travis
-    chmod +x dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaard
-
-    echo 'Create debian archive'
-    electron-installer-debian --config .travis/config_amd64.json
-
-    echo 'Create RPM archive'
-    electron-installer-redhat --config .travis/config_x86_64.json
-
-    APPNAME="openbazaar2client"
-
-    echo "Packaging Electron application"
-    electron-packager . ${APPNAME} --platform=linux --arch=ia32 --ignore="OPENBAZAAR_TEMP" --electronVersion=${ELECTRONVER} --overwrite --prune --out=dist
-
-    echo 'Create debian archive'
-    electron-installer-debian --config .travis/config_ia32.client.json
-
-    echo 'Create RPM archive'
-    electron-installer-redhat --config .travis/config_ia32.client.json
-
-    echo 'Building Linux 64-bit Installer....'
-
-    echo "Packaging Electron application"
-    electron-packager . ${APPNAME} --platform=linux --arch=x64 --ignore="OPENBAZAAR_TEMP" --electronVersion=${ELECTRONVER} --overwrite --prune --out=dist
-
-    echo 'Create debian archive'
-    electron-installer-debian --config .travis/config_amd64.client.json
-
-    echo 'Create RPM archive'
-    electron-installer-redhat --config .travis/config_x86_64.client.json
-
-    ;;
-
+#  "linux")
+#
+#    echo 'Linux builds'
+#
+#    echo 'Building Linux 32-bit Installer....'
+#
+#    echo 'Making dist directories'
+#    mkdir dist/linux32
+#    mkdir dist/linux64
+#
+#    echo 'Install npm packages for Linux'
+#    npm install -g --save-dev electron-installer-debian --silent
+#    npm install -g --save-dev electron-installer-redhat --silent
+#
+#    # Install libgconf2-4
+#    sudo apt-get install libgconf2-4 libgconf-2-4
+#
+#    # Install rpmbuild
+#    sudo apt-get install rpm
+#
+#    # Ensure fakeroot is installed
+#    sudo apt-get install fakeroot
+#
+#    # Retrieve Latest Server Binaries
+#    sudo apt-get install jq
+#    cd OPENBAZAAR_TEMP/
+#    curl -u $GITHUB_USER:$GITHUB_TOKEN -s https://api.github.com/repos/OpenBazaar/openbazaar-go/releases/$SERVERTAG > release.txt
+#    cat release.txt | jq -r ".assets[].browser_download_url" | xargs -n 1 curl -L -O
+#    cd ..
+#
+#    APPNAME="openbazaar2"
+#
+#    echo "Packaging Electron application"
+#    electron-packager . ${APPNAME} --platform=linux --arch=ia32 --electronVersion=${ELECTRONVER} --ignore="OPENBAZAAR_TEMP" --overwrite --prune --out=dist
+#
+#    echo 'Move go server to electron app'
+#    mkdir dist/${APPNAME}-linux-ia32/resources/openbazaar-go/
+#    cp -rf OPENBAZAAR_TEMP/openbazaar-go-linux-386 dist/${APPNAME}-linux-ia32/resources/openbazaar-go
+#    mv dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaar-go-linux-386 dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaard
+#    rm -rf dist/${APPNAME}-linux-ia32/resources/app/.travis
+#    chmod +x dist/${APPNAME}-linux-ia32/resources/openbazaar-go/openbazaard
+#
+#    echo 'Create debian archive'
+#    electron-installer-debian --config .travis/config_ia32.json
+#
+#    echo 'Create RPM archive'
+#    electron-installer-redhat --config .travis/config_ia32.json
+#
+#    echo 'Building Linux 64-bit Installer....'
+#
+#    echo "Packaging Electron application"
+#    electron-packager . ${APPNAME} --platform=linux --arch=x64 --electronVersion=${ELECTRONVER} --overwrite --ignore="OPENBAZAAR_TEMP" --prune --out=dist
+#
+#    echo 'Move go server to electron app'
+#    mkdir dist/${APPNAME}-linux-x64/resources/openbazaar-go/
+#    cp -rf OPENBAZAAR_TEMP/openbazaar-go-linux-amd64 dist/${APPNAME}-linux-x64/resources/openbazaar-go
+#    rm -rf OPENBAZAAR_TEMP/*
+#    mv dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaar-go-linux-amd64 dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaard
+#    rm -rf dist/${APPNAME}-linux-x64/resources/app/.travis
+#    chmod +x dist/${APPNAME}-linux-x64/resources/openbazaar-go/openbazaard
+#
+#    echo 'Create debian archive'
+#    electron-installer-debian --config .travis/config_amd64.json
+#
+#    echo 'Create RPM archive'
+#    electron-installer-redhat --config .travis/config_x86_64.json
+#
+#    APPNAME="openbazaar2client"
+#
+#    echo "Packaging Electron application"
+#    electron-packager . ${APPNAME} --platform=linux --arch=ia32 --ignore="OPENBAZAAR_TEMP" --electronVersion=${ELECTRONVER} --overwrite --prune --out=dist
+#
+#    echo 'Create debian archive'
+#    electron-installer-debian --config .travis/config_ia32.client.json
+#
+#    echo 'Create RPM archive'
+#    electron-installer-redhat --config .travis/config_ia32.client.json
+#
+#    echo 'Building Linux 64-bit Installer....'
+#
+#    echo "Packaging Electron application"
+#    electron-packager . ${APPNAME} --platform=linux --arch=x64 --ignore="OPENBAZAAR_TEMP" --electronVersion=${ELECTRONVER} --overwrite --prune --out=dist
+#
+#    echo 'Create debian archive'
+#    electron-installer-debian --config .travis/config_amd64.client.json
+#
+#    echo 'Create RPM archive'
+#    electron-installer-redhat --config .travis/config_x86_64.client.json
+#
+#    ;;
+#
   "osx")
 
     brew update
@@ -159,7 +159,7 @@ case "$TRAVIS_OS_NAME" in
     brew install openssl
     brew remove osslsigncode
     brew install mono osslsigncode
-    brew link freetype graphicsmagick mono 
+    brew link freetype graphicsmagick mono
 
     # Retrieve Latest Server Binaries
     cd OPENBAZAAR_TEMP/
@@ -167,73 +167,73 @@ case "$TRAVIS_OS_NAME" in
     cat release.txt | jq -r ".assets[].browser_download_url" | xargs -n 1 curl -L -O
     cd ..
 
-    # WINDOWS 32
-    echo 'Building Windows 32-bit Installer...'
-    mkdir dist/win32
-
-    echo 'Running Electron Packager...'
-    electron-packager . OpenBazaar2 --asar --out=dist --ignore="OPENBAZAAR_TEMP" --protocol-name=OpenBazaar --win32metadata.ProductName="OpenBazaar2" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2.exe --protocol=ob --platform=win32 --arch=ia32 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
-
-    echo 'Copying server binary into application folder...'
-    cp -rf OPENBAZAAR_TEMP/openbazaar-go-windows-4.0-386.exe dist/OpenBazaar2-win32-ia32/resources/
-    cp -rf OPENBAZAAR_TEMP/libwinpthread-1.win32.dll dist/OpenBazaar2-win32-ia32/resources/libwinpthread-1.dll
-    mkdir dist/OpenBazaar2-win32-ia32/resources/openbazaar-go
-    mv dist/OpenBazaar2-win32-ia32/resources/openbazaar-go-windows-4.0-386.exe dist/OpenBazaar2-win32-ia32/resources/openbazaar-go/openbazaard.exe
-    mv dist/OpenBazaar2-win32-ia32/resources/libwinpthread-1.dll dist/OpenBazaar2-win32-ia32/resources/openbazaar-go/libwinpthread-1.dll
-    rm -rf dist/OPENBAZAAR_TEMP
-
-    echo 'Building Installer...'
-    grunt create-windows-installer --appname=OpenBazaar2 --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2-win32-ia32 --outdir=dist/win32
-    mv dist/win32/OpenBazaar2Setup.exe dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe
-    mv dist/win32/RELEASES dist/RELEASES
-
-    #### CLIENT ONLY
-    echo 'Running Electron Packager...'
-    electron-packager . OpenBazaar2Client --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2Client" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2Client.exe --protocol=ob --platform=win32 --arch=ia32 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
-
-    echo 'Building Installer...'
-    grunt create-windows-installer --appname=OpenBazaar2Client --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2Client-win32-ia32 --outdir=dist/win32
-    mv dist/win32/OpenBazaar2ClientSetup.exe dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe
-
-    echo 'Sign the installer'
-    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe -out dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe
-    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe -out dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe
-
-    rm dist/win32/RELEASES
-
-    # WINDOWS 64
-    echo 'Building Windows 64-bit Installer...'
-    mkdir dist/win64
-
-    echo 'Running Electron Packager...'
-    electron-packager . OpenBazaar2 --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2.exe --protocol=ob --platform=win32 --arch=x64 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
-
-    echo 'Copying server binary into application folder...'
-    cp -rf OPENBAZAAR_TEMP/openbazaar-go-windows-4.0-amd64.exe dist/OpenBazaar2-win32-x64/resources/
-    cp -rf OPENBAZAAR_TEMP/libwinpthread-1.win64.dll dist/OpenBazaar2-win32-x64/resources/libwinpthread-1.dll
-    mkdir dist/OpenBazaar2-win32-x64/resources/openbazaar-go
-    mv dist/OpenBazaar2-win32-x64/resources/openbazaar-go-windows-4.0-amd64.exe dist/OpenBazaar2-win32-x64/resources/openbazaar-go/openbazaard.exe
-    mv dist/OpenBazaar2-win32-x64/resources/libwinpthread-1.dll dist/OpenBazaar2-win32-x64/resources/openbazaar-go/libwinpthread-1.dll
-
-    echo 'Building Installer...'
-    grunt create-windows-installer --appname=OpenBazaar2 --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2-win32-x64 --outdir=dist/win64
-    mv dist/win64/OpenBazaar2Setup.exe dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe
-    mv dist/win64/RELEASES dist/win64/RELEASES-x64
-
-    #### CLIENT ONLY
-    echo 'Running Electron Packager...'
-    electron-packager . OpenBazaar2Client --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2Client" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2Client.exe --protocol=ob --platform=win32 --arch=x64 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
-
-    echo 'Building Installer...'
-    grunt create-windows-installer --appname=OpenBazaar2Client --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2Client-win32-x64 --outdir=dist/win64
-    mv dist/win64/OpenBazaar2ClientSetup.exe dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe
-
-    echo 'Sign the installer'
-    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe -out dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe
-    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe -out dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe
-
-    mv dist/RELEASES dist/win32/RELEASES
-
+##    # WINDOWS 32
+##    echo 'Building Windows 32-bit Installer...'
+##    mkdir dist/win32
+##
+##    echo 'Running Electron Packager...'
+##    electron-packager . OpenBazaar2 --asar --out=dist --ignore="OPENBAZAAR_TEMP" --protocol-name=OpenBazaar --win32metadata.ProductName="OpenBazaar2" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2.exe --protocol=ob --platform=win32 --arch=ia32 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
+##
+##    echo 'Copying server binary into application folder...'
+##    cp -rf OPENBAZAAR_TEMP/openbazaar-go-windows-4.0-386.exe dist/OpenBazaar2-win32-ia32/resources/
+##    cp -rf OPENBAZAAR_TEMP/libwinpthread-1.win32.dll dist/OpenBazaar2-win32-ia32/resources/libwinpthread-1.dll
+##    mkdir dist/OpenBazaar2-win32-ia32/resources/openbazaar-go
+##    mv dist/OpenBazaar2-win32-ia32/resources/openbazaar-go-windows-4.0-386.exe dist/OpenBazaar2-win32-ia32/resources/openbazaar-go/openbazaard.exe
+##    mv dist/OpenBazaar2-win32-ia32/resources/libwinpthread-1.dll dist/OpenBazaar2-win32-ia32/resources/openbazaar-go/libwinpthread-1.dll
+##    rm -rf dist/OPENBAZAAR_TEMP
+##
+##    echo 'Building Installer...'
+##    grunt create-windows-installer --appname=OpenBazaar2 --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2-win32-ia32 --outdir=dist/win32
+##    mv dist/win32/OpenBazaar2Setup.exe dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe
+##    mv dist/win32/RELEASES dist/RELEASES
+##
+##    #### CLIENT ONLY
+##    echo 'Running Electron Packager...'
+##    electron-packager . OpenBazaar2Client --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2Client" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2Client.exe --protocol=ob --platform=win32 --arch=ia32 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
+##
+##    echo 'Building Installer...'
+##    grunt create-windows-installer --appname=OpenBazaar2Client --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2Client-win32-ia32 --outdir=dist/win32
+##    mv dist/win32/OpenBazaar2ClientSetup.exe dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe
+##
+##    echo 'Sign the installer'
+##    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe -out dist/win32/OpenBazaar2-$PACKAGE_VERSION-Setup-32.exe
+##    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe -out dist/win32/OpenBazaar2Client-$PACKAGE_VERSION-Setup-32.exe
+##
+##    rm dist/win32/RELEASES
+##
+##    # WINDOWS 64
+##    echo 'Building Windows 64-bit Installer...'
+##    mkdir dist/win64
+##
+##    echo 'Running Electron Packager...'
+##    electron-packager . OpenBazaar2 --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2.exe --protocol=ob --platform=win32 --arch=x64 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
+##
+##    echo 'Copying server binary into application folder...'
+##    cp -rf OPENBAZAAR_TEMP/openbazaar-go-windows-4.0-amd64.exe dist/OpenBazaar2-win32-x64/resources/
+##    cp -rf OPENBAZAAR_TEMP/libwinpthread-1.win64.dll dist/OpenBazaar2-win32-x64/resources/libwinpthread-1.dll
+##    mkdir dist/OpenBazaar2-win32-x64/resources/openbazaar-go
+##    mv dist/OpenBazaar2-win32-x64/resources/openbazaar-go-windows-4.0-amd64.exe dist/OpenBazaar2-win32-x64/resources/openbazaar-go/openbazaard.exe
+##    mv dist/OpenBazaar2-win32-x64/resources/libwinpthread-1.dll dist/OpenBazaar2-win32-x64/resources/openbazaar-go/libwinpthread-1.dll
+##
+##    echo 'Building Installer...'
+##    grunt create-windows-installer --appname=OpenBazaar2 --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2-win32-x64 --outdir=dist/win64
+##    mv dist/win64/OpenBazaar2Setup.exe dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe
+##    mv dist/win64/RELEASES dist/win64/RELEASES-x64
+##
+##    #### CLIENT ONLY
+##    echo 'Running Electron Packager...'
+##    electron-packager . OpenBazaar2Client --asar --out=dist --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --win32metadata.ProductName="OpenBazaar2Client" --win32metadata.CompanyName="OpenBazaar" --win32metadata.FileDescription='Decentralized p2p marketplace for Bitcoin' --win32metadata.OriginalFilename=OpenBazaar2Client.exe --protocol=ob --platform=win32 --arch=x64 --icon=imgs/openbazaar2.ico --electron-version=${ELECTRONVER} --overwrite
+##
+##    echo 'Building Installer...'
+##    grunt create-windows-installer --appname=OpenBazaar2Client --obversion=$PACKAGE_VERSION --appdir=dist/OpenBazaar2Client-win32-x64 --outdir=dist/win64
+##    mv dist/win64/OpenBazaar2ClientSetup.exe dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe
+##
+##    echo 'Sign the installer'
+##    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe -out dist/win64/OpenBazaar2-$PACKAGE_VERSION-Setup-64.exe
+##    osslsigncode sign -t http://timestamp.digicert.com -h sha1 -key .travis/ob1.keyfile -pass "$OB1_SECRET" -certs .travis/ob1.cert.spc -in dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe -out dist/win64/OpenBazaar2Client-$PACKAGE_VERSION-Setup-64.exe
+##
+##    mv dist/RELEASES dist/win32/RELEASES
+#
     # OSX
     echo 'Building OSX Installer'
     mkdir dist/osx
@@ -246,7 +246,7 @@ case "$TRAVIS_OS_NAME" in
     echo 'Signing Go binary'
     mv OPENBAZAAR_TEMP/openbazaar-go-darwin-10.6-amd64 dist/osx/openbazaard
     rm -rf OPENBAZAAR_TEMP/*
-    codesign --force --sign "$SIGNING_IDENTITY" dist/osx/openbazaard
+    codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime dist/osx/openbazaard
 
     echo 'Running Electron Packager...'
     electron-packager . OpenBazaar2 --out=dist -app-category-type=public.app-category.business --protocol-name=OpenBazaar --ignore="OPENBAZAAR_TEMP" --protocol=ob --platform=darwin --arch=x64 --icon=imgs/openbazaar2.icns --electron-version=${ELECTRONVER} --overwrite --app-version=$PACKAGE_VERSION
@@ -261,14 +261,14 @@ case "$TRAVIS_OS_NAME" in
     chmod +x dist/OpenBazaar2-darwin-x64/OpenBazaar2.app/Contents/Resources/openbazaar-go/openbazaard
 
     echo 'Codesign the .app'
-    codesign --force --deep --sign "$SIGNING_IDENTITY" dist/OpenBazaar2-darwin-x64/OpenBazaar2.app
+    codesign --force --deep --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2-darwin-x64/OpenBazaar2.app
     electron-installer-dmg dist/OpenBazaar2-darwin-x64/OpenBazaar2.app OpenBazaar2-$PACKAGE_VERSION --icon ./imgs/openbazaar2.icns --out=dist/OpenBazaar2-darwin-x64 --overwrite --background=./imgs/osx-finder_background.png --debug
     # Client Only
-    codesign --force --deep --sign "$SIGNING_IDENTITY" dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client.app
+    codesign --force --deep --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client.app
     electron-installer-dmg dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client.app OpenBazaar2Client-$PACKAGE_VERSION --icon ./imgs/openbazaar2.icns --out=dist/OpenBazaar2Client-darwin-x64 --overwrite --background=./imgs/osx-finder_background.png --debug
 
     echo 'Codesign the DMG and zip'
-    codesign --force --sign "$SIGNING_IDENTITY" dist/OpenBazaar2-darwin-x64/OpenBazaar2-$PACKAGE_VERSION.dmg
+    codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2-darwin-x64/OpenBazaar2-$PACKAGE_VERSION.dmg
     cd dist/OpenBazaar2-darwin-x64/
     zip -q -r OpenBazaar2-mac-$PACKAGE_VERSION.zip OpenBazaar2.app
     cp -r OpenBazaar2.app ../osx/
@@ -277,12 +277,69 @@ case "$TRAVIS_OS_NAME" in
 
     # Client Only
     cd ../../
-    codesign --force --sign "$SIGNING_IDENTITY" dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client-$PACKAGE_VERSION.dmg
+    codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client-$PACKAGE_VERSION.dmg
     cd dist/OpenBazaar2Client-darwin-x64/
     zip -q -r OpenBazaar2Client-mac-$PACKAGE_VERSION.zip OpenBazaar2Client.app
     cp -r OpenBazaar2Client.app ../osx/
     cp OpenBazaar2Client-mac-$PACKAGE_VERSION.zip ../osx/
     cp OpenBazaar2Client-$PACKAGE_VERSION.dmg ../osx/
+
+    cd ../..
+
+    # Notarize the zip files
+    UPLOAD_INFO_PLIST="uploadinfo.plist"
+    REQUEST_INFO_PLIST="request.plist"
+    touch $UPLOAD_INFO_PLIST
+
+    # Zip up .dmg files for notarization
+    zip -q -r dist/osx/OpenBazaar2.zip dist/OpenBazaar2-darwin-x64/OpenBazaar2-$PACKAGE_VERSION.dmg
+    zip -q -r dist/osx/OpenBazaar2Client.zip dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client-$PACKAGE_VERSION.dmg
+
+    wait_for_notarization() {
+      while true; do \
+
+        echo "Checking Apple for notarization status..."; \
+        /usr/bin/xcrun altool --notarization-info `/usr/libexec/PlistBuddy -c "Print :notarization-upload:RequestUUID" $UPLOAD_INFO_PLIST` -u $APPLE_ID -p $APPLE_PASS --output-format xml > "$REQUEST_INFO_PLIST" ;\
+
+        if [[ `/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" ${REQUEST_INFO_PLIST}` != "in progress" ]] || [[ "$requestUUID" == "" ]] ; then \
+
+           # check if it has been uploaded already and get the RequestUUID from the error message
+           echo "Checking if binary has already been uploaded..."; \
+           message=`/usr/libexec/PlistBuddy -c "Print :product-errors:0:message" $UPLOAD_INFO_PLIST`;\
+           if [[ ${message} =~ ^ERROR\ ITMS-90732* ]]; then \
+               prefix="ERROR ITMS-90732: \"The software asset has already been uploaded. The upload ID is "; \
+               suffix="\" at SoftwareAssets\/EnigmaSoftwareAsset"; \
+               requestUUID=`echo "${message}" | sed -e "s/^$prefix//" -e "s/$suffix$//"`; \
+
+               echo "Binary has already been uploaded. Checking Apple status for request ${requestUUID}..."; \
+               /usr/bin/xcrun altool --notarization-info ${requestUUID} -u $APPLE_ID -p $APPLE_PASS --output-format xml > "$REQUEST_INFO_PLIST" ;\
+           fi ;\
+
+           if [[ `/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" ${REQUEST_INFO_PLIST}` != "in progress" ]]; then \
+            echo "Binary has been notarized"; \
+            break; \
+           fi; \
+        fi ;\
+        echo "Waiting 60 seconds to check status again..."; \
+        sleep 60 ;\
+      done
+    }
+
+    # Upload to apple and notarize
+    echo "Uploading binary to Apple Notarization server..."
+    xcrun altool --notarize-app --primary-bundle-id "org.openbazaar.desktop-${PACKAGE_VERSION}" --username "$APPLE_ID" --password "$APPLE_PASS" --file dist/osx/OpenBazaar2.zip --output-format xml > ${UPLOAD_INFO_PLIST}
+    wait_for_notarization
+
+    # Staple ticket to .app file
+    echo "Stapling ticket to the app..."
+    xcrun stapler staple dist/osx/OpenBazaar2-2.3.6.dmg
+
+    # Re-zip it up for distribution
+
+    echo "Uploading client only binary to Apple Notarization server..."
+    xcrun altool --notarize-app --primary-bundle-id "org.openbazaar.desktopclient-$PACKAGE_VERSION" --username "$APPLE_ID" --password "$APPLE_PASS" --file dist/osx/OpenBazaar2Client.zip --output-format xml > $UPLOAD_INFO_PLIST
+    wait_for_notarization
+    xcrun stapler staple dist/osx/OpenBazaar2Client-2.3.6.dmg
 
     ;;
 esac

--- a/build.sh
+++ b/build.sh
@@ -259,7 +259,7 @@ case "$TRAVIS_OS_NAME" in
         # Notarize the zip files
         UPLOAD_INFO_PLIST="uploadinfo.plist"
         REQUEST_INFO_PLIST="request.plist"
-        touch $UPLOAD_INFO_PLIST
+        touch ${UPLOAD_INFO_PLIST}
 
         wait_for_notarization() {
           while true; do \
@@ -281,7 +281,7 @@ case "$TRAVIS_OS_NAME" in
                    /usr/bin/xcrun altool --notarization-info ${requestUUID} -u $APPLE_ID -p $APPLE_PASS --output-format xml > "$REQUEST_INFO_PLIST" ;\
                fi ;\
 
-               if [[ `/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" ${REQUEST_INFO_PLIST}` != "in progress" ]]; then \
+               if [[ `/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" ${REQUEST_INFO_PLIST}` == "success" ]]; then \
                 echo "Binary has been notarized"; \
                 break; \
                fi; \
@@ -366,7 +366,6 @@ case "$TRAVIS_OS_NAME" in
             electron-installer-dmg dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client.app OpenBazaar2Client-$PACKAGE_VERSION --icon ./imgs/openbazaar2.icns --out=dist/OpenBazaar2Client-darwin-x64 --overwrite --background=./imgs/osx-finder_background.png --debug
 
             # Client Only
-            cd ../../
             codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime --entitlements openbazaar.entitlements dist/OpenBazaar2Client-darwin-x64/OpenBazaar2Client-$PACKAGE_VERSION.dmg
             cd dist/OpenBazaar2Client-darwin-x64/
             zip -q -r OpenBazaar2Client-mac-$PACKAGE_VERSION.zip OpenBazaar2Client.app

--- a/build.sh
+++ b/build.sh
@@ -173,6 +173,8 @@ case "$TRAVIS_OS_NAME" in
         brew remove osslsigncode
         brew install mono osslsigncode
 
+        rvm get stable
+
         # WINDOWS 32
         echo 'Building Windows 32-bit Installer...'
         mkdir dist/win32

--- a/build.sh
+++ b/build.sh
@@ -173,7 +173,7 @@ case "$TRAVIS_OS_NAME" in
         brew remove osslsigncode
         brew install mono osslsigncode
 
-        rvm get stable
+        brew reinstall openssl@1.1
 
         # WINDOWS 32
         echo 'Building Windows 32-bit Installer...'

--- a/openbazaar.entitlements
+++ b/openbazaar.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
This is a big boy. In order to notarize and staple OS X apps for Catalina and Mojave we needed to amend the build process to incorporate this hugely annoying process. The following actions have been taken in this PR:

- Travis CI caching updated
- OS X build process split into three separate jobs (windows binaries, osx and osx client only)
- Apple Notarization upload processing and stapling of final binaries for packaging