### PR TITLE
Remove Win32 Upgrade Path

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,11 +19,8 @@ let trayMenu;
 let closeConfirmed = false;
 const version = app.getVersion();
 
-function isOSWin64() {
-  return process.arch === 'x64' || process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
-}
-
-const plat = process.platform === 'win32' ? `${isOSWin64() ? 'win64' : 'win32'}` : process.platform;
+// We no longer support win32, but process.platform returns Windows 64 bit as win32.
+const plat = process.platform === 'win32' ? 'win64' : process.platform;
 
 const feedURL = `https://updates2.openbazaar.org:5001/update/${plat}/${version}`;
 


### PR DESCRIPTION
This removes the code that was creating different update paths for Windows 32 and 64 bit OSes, since we no longer support 32 bit OSes at all.

Closes #1836