### PR TITLE
Add Processing Error to Order Progress Bar

### DIFF
--- a/js/languages/en_US.json
+++ b/js/languages/en_US.json
@@ -1785,7 +1785,8 @@
           "refunded": "Refunded",
           "decided": "Decided",
           "resolved": "Resolved",
-          "disputed": "Disputed"
+          "disputed": "Disputed",
+          "errored": "Error"
         },
         "heading": "Order Details",
         "shipToHeading": "Ship to",

--- a/js/views/modals/orderDetail/summaryTab/Summary.js
+++ b/js/views/modals/orderDetail/summaryTab/Summary.js
@@ -383,6 +383,11 @@ export default class extends BaseVw {
           }
 
           break;
+        case 'PROCESSING_ERROR':
+          state.states.push(app.polyglot.t(
+            'orderDetail.summaryTab.orderDetails.progressBarStates.errored'));
+          state.currentState = state.states.length;
+          break;
         default:
           state.currentState = 0;
       }


### PR DESCRIPTION
We've had a report of an order where the progress bar in the order details was blank, and we confirmed the order state was PROCESSING_ERROR.

I didn't see anything in the summary.js code that would handle that situation.

I'm not sure if this is a complete fix, we'd also want to show the error, or some message to the user about the error, so they can do something to fix it. I don't have an order in an error state though, so I don't know what data about the error we'd have access to. 

Screen cap from the affected user:

![image](https://user-images.githubusercontent.com/1584275/72269043-eb0ad400-35f0-11ea-92b7-6ec7ea3c7149.png)
