### PR TITLE
Bump node-sass to 4.13.0 cause binding node asset is unavailable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7928,9 +7928,9 @@
       }
     },
     "node-sass": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
+      "integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "json-format": "1.0.1",
     "mocha": "5.2.0",
     "node-fetch": "2.6.0",
-    "node-sass": "4.12.0",
+    "node-sass": "4.13.0",
     "nodemon": "1.19.1",
     "npm-run-all": "4.1.5",
     "pre-commit": "1.2.2",


### PR DESCRIPTION
During the latest building process of openbazaar 2.3.6 a message about the
node-sass/4.12.0/linux-x64-79_binding.node
pop out about the non existing resource
This commit fix the issue