### PR TITLE
Transactions api fix

### DIFF
--- a/js/models/transaction/Case.js
+++ b/js/models/transaction/Case.js
@@ -1,7 +1,4 @@
-import {
-  integerToDecimal,
-  getCoinDivisibility,
-} from '../../utils/currency';
+import { curDefToDecimal } from '../../utils/currency';
 import BaseModel from '../BaseModel';
 
 export default class extends BaseModel {
@@ -10,24 +7,9 @@ export default class extends BaseModel {
   }
 
   parse(response = {}) {
-    let returnVal = { ...response };
-
-    // pending this issue, we'll get the divisibility from wallet cur def list
-    // https://github.com/OpenBazaar/openbazaar-go/issues/1826
-
-    let divisibility;
-
-    try {
-      divisibility = getCoinDivisibility(returnVal.paymentCoin);
-    } catch (e) {
-      // pass
-    }
-
-    returnVal = {
-      ...returnVal,
-      total: integerToDecimal(returnVal.total, divisibility, { fieldName: 'total' }),
+    return {
+      ...response,
+      total: curDefToDecimal(response.total),
     };
-
-    return returnVal;
   }
 }

--- a/js/models/transaction/Transaction.js
+++ b/js/models/transaction/Transaction.js
@@ -1,8 +1,5 @@
 // used for sales, purchases
-import {
-  integerToDecimal,
-  getCoinDivisibility,
-} from '../../utils/currency';
+import { curDefToDecimal } from '../../utils/currency';
 import BaseModel from '../BaseModel';
 
 export default class extends BaseModel {
@@ -11,24 +8,9 @@ export default class extends BaseModel {
   }
 
   parse(response = {}) {
-    let returnVal = { ...response };
-
-    // pending this issue, we'll get the divisibility from wallet cur def list
-    // https://github.com/OpenBazaar/openbazaar-go/issues/1826
-
-    let divisibility;
-
-    try {
-      divisibility = getCoinDivisibility(returnVal.paymentCoin);
-    } catch (e) {
-      // pass
-    }
-
-    returnVal = {
-      ...returnVal,
-      total: integerToDecimal(returnVal.total, divisibility, { fieldName: 'total' }),
+    return {
+      ...response,
+      total: curDefToDecimal(response.total),
     };
-
-    return returnVal;
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "backbone": "1.3.3",
     "backbone.localstorage": "1.1.16",
     "bech32": "0.0.3",
-    "bignumber.js": "^9.0.0",
+    "bignumber.js": "9.0.0",
     "bitcore-lib": "8.6.0",
     "cropit": "0.5.1",
     "homedir": "0.6.0",


### PR DESCRIPTION
Updates the Transaction and Case model to parse the full currency definition that is now being provided for the the `total` in the `sales`, `purchases` and `cases` apis (https://github.com/OpenBazaar/openbazaar-go/pull/1973).