### PR TITLE
Add feature stores

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="../node_modules/ionicons/css/ionicons.min.css">
     <link rel="stylesheet" href="../node_modules/trumbowyg/dist/ui/trumbowyg.min.css">
     <link rel="stylesheet" href="../node_modules/selectize/dist/css/selectize.css">
+    <link rel="stylesheet" href="../node_modules/swiper/css/swiper.min.css">
     <link rel="stylesheet" href="../styles/lib/select2.css">
     <link rel="stylesheet" href="./styles/main.css">
   </head>

--- a/js/models/search/SearchProvider.js
+++ b/js/models/search/SearchProvider.js
@@ -9,6 +9,7 @@ export default class extends BaseModel {
     return {
       name: '',
       logo: '',
+      featureStores: '',
       listings: '',
       torlistings: '',
       vendors: '',
@@ -28,6 +29,11 @@ export default class extends BaseModel {
 
   get tor() {
     return curConnOnTor() ? 'tor' : '';
+  }
+
+  get featureStoresUrl() {
+    // Fall back to clear endpoint on tor if no tor endpoint exists.
+    return this.get(`${this.tor}featureStores`) || this.get('featureStores');
   }
 
   get listingsUrl() {
@@ -52,7 +58,8 @@ export default class extends BaseModel {
       errObj[fieldName].push(error);
     };
     const urlTypes = options.urlTypes ||
-      ['listings', 'torlistings', 'vendors', 'torvendors', 'reports', 'torreports'];
+      ['featureStores', 'listings', 'torlistings', 'vendors', 'torvendors',
+        'reports', 'torreports'];
 
     if (attrs.name && is.not.string(attrs.name)) {
       addError('name', app.polyglot.t('searchProviderModelErrors.invalidName'));

--- a/js/templates/search/featureStores.html
+++ b/js/templates/search/featureStores.html
@@ -1,0 +1,9 @@
+<h2>Featured Stores</h2>
+<% if (!ob.loading) { %>
+<div class="swiper-container">
+    <div class="swiper-wrapper userCardsContainer"></div>
+</div>
+<% } else { %>
+<div class="flexCent loadingSearch clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
+<% } %>
+<hr class="clrBr featureStoresRow">

--- a/js/templates/search/search.html
+++ b/js/templates/search/search.html
@@ -41,6 +41,14 @@
         <div class="js-suggestions"></div>
         <hr class="clrBr">
       </div>
+      <% if (ob.showFeatureStores) { %>
+      <div class="featureStores">
+        <h1 style="float: left; width: auto">Featured Stores</h1>
+        <div class="swiper-container">
+          <div class="swiper-wrapper userCardsContainer"></div>
+        </div>
+      </div>
+      <% } %>
       <div class="js-categoryWrapper"></div>
       <div class="flexRow gutterHLg">
         <% if (ob.hasFilters) { %>

--- a/js/templates/search/search.html
+++ b/js/templates/search/search.html
@@ -41,18 +41,7 @@
         <div class="js-suggestions"></div>
         <hr class="clrBr">
       </div>
-      <% if (ob.showFeatureStores) { %>
-      <% if (!ob.fetchingFeatureStores) { %>
-      <div class="featureStores">
-        <h2>Featured Stores</h2>
-        <div class="swiper-container">
-          <div class="swiper-wrapper userCardsContainer"></div>
-        </div>
-      </div>
-      <% } else { %>
-      <div class="flexCent loadingSearch clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
-      <% } %>
-      <% } %>
+      <div class="js-featureStores"></div>
       <div class="js-categoryWrapper"></div>
       <div class="flexRow gutterHLg">
         <% if (ob.hasFilters) { %>

--- a/js/templates/search/search.html
+++ b/js/templates/search/search.html
@@ -42,12 +42,16 @@
         <hr class="clrBr">
       </div>
       <% if (ob.showFeatureStores) { %>
+      <% if (!ob.fetchingFeatureStores) { %>
       <div class="featureStores">
-        <h1 style="float: left; width: auto">Featured Stores</h1>
+        <h2>Featured Stores</h2>
         <div class="swiper-container">
           <div class="swiper-wrapper userCardsContainer"></div>
         </div>
       </div>
+      <% } else { %>
+      <div class="flexCent loadingSearch clrS"><%= ob.spinner({ className: 'spinnerLg' }) %></div>
+      <% } %>
       <% } %>
       <div class="js-categoryWrapper"></div>
       <div class="flexRow gutterHLg">

--- a/js/views/search/FeatureStores.js
+++ b/js/views/search/FeatureStores.js
@@ -1,0 +1,86 @@
+import $ from 'jquery';
+import Swiper from 'swiper';
+import loadTemplate from '../../utils/loadTemplate';
+import BaseView from '../baseVw';
+import UserCardSwiper from './UserCardSwiper';
+
+export default class extends BaseView {
+  constructor(options = {}) {
+    if (!options.fetchUrl || !(typeof options.fetchUrl === 'string')) {
+      throw new Error('Please provide a feature store fetch url.');
+    }
+
+    const opts = {
+      ...options,
+      initialState: {
+        loading: false,
+        ...options.initialState,
+      },
+    };
+
+    super(opts);
+    this.options = opts;
+
+    this.storeViews = [];
+    this.loadStores();
+  }
+
+  className() {
+    return 'featureStores';
+  }
+
+  renderStores(collection = []) {
+    const resultsFrag = document.createDocumentFragment();
+
+    collection.forEach(storeID => {
+      const view = this.createChild(UserCardSwiper, { guid: storeID });
+      this.storeViews.push(view);
+      view.render().$el.appendTo(resultsFrag);
+    });
+
+    this.getCachedEl('.swiper-wrapper').html(resultsFrag);
+  }
+
+  loadStores() {
+    this.removeStoreViews();
+    this.setState({ loading: true });
+
+    if (this.storesFetch) this.storesFetch.abort();
+    this.storesFetch = $.get({
+      url: this.options.fetchUrl,
+      dataType: 'json',
+    })
+      .done((data) => (this.featureStoreIDs = data))
+      .always(() => (this.setState({ loading: false })));
+  }
+
+  removeStoreViews() {
+    this.storeViews.forEach(vw => vw.remove());
+    this.storeViews = [];
+  }
+
+  remove() {
+    this.removeStoreViews();
+    if (this.storesFetch) this.storesFetch.abort();
+    super.remove();
+  }
+
+  render() {
+    super.render();
+    loadTemplate('search/featureStores.html', t => {
+      this.$el.html(t({
+        ...this.getState(),
+      }));
+    });
+
+    if (this.featureStoreIDs) this.renderStores(this.featureStoreIDs);
+
+    this._swiper = new Swiper(this.getCachedEl('.swiper-container'), {
+      slidesPerView: 3,
+      spaceBetween: 10,
+      autoplay: true,
+    });
+
+    return this;
+  }
+}

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -564,16 +564,16 @@ export default class extends baseVw {
   }
 
   renderFeatureStores() {
-    if (this.featureStoreIDs.length == 0) {
+    if (this.featureStoreIDs.length === 0) {
       return;
     }
 
     const UserCardSwiper = Backbone.View.extend({
       className: 'swiper-slide',
-      initialize: function (options) {
-        _.extend(this, _.pick(options, "guid"));
+      initialize(options) {
+        _.extend(this, _.pick(options, 'guid'));
       },
-      render: function () {
+      render() {
         const view = new UserCard({ guid: this.guid });
         this.$el.append(view.render().el);
         return this;

--- a/js/views/search/Search.js
+++ b/js/views/search/Search.js
@@ -586,7 +586,6 @@ export default class extends baseVw {
         term,
         errTitle,
         errMsg,
-        showFeatureStores: state.tab === 'home' && !!this._search.provider.get('featureStores'),
         providerLocked: this.providerIsADefault(this._search.provider.id),
         isExistingProvider: this.isExistingProvider(this._search.provider),
         showMakeDefault: this._search.provider !== this.currentDefaultProvider,

--- a/js/views/search/UserCardSwiper.js
+++ b/js/views/search/UserCardSwiper.js
@@ -1,0 +1,25 @@
+
+import BaseView from '../baseVw';
+import UserCard from '../UserCard';
+
+export default class extends BaseView {
+  constructor(options = {}) {
+    if (!options.guid || !(typeof options.guid === 'string')) {
+      throw new Error('Please provide a guid.');
+    }
+
+    super(options);
+    this.options = options;
+  }
+
+  className() {
+    return 'swiper-slide';
+  }
+
+  render() {
+    super.render();
+    const view = new UserCard({ guid: this.options.guid });
+    this.$el.append(view.render().el);
+    return this;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "sanitize-html": "1.20.0",
     "selectize": "0.12.4",
     "sortablejs": "1.9.0",
+    "swiper": "^5.3.1",
     "trumbowyg": "2.18.0",
     "trunk8": "0.0.1",
     "twemoji": "12.0.4",

--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -135,8 +135,8 @@
     width: auto;
 
     .userCard {
-      // width: 306px;
-      width: 100%;
+      width: 306px;
+      // width: 100%;
       flex: 0 0 auto;
       box-sizing: border-box;
     }

--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -114,6 +114,33 @@
       }
     }
   }
+  
+  .swiper-container {
+    width: 100%;
+    height: 100%;
+  }
+  
+  .swiper-slide {
+    /* Center slide text vertically */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  
+  .swiper-container {
+    --swiper-pagination-color: #eee;
+  }
+  
+  .userCardsContainer {
+    width: auto;
+
+    .userCard {
+      // width: 306px;
+      width: 100%;
+      flex: 0 0 auto;
+      box-sizing: border-box;
+    }
+  }
 
   .searchBar {
     display: flex;

--- a/styles/modules/_search.scss
+++ b/styles/modules/_search.scss
@@ -130,6 +130,10 @@
   .swiper-container {
     --swiper-pagination-color: #eee;
   }
+
+  .featureStoresRow {
+    margin-top: 20px;
+  }
   
   .userCardsContainer {
     width: auto;


### PR DESCRIPTION
Enable category views for third-party search engine, and add feature stores section if third-party API has links.featureStores link in response. If there is no featureStores link, keep the current one.

Below is the effect:
**Default OB1**
![image](https://user-images.githubusercontent.com/34826428/75162954-58199980-5759-11ea-9c27-a84e268e8d24.png)

**Third-party without the link**
![image](https://user-images.githubusercontent.com/34826428/75163004-7089b400-5759-11ea-9b0b-45d3d13db677.png)

**Third-party with the link**
![image](https://user-images.githubusercontent.com/34826428/75224166-f271ef80-57e2-11ea-8a7e-46daea5e41a8.png)
