### PR TITLE
Handle Mod With Missing Fixed Fee Currency

### DIFF
--- a/js/views/components/moderators/Card.js
+++ b/js/views/components/moderators/Card.js
@@ -44,6 +44,9 @@ export default class extends BaseVw {
     const modInfo = this.model.get('moderatorInfo');
     this.modCurs = modInfo && modInfo.get('acceptedCurrencies') || [];
 
+    const fixedFee = modInfo && modInfo.get('fee').get('fixedFee');
+    this.feeCur = fixedFee && fixedFee.get('currencyCode');
+
     this.modLanguages = [];
     if (this.model.isModerator) {
       this.modLanguages = this.model.get('moderatorInfo')
@@ -86,7 +89,7 @@ export default class extends BaseVw {
   }
 
   get hasValidCurrency() {
-    return anySupportedByWallet(this.modCurs);
+    return this.feeCur && anySupportedByWallet([...this.modCurs, this.feeCur]);
   }
 
   get hasPreferredCur() {

--- a/js/views/components/moderators/Card.js
+++ b/js/views/components/moderators/Card.js
@@ -44,9 +44,6 @@ export default class extends BaseVw {
     const modInfo = this.model.get('moderatorInfo');
     this.modCurs = modInfo && modInfo.get('acceptedCurrencies') || [];
 
-    const fixedFee = modInfo && modInfo.get('fee').get('fixedFee');
-    this.feeCur = fixedFee && fixedFee.get('currencyCode');
-
     this.modLanguages = [];
     if (this.model.isModerator) {
       this.modLanguages = this.model.get('moderatorInfo')
@@ -89,7 +86,7 @@ export default class extends BaseVw {
   }
 
   get hasValidCurrency() {
-    return this.feeCur && anySupportedByWallet([...this.modCurs, this.feeCur]);
+    return anySupportedByWallet(this.modCurs);
   }
 
   get hasPreferredCur() {

--- a/js/views/components/moderators/Moderators.js
+++ b/js/views/components/moderators/Moderators.js
@@ -153,7 +153,7 @@ export default class extends baseVw {
     const validCur = anySupportedByWallet(modCurs);
 
     if ((!!validMod && validCur || this.options.showInvalid)) {
-      this.moderatorsCol.add(new Moderator(data, { parse: true }));
+      this.moderatorsCol.add(new Moderator(data, { parse: true, validate: true }));
       this.removeNotFetched(data.peerID);
     } else {
       // remove the invalid moderator from the notFetched list

--- a/js/views/components/moderators/Moderators.js
+++ b/js/views/components/moderators/Moderators.js
@@ -153,7 +153,8 @@ export default class extends baseVw {
     const validCur = anySupportedByWallet(modCurs);
 
     if ((!!validMod && validCur || this.options.showInvalid)) {
-      this.moderatorsCol.add(new Moderator(data, { parse: true, validate: true }));
+      const newMod = new Moderator(data, { parse: true });
+      if (newMod.isValid()) this.moderatorsCol.add(newMod);
       this.removeNotFetched(data.peerID);
     } else {
       // remove the invalid moderator from the notFetched list


### PR DESCRIPTION
This prevents an unhandled error when a moderator has '' for the currency code in their fixedFee object by validating the model when it's added to the collection. This was causing loading moderators in settings/store to fail.

Now all moderators will be validated before being added to the moderator view, and if they are invalid, they will not be shown.
